### PR TITLE
feat: avoid animated sparkline

### DIFF
--- a/app/components/PackageDownloadStats.vue
+++ b/app/components/PackageDownloadStats.vue
@@ -24,6 +24,9 @@ const config = computed(() => ({
   theme: 'dark', // enforced dark mode for now
   style: {
     backgroundColor: 'transparent',
+    animation: {
+      show: false,
+    },
     area: {
       color: '#6A6A6A',
       useGradient: false,


### PR DESCRIPTION
The npm downloads count graph animation distracting when loading the package details. This PR disables it so the graph is shown instantly.