### PR TITLE
feat: support resolving tag and version ranges

### DIFF
--- a/app/components/PackageDependencies.vue
+++ b/app/components/PackageDependencies.vue
@@ -91,13 +91,14 @@ const sortedOptionalDependencies = computed(() => {
             >
               <span class="i-carbon-warning-alt w-3 h-3" />
             </span>
-            <span
+            <NuxtLink
+              :to="{ name: 'package', params: { package: [...dep.split('/'), 'v', version] } }"
               class="font-mono text-xs text-right truncate"
               :class="getVersionClass(outdatedDeps[dep])"
               :title="outdatedDeps[dep] ? getOutdatedTooltip(outdatedDeps[dep]) : version"
             >
               {{ version }}
-            </span>
+            </NuxtLink>
             <span v-if="outdatedDeps[dep]" class="sr-only">
               ({{ getOutdatedTooltip(outdatedDeps[dep]) }})
             </span>
@@ -143,12 +144,16 @@ const sortedOptionalDependencies = computed(() => {
               optional
             </span>
           </div>
-          <span
+          <NuxtLink
+            :to="{
+              name: 'package',
+              params: { package: [...peer.name.split('/'), 'v', peer.version] },
+            }"
             class="font-mono text-xs text-fg-subtle max-w-[40%] text-right truncate"
             :title="peer.version"
           >
             {{ peer.version }}
-          </span>
+          </NuxtLink>
         </li>
       </ul>
       <button
@@ -187,12 +192,13 @@ const sortedOptionalDependencies = computed(() => {
           >
             {{ dep }}
           </NuxtLink>
-          <span
+          <NuxtLink
+            :to="{ name: 'package', params: { package: [...dep.split('/'), 'v', version] } }"
             class="font-mono text-xs text-fg-subtle max-w-[50%] text-right truncate"
             :title="version"
           >
             {{ version }}
-          </span>
+          </NuxtLink>
         </li>
       </ul>
       <button

--- a/app/pages/[...package].vue
+++ b/app/pages/[...package].vue
@@ -50,7 +50,7 @@ const orgName = computed(() => {
   return match ? match[1] : null
 })
 
-const { data: pkg, status, error } = usePackage(packageName, requestedVersion)
+const { data: pkg, status, error, resolvedVersion } = usePackage(packageName, requestedVersion)
 
 const { data: downloads } = usePackageDownloads(packageName, 'last-week')
 const { data: weeklyDownloads } = usePackageWeeklyDownloadEvolution(packageName, { weeks: 52 })
@@ -109,15 +109,16 @@ const sizeTooltip = computed(() => {
   return chunks.filter(Boolean).join('\n')
 })
 
-// Get the version to display (requested or latest)
+// Get the version to display (resolved version or latest)
 const displayVersion = computed(() => {
   if (!pkg.value) return null
 
-  const reqVer = requestedVersion.value
-  if (reqVer && pkg.value.versions[reqVer]) {
-    return pkg.value.versions[reqVer]
+  // Use resolved version if available
+  if (resolvedVersion.value) {
+    return pkg.value.versions[resolvedVersion.value] ?? null
   }
 
+  // Fallback to latest
   const latestTag = pkg.value['dist-tags']?.latest
   if (!latestTag) return null
   return pkg.value.versions[latestTag] ?? null
@@ -317,21 +318,33 @@ defineOgImageComponent('Package', {
               v-if="displayVersion"
               class="inline-flex items-baseline gap-1.5 font-mono text-base sm:text-lg text-fg-muted shrink-0"
             >
+              <!-- Version resolution indicator (e.g., "latest → 4.2.0") -->
+              <template v-if="resolvedVersion !== requestedVersion">
+                <span class="font-mono text-fg-muted text-sm">{{ requestedVersion }}</span>
+                <span class="i-carbon-arrow-right w-3 h-3" aria-hidden="true" />
+              </template>
+
+              <NuxtLink
+                v-if="resolvedVersion !== requestedVersion"
+                :to="`/${pkg.name}/v/${displayVersion.version}`"
+                title="View permalink for this version"
+                >{{ displayVersion.version }}</NuxtLink
+              >
+              <span v-else>v{{ displayVersion.version }}</span>
+
               <a
                 v-if="hasProvenance(displayVersion)"
                 :href="`https://www.npmjs.com/package/${pkg.name}/v/${displayVersion.version}#provenance`"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="inline-flex items-center gap-1.5 text-fg-muted hover:text-fg-muted/80 transition-colors duration-200"
+                class="inline-flex items-center gap-1.5 text-fg-muted hover:text-fg transition-colors duration-200"
                 title="Verified provenance"
               >
-                v{{ displayVersion.version }}
                 <span
                   class="i-solar-shield-check-outline w-3.5 h-3.5 shrink-0"
                   aria-hidden="true"
                 />
               </a>
-              <span v-else>v{{ displayVersion.version }}</span>
               <span
                 v-if="
                   requestedVersion &&

--- a/app/utils/versions.ts
+++ b/app/utils/versions.ts
@@ -1,6 +1,19 @@
+import { valid } from 'semver'
+
 /**
  * Utilities for handling npm package versions and dist-tags
  */
+
+/**
+ * Check if a version string is an exact semver version.
+ * Returns true for "1.2.3", "1.0.0-beta.1", etc.
+ * Returns false for ranges like "^1.2.3", ">=1.0.0", tags like "latest", etc.
+ * @param version - The version string to check
+ * @returns true if the version is an exact semver version
+ */
+export function isExactVersion(version: string): boolean {
+  return valid(version) !== null
+}
 
 /** Parsed semver version components */
 export interface ParsedVersion {


### PR DESCRIPTION
This PR adds support for:

- `/vue/v/latest`
- `/vue/v/^1`
- `/vue/v/*` (any valid semver ranges)

And it also shows the indicator when it's in tag/range mode.

<img width="1426" height="292" alt="CleanShot 2026-01-26 at 15 41 37@2x" src="https://github.com/user-attachments/assets/c2446fff-ef76-4648-be3a-921820343ea2" />

<img width="1122" height="188" alt="CleanShot 2026-01-26 at 15 40 23@2x" src="https://github.com/user-attachments/assets/e7fd998d-9dd0-4be6-98ea-74dcc7f7d31d" />

Along with this, I also made the version tags in deps clickable:

<img width="323" height="403" alt="image" src="https://github.com/user-attachments/assets/8cc5afab-6cc5-445c-adda-acfc246b40f1" />

