### PR TITLE
fix: deno command template spacing

### DIFF
--- a/app/pages/package/[...name].vue
+++ b/app/pages/package/[...name].vue
@@ -505,10 +505,10 @@ defineOgImageComponent('Package', {
             </div>
             <div class="flex items-center gap-2 px-4 pt-3 pb-4">
               <span class="text-fg-subtle font-mono text-sm select-none">$</span>
-              <code class="font-mono text-sm"><ClientOnly><span class="text-fg">{{ selectedPMLabel }}</span> <span class="text-fg-muted">{{ selectedPMAction }}</span>&nbsp;<span
+              <code class="font-mono text-sm"><ClientOnly><span class="text-fg">{{ selectedPMLabel }}</span> <span class="text-fg-muted">{{ selectedPMAction }}</span><span
                 v-if="selectedPM !== 'deno'"
                 class="text-fg-muted"
-              > {{ pkg.name }}</span><span
+              >&nbsp;{{ pkg.name }}</span><span
                 v-else
                 class="text-fg-muted"
               >{{ pkg.name }}</span><template #fallback><span class="text-fg">npm</span>&nbsp;<span class="text-fg-muted">install {{ pkg.name }}</span></template></ClientOnly></code>


### PR DESCRIPTION
Just a small fix moving the non-breakable space from the main command to the non-deno branch.