### PR TITLE
feat: show repo ref

### DIFF
--- a/app/pages/[...package].vue
+++ b/app/pages/[...package].vue
@@ -154,7 +154,7 @@ const repositoryUrl = computed(() => {
   return url
 })
 
-const { meta: repoMeta, repoRef, stars, forks, forksLink } = useRepoMeta(repositoryUrl)
+const { meta: repoMeta, repoRef, stars, starsLink, forks, forksLink } = useRepoMeta(repositoryUrl)
 
 const PROVIDER_ICONS: Record<string, string> = {
   github: 'i-carbon-logo-github',
@@ -513,11 +513,21 @@ defineOgImageComponent('Package', {
                 class="link-subtle font-mono text-sm inline-flex items-center gap-1.5"
               >
                 <span class="w-4 h-4" :class="repoProviderIcon" aria-hidden="true" />
-                <span v-if="repoMeta && stars">
-                  {{ formatCompactNumber(stars, { decimals: 1 }) }}
-                  {{ stars === 1 ? 'star' : 'stars' }}
+                <span v-if="repoRef">
+                  {{ repoRef.owner }}<span class="opacity-50">/</span>{{ repoRef.repo }}
                 </span>
                 <span v-else>repo</span>
+              </a>
+            </li>
+            <li v-if="repositoryUrl && repoMeta && starsLink">
+              <a
+                :href="starsLink"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="link-subtle font-mono text-sm inline-flex items-center gap-1.5"
+              >
+                <span class="w-4 h-4 i-carbon-star" aria-hidden="true" />
+                {{ formatCompactNumber(stars, { decimals: 1 }) }}
               </a>
             </li>
             <li v-if="homepageUrl">


### PR DESCRIPTION
When I run into a package, I find it's important to me to know "who is behind the project", or "where is the source code". Having the repo link under the "stars" is a bit confusing to me, and it's not obvious where the repo is at first glance.

Updated UI:

<img width="2056" height="784" alt="CleanShot 2026-01-26 at 13 20 36@2x" src="https://github.com/user-attachments/assets/64eb468c-7d62-4148-845f-b78c2d1a24e8" />
