### PR TITLE
Fix: package updated column alignment issue on mobile

### DIFF
--- a/app/pages/[...package].vue
+++ b/app/pages/[...package].vue
@@ -463,8 +463,8 @@ defineOgImageComponent('Package', {
           </div>
 
           <div v-if="pkg.time?.modified" class="space-y-1">
-            <dt class="text-xs text-fg-subtle uppercase tracking-wider text-right">Updated</dt>
-            <dd class="font-mono text-sm text-fg text-right">
+            <dt class="text-xs text-fg-subtle uppercase tracking-wider sm:text-right">Updated</dt>
+            <dd class="font-mono text-sm text-fg sm:text-right">
               <NuxtTime :datetime="pkg.time.modified" date-style="medium" />
             </dd>
           </div>


### PR DESCRIPTION
Fixes the mobile regression introduced in #57, by not right-aligning the `updated` column on mobile. @danielroe thanks for the patience 😬 😀  