### PR TITLE
feat: style improvement in package page

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -195,6 +195,10 @@ button {
   margin-top: 2rem;
   margin-bottom: 1rem;
   line-height: 1.3;
+
+  a {
+    text-decoration: none;
+  }
 }
 
 /* Visual styling based on original README heading level */

--- a/app/pages/[...package].vue
+++ b/app/pages/[...package].vue
@@ -489,7 +489,7 @@ defineOgImageComponent('Package', {
 
           <div v-if="downloads" class="space-y-1">
             <dt class="text-xs text-fg-subtle uppercase tracking-wider">Weekly</dt>
-            <dd class="font-mono text-sm text-fg flex items-baseline justify-start gap-2">
+            <dd class="font-mono text-sm text-fg flex items-center justify-start gap-2">
               {{ formatNumber(downloads.downloads) }}
               <a
                 :href="`https://npm.chart.dev/${pkg.name}`"
@@ -506,7 +506,7 @@ defineOgImageComponent('Package', {
 
           <div class="space-y-1">
             <dt class="text-xs text-fg-subtle uppercase tracking-wider">Deps</dt>
-            <dd class="font-mono text-sm text-fg flex items-baseline justify-start gap-2">
+            <dd class="font-mono text-sm text-fg flex items-center justify-start gap-2">
               {{ getDependencyCount(displayVersion) }}
               <a
                 v-if="getDependencyCount(displayVersion) > 0"


### PR DESCRIPTION
<table>
<tr>
 <td>
 <td>
 Before
 <td>
After
<tr>
 <td>
 `a` under heading
 <td>
<img width="1260" height="1038" alt="CleanShot 2026-01-26 at 23 43 07@2x" src="https://github.com/user-attachments/assets/6482eb95-2d8f-4cdd-a545-6283410add90" />

 <td>
<img width="1298" height="1070" alt="CleanShot 2026-01-26 at 23 42 58@2x" src="https://github.com/user-attachments/assets/8e0b6b96-2767-4bcd-ada8-252df8b19d17" />

<tr>
 <td>
 center icons
 <td>
<img width="1756" height="130" alt="CleanShot 2026-01-26 at 23 38 54@2x" src="https://github.com/user-attachments/assets/e232d0b6-315e-4c43-88cc-22ba5de5b443" />

 <td>
<img width="1770" height="142" alt="CleanShot 2026-01-26 at 23 38 45@2x" src="https://github.com/user-attachments/assets/3220ca31-0678-448f-bbc5-583692186ef2" />

</table>
