### PR TITLE
fix(cli): allow any localhost port in CORS config to handle non-3000 dev server

### DIFF
--- a/cli/src/server.ts
+++ b/cli/src/server.ts
@@ -37,7 +37,7 @@ function generateOperationId(): string {
 }
 
 const corsOptions: CorsOptions = {
-  origin: ['https://npmx.dev', 'http://localhost:3000'],
+  origin: ['https://npmx.dev', /^http:\/\/localhost:\d+$/],
   methods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
   allowHeaders: ['Content-Type', 'Authorization'],
 }


### PR DESCRIPTION
When port 3000 is unavailable, Nuxt/Vite automatically picks an alternative port:

```
[get-port] Unable to find an available port (tried 3000 on host "localhost"). Using alternative port 3001.
```

But the connector CORS config was hardcoded to only allow the prod host and `http://localhost:3000`, causing local authentication to fail in an opaque manner.

<img width="484" height="534" alt="Screenshot 2026-01-25 at 20 30 43" src="https://github.com/user-attachments/assets/7e0a8f55-0d68-4249-8b2b-f6e6da01f39e" />

It now uses a regex pattern to allow any localhost port. This seems fine from a security perspective, and there aren't alternatives with great DX that I can think of.