### PR TITLE
fix: cli links to localhost when run with dev script

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -27,7 +27,7 @@
   ],
   "scripts": {
     "build": "tsdown",
-    "dev": "node --experimental-strip-types src/cli.ts",
+    "dev": "node --experimental-strip-types src/cli.ts --frontend-url http://localhost:3000/",
     "test:types": "tsc --noEmit"
   },
   "dependencies": {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -10,6 +10,7 @@ import { getNpmUser } from './npm-client.ts'
 import { initLogger, showToken, logInfo, logWarning, logError } from './logger.ts'
 
 const DEFAULT_PORT = 31415
+const DEFAULT_FRONTEND_URL = 'https://npmx.dev/'
 
 async function runNpmLogin(): Promise<boolean> {
   return new Promise(resolve => {
@@ -35,10 +36,15 @@ const main = defineCommand({
     description: 'Local connector for npmx.dev',
   },
   args: {
-    port: {
+    'port': {
       type: 'string',
       description: 'Port to listen on',
       default: String(DEFAULT_PORT),
+    },
+    'frontend-url': {
+      type: 'string',
+      description: 'Url for the npmx.dev frontend',
+      default: DEFAULT_FRONTEND_URL,
     },
   },
   async run({ args }) {
@@ -90,7 +96,7 @@ const main = defineCommand({
     logInfo(`Authenticated as: ${npmUser}`)
 
     const token = generateToken()
-    showToken(token, port)
+    showToken(token, port, args.frontendUrl)
 
     const app = createConnectorApp(token)
 

--- a/cli/src/logger.ts
+++ b/cli/src/logger.ts
@@ -63,8 +63,8 @@ export function logMessage(message: string): void {
 /**
  * Show the connection token in a nice box
  */
-export function showToken(token: string, port: number): void {
-  const connectUrl = `https://npmx.dev/?token=${token}&port=${port}`
+export function showToken(token: string, port: number, frontendUrl: string): void {
+  const connectUrl = `${frontendUrl}?token=${token}&port=${port}`
 
   p.note(
     [


### PR DESCRIPTION
Smal QOL for the CLI - assumes that if you're running the cli w. the `dev` script you're likely also running and testing the frontend locally.

Configured with an argument so you could add another script that points the CLI at prod.

<img width="604" height="161" alt="Screenshot 2026-01-27 at 06 55 58" src="https://github.com/user-attachments/assets/5bac0c02-9b25-4a4f-9a19-f67d241ae269" />
