### PR TITLE
fix: allow srcset in picture sources

### DIFF
--- a/server/utils/readme.ts
+++ b/server/utils/readme.ts
@@ -21,7 +21,7 @@ const ALLOWED_TAGS = [
 const ALLOWED_ATTR: Record<string, string[]> = {
   a: ['href', 'title', 'target', 'rel'],
   img: ['src', 'alt', 'title', 'width', 'height'],
-  source: ['src', 'type', 'media'],
+  source: ['src', 'srcset', 'type', 'media'],
   th: ['colspan', 'rowspan', 'align'],
   td: ['colspan', 'rowspan', 'align'],
   h3: ['id', 'data-level'],


### PR DESCRIPTION
In ESLint Plugin Perfectionist, we use different images for light and dark themes in Readme.

Before:

<img width="1512" height="1093" alt="image" src="https://github.com/user-attachments/assets/fcade73c-0dcb-4762-888a-4b5a0dafca0f" />

After:

<img width="1512" height="1093" alt="image" src="https://github.com/user-attachments/assets/2ffe85d2-8a5d-451a-9e5a-48214ce9cb9f" />
