### PR TITLE
feat: show command to install a specific version

### DIFF
--- a/app/pages/package/[...name].vue
+++ b/app/pages/package/[...name].vue
@@ -162,11 +162,15 @@ const selectedPMAction = computed(() => currentPM.value.action)
 const installCommand = computed(() => {
   if (!pkg.value) return ''
   const pm = currentPM.value
+  let command = `${pm.label} ${pm.action} ${pkg.value.name}`
   // deno uses "add npm:package" format
   if (pm.id === 'deno') {
-    return `${pm.label} ${pm.action}${pkg.value.name}`
+    command = `${pm.label} ${pm.action}${pkg.value.name}`
   }
-  return `${pm.label} ${pm.action} ${pkg.value.name}`
+  if (requestedVersion.value) {
+    command += `@${requestedVersion.value}`
+  }
+  return command
 })
 
 // Copy install command
@@ -511,7 +515,10 @@ defineOgImageComponent('Package', {
               > {{ pkg.name }}</span><span
                 v-else
                 class="text-fg-muted"
-              >{{ pkg.name }}</span><template #fallback><span class="text-fg">npm</span>&nbsp;<span class="text-fg-muted">install {{ pkg.name }}</span></template></ClientOnly></code>
+              >{{ pkg.name }}</span><span
+                v-if="requestedVersion"
+                class="text-fg-muted"
+              >@{{ requestedVersion }}</span><template #fallback><span class="text-fg">npm</span>&nbsp;<span class="text-fg-muted">install {{ pkg.name }}</span></template></ClientOnly></code>
             </div>
           </div>
           <button


### PR DESCRIPTION
All package manager commands shown in the UI accept `@version` suffixes. If the user is viewing a specific version, this PR will now make it so the clipboard text and the visual code snippet contain the version.

| Manager | Install command | Docs |
|---------|-----------------|------|
| npm | `npm install nuxt@3.0.0` | https://docs.npmjs.com/cli/v10/commands/npm-install |
| pnpm | `pnpm add nuxt@3.0.0` | https://pnpm.io/cli/add |
| yarn | `yarn add nuxt@3.0.0` | https://yarnpkg.com/cli/add |
| bun | `bun add nuxt@3.0.0` | https://bun.sh/docs/cli/add |
| deno | `deno add npm:nuxt@3.0.0` | https://docs.deno.com/runtime/reference/cli/add/ |
