### PR TITLE
fix: skip displaying packages with undefined dist tags in org route

### DIFF
--- a/app/composables/useNpmRegistry.ts
+++ b/app/composables/useNpmRegistry.ts
@@ -386,7 +386,7 @@ export function useOrgPackages(orgName: MaybeRefOrGetter<string>) {
         const packuments = await Promise.all(batch.map(name => fetchMinimalPackument(name)))
 
         for (const pkg of packuments) {
-          // Filter out any unpublished packages (non-existant dist-tags)
+          // Filter out any unpublished packages (missing dist-tags)
           if (pkg && pkg['dist-tags']) {
             results.push(packumentToSearchResult(pkg))
           }


### PR DESCRIPTION
## Why

In production, we get a JS error when accessing this url https://npmx.dev/@react-bot. This is due to a package not having `dist-tags`: `react-server-dom-vite`. 

Interestingly, https://www.npmjs.com/~react-bot?activeTab=packages shows that there are 21 packages but doing a manual count of the package list only shows 20. So I guess their UI is also incorrect.

## What changed

- Filter out any package that has undefined `dist-tags`

## Testing
I manually tested going to http://localhost:3000/@react-bot.

The page now shows a package list.

<img width="1926" height="2176" alt="CleanShot 2026-01-26 at 07 41 58@2x" src="https://github.com/user-attachments/assets/5960ef12-8d02-4a67-87d4-bf12a5788c63" />
