### PR TITLE
feat(cli): set host with env variable

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -27,7 +27,7 @@
   ],
   "scripts": {
     "build": "tsdown",
-    "dev": "node --experimental-strip-types src/cli.ts",
+    "dev": "NPMX_CLI_DEV=true node --experimental-strip-types src/cli.ts",
     "test:types": "tsc --noEmit"
   },
   "dependencies": {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -10,6 +10,8 @@ import { getNpmUser } from './npm-client.ts'
 import { initLogger, showToken, logInfo, logWarning, logError } from './logger.ts'
 
 const DEFAULT_PORT = 31415
+const DEFAULT_FRONTEND_URL = 'https://npmx.dev/'
+const DEV_FRONTEND_URL = 'http://localhost:3000/'
 
 async function runNpmLogin(): Promise<boolean> {
   return new Promise(resolve => {
@@ -43,6 +45,8 @@ const main = defineCommand({
   },
   async run({ args }) {
     const port = Number.parseInt(args.port as string, 10) || DEFAULT_PORT
+    const frontendUrl =
+      process.env.NPMX_CLI_DEV === 'true' ? DEV_FRONTEND_URL : DEFAULT_FRONTEND_URL
 
     initLogger()
 
@@ -90,7 +94,7 @@ const main = defineCommand({
     logInfo(`Authenticated as: ${npmUser}`)
 
     const token = generateToken()
-    showToken(token, port)
+    showToken(token, port, frontendUrl)
 
     const app = createConnectorApp(token)
 

--- a/cli/src/logger.ts
+++ b/cli/src/logger.ts
@@ -63,8 +63,8 @@ export function logMessage(message: string): void {
 /**
  * Show the connection token in a nice box
  */
-export function showToken(token: string, port: number): void {
-  const connectUrl = `https://npmx.dev/?token=${token}&port=${port}`
+export function showToken(token: string, port: number, frontendUrl: string): void {
+  const connectUrl = `${frontendUrl}?token=${token}&port=${port}`
 
   p.note(
     [


### PR DESCRIPTION
Smal QOL for the CLI - assumes that if you're running the cli w. the dev script you're likely also running and testing the frontend locally.

Configured with an environment variable `NPMX_CLI_DEV`.

<img width="604" height="161" alt="Screenshot 2026-01-27 at 06 55 58" src="https://github.com/user-attachments/assets/ed3da97c-8977-4701-9f90-f309bc1d43d0" />
