### PR TITLE
fix: correct pluralization for stars and forks

### DIFF
--- a/app/pages/[...package].vue
+++ b/app/pages/[...package].vue
@@ -496,7 +496,8 @@ defineOgImageComponent('Package', {
               >
                 <span class="i-carbon-logo-github w-4 h-4" aria-hidden="true" />
                 <span v-if="repoMeta">
-                  {{ formatCompactNumber(stars, { decimals: 1 }) }} stars
+                  {{ formatCompactNumber(stars, { decimals: 1 }) }}
+                  {{ stars === 1 ? 'star' : 'stars' }}
                 </span>
                 <span v-else>repo</span>
               </a>
@@ -532,7 +533,10 @@ defineOgImageComponent('Package', {
                 class="link-subtle font-mono text-sm inline-flex items-center gap-1.5"
               >
                 <span class="i-carbon-fork w-4 h-4" aria-hidden="true" />
-                <span>{{ formatCompactNumber(forks, { decimals: 1 }) }} forks</span>
+                <span>
+                  {{ formatCompactNumber(forks, { decimals: 1 }) }}
+                  {{ forks === 1 ? 'fork' : 'forks' }}
+                </span>
               </a>
             </li>
 


### PR DESCRIPTION
This PR fixes the pluralization for stars and forks if `stars === 1` or `forks === 1`

before:
<img width="765" height="141" alt="image" src="https://github.com/user-attachments/assets/73476335-3c5f-43de-b8b5-d25b0ef88a88" />
after:
<img width="765" height="141" alt="image" src="https://github.com/user-attachments/assets/b48d2ab4-8eb1-48de-8154-9d908a5a6355" />
