### PR TITLE
Fix: updated column is balanced with package links

### DIFF
--- a/app/pages/[...package].vue
+++ b/app/pages/[...package].vue
@@ -407,11 +407,12 @@ defineOgImageComponent('Package', {
             </dd>
           </div>
 
-          <div v-if="getDependencyCount(displayVersion) > 0" class="space-y-1">
+          <div class="space-y-1">
             <dt class="text-xs text-fg-subtle uppercase tracking-wider">Deps</dt>
             <dd class="font-mono text-sm text-fg flex items-baseline justify-start gap-2">
               {{ getDependencyCount(displayVersion) }}
               <a
+                v-if="getDependencyCount(displayVersion) > 0"
                 :href="`https://npmgraph.js.org/?q=${pkg.name}`"
                 target="_blank"
                 rel="noopener noreferrer"


### PR DESCRIPTION
This PR balances the license/downloads/deps etc. row somewhat with the package links row beneath it, by right-aligning the last column. Also, currently if there are no dependencies, the deps column is hidden, causing `install size` and `updated` to shift a position to the left. I think it's worth showing `deps` even if the value is 0 - a user might be looking for the section, not finding it, and not realizing that this is because the package has none. Showing it, even if the value is 0, makes this very clear. The npmgraph link should probably be hidden though.

**Before**:
<img width="976" height="476" alt="Screenshot 2026-01-25 at 08 13 31" src="https://github.com/user-attachments/assets/205e3c35-c728-46e5-9f54-7243c3e72c40" />

<img width="918" height="339" alt="Screenshot 2026-01-25 at 08 13 03" src="https://github.com/user-attachments/assets/e95e1e77-4991-4046-8a07-84466036ac7a" />

---

**After**: 
<img width="940" height="315" alt="Screenshot 2026-01-25 at 08 12 30" src="https://github.com/user-attachments/assets/325e5af3-e042-4b0d-a39d-2ef3eeeaf13e" />

Again, just a proposal :-)
