### PR TITLE
fix: wrap package node engines to next line

### DIFF
--- a/app/pages/[...package].vue
+++ b/app/pages/[...package].vue
@@ -611,21 +611,21 @@ defineOgImageComponent('Package', {
               Compatibility
             </h2>
             <dl class="space-y-2">
-              <div
-                v-if="displayVersion.engines.node"
-                class="flex items-center justify-between gap-4 py-1"
-              >
+              <div v-if="displayVersion.engines.node" class="flex justify-between gap-4 py-1">
                 <dt class="text-fg-muted text-sm shrink-0">node</dt>
-                <dd class="font-mono text-sm text-fg truncate" :title="displayVersion.engines.node">
+                <dd
+                  class="font-mono text-sm text-fg text-right"
+                  :title="displayVersion.engines.node"
+                >
                   {{ displayVersion.engines.node }}
                 </dd>
               </div>
-              <div
-                v-if="displayVersion.engines.npm"
-                class="flex items-center justify-between gap-4 py-1"
-              >
+              <div v-if="displayVersion.engines.npm" class="flex justify-between gap-4 py-1">
                 <dt class="text-fg-muted text-sm shrink-0">npm</dt>
-                <dd class="font-mono text-sm text-fg truncate" :title="displayVersion.engines.npm">
+                <dd
+                  class="font-mono text-sm text-fg text-right"
+                  :title="displayVersion.engines.npm"
+                >
                   {{ displayVersion.engines.npm }}
                 </dd>
               </div>


### PR DESCRIPTION
So I was looking at fixing the node version layout as a simple contribution: 

<img width="337" height="170" alt="Screenshot 2026-01-24 at 17 48 45" src="https://github.com/user-attachments/assets/5828f8aa-cb96-4c19-8174-c63ef79fa1d0" />

But I realize you already fixed it in the meantime by truncating :-)
Anyway - I don't thinking wrapping to two lines is that bad of an idea, if you make sure the div doesn't center align, and right-align the packages text. Truncating can be a little bit annoying sometimes. Just a proposal of course.

<img width="332" height="189" alt="Screenshot 2026-01-24 at 21 38 17" src="https://github.com/user-attachments/assets/71b1f108-e7e8-4ab9-8446-79a9df256df0" />
