### PR TITLE
fix: focus settings toggle when opening with keyboard shortcut

### DIFF
--- a/app/components/SettingsMenu.vue
+++ b/app/components/SettingsMenu.vue
@@ -39,7 +39,8 @@ onKeyStroke(',', e => {
     return
   }
   e.preventDefault()
-  toggle()
+  triggerRef.value?.focus()
+  triggerRef.value?.click()
 })
 </script>
 


### PR DESCRIPTION
Currently the focus tab order is not correct after opening the settings menu with the `,` shortcut (it stays where it is, instead of moving to the menu). This PR addresses the issue by focusing the settings button and clicking it programmatically, instead of simply toggling the `isOpen` value. 

Before:
https://github.com/user-attachments/assets/4f8a52f9-36f5-4cdb-b5b2-d146253cbc75

After:
https://github.com/user-attachments/assets/27bf26e8-4bf9-4e48-be64-38c1dae8a922

