### PR TITLE
fix: set correct Content-Type for opensearch.xml

### DIFF
--- a/server/routes/opensearch.xml.get.ts
+++ b/server/routes/opensearch.xml.get.ts
@@ -1,6 +1,9 @@
-export default defineEventHandler(async event => {
+export default defineEventHandler(event => {
   const url = getRequestURL(event)
   const origin = url.origin
+
+  setHeader(event, 'Content-Type', 'application/opensearchdescription+xml')
+
   return `
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">


### PR DESCRIPTION
## Summary

Set the correct `Content-Type` header for the OpenSearch XML response to prevent Vercel from injecting preview toolbar scripts.

Follow up to #113.

## Problem

Vercel's preview toolbar only injects scripts into responses with `Content-Type: text/html`. Without an explicit Content-Type, the XML response was being treated as HTML, causing:
- Feedback script injection at the end of the XML
- Invalid XML that browsers couldn't parse as an OpenSearch description

## Solution

Add `setHeader(event, 'Content-Type', 'application/opensearchdescription+xml')` to the server route handler.