### PR TITLE
feat: add package manager tabs to local connector install command

### DIFF
--- a/app/components/ConnectorModal.vue
+++ b/app/components/ConnectorModal.vue
@@ -125,6 +125,14 @@ watch(open, isOpen => {
               </p>
 
               <div
+                class="inline-flex items-center gap-1 p-0.5 bg-bg-subtle border border-border-subtle rounded-md"
+                role="tablist"
+                :aria-label="$t('package.install.pm_label')"
+              >
+                <PackageManagerTabs v-model="selectedPM" />
+              </div>
+
+              <div
                 class="flex items-center p-3 bg-[#0d0d0d] border border-border rounded-lg font-mono text-sm"
               >
                 <span class="text-fg-subtle">$</span>

--- a/app/components/PackageManagerTabs.vue
+++ b/app/components/PackageManagerTabs.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+const selectedPM = defineModel<PackageManagerId>({ required: true })
+</script>
+
+<template>
+  <ClientOnly>
+    <button
+      v-for="pm in packageManagers"
+      :key="pm.id"
+      type="button"
+      role="tab"
+      :aria-selected="selectedPM === pm.id"
+      class="px-2 py-1 font-mono text-xs rounded transition-colors duration-150 border border-solid focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/50"
+      :class="
+        selectedPM === pm.id
+          ? 'bg-bg shadow text-fg border-border'
+          : 'text-fg-subtle hover:text-fg border-transparent'
+      "
+      @click="selectedPM = pm.id"
+    >
+      {{ pm.label }}
+    </button>
+    <template #fallback>
+      <span
+        v-for="pm in packageManagers"
+        :key="pm.id"
+        class="px-2 py-1 font-mono text-xs rounded"
+        :class="pm.id === 'npm' ? 'bg-bg-elevated text-fg' : 'text-fg-subtle'"
+      >
+        {{ pm.label }}
+      </span>
+    </template>
+  </ClientOnly>
+</template>

--- a/app/pages/[...package].vue
+++ b/app/pages/[...package].vue
@@ -785,33 +785,7 @@ defineOgImageComponent('Package', {
             role="tablist"
             :aria-label="$t('package.install.pm_label')"
           >
-            <ClientOnly>
-              <button
-                v-for="pm in packageManagers"
-                :key="pm.id"
-                role="tab"
-                :aria-selected="selectedPM === pm.id"
-                class="px-2 py-1 font-mono text-xs rounded transition-colors duration-150 border border-solid focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/50"
-                :class="
-                  selectedPM === pm.id
-                    ? 'bg-bg shadow text-fg border-border'
-                    : 'text-fg-subtle hover:text-fg  border-transparent'
-                "
-                @click="selectedPM = pm.id"
-              >
-                {{ pm.label }}
-              </button>
-              <template #fallback>
-                <span
-                  v-for="pm in packageManagers"
-                  :key="pm.id"
-                  class="px-2 py-1 font-mono text-xs rounded"
-                  :class="pm.id === 'npm' ? 'bg-bg-elevated text-fg' : 'text-fg-subtle'"
-                >
-                  {{ pm.label }}
-                </span>
-              </template>
-            </ClientOnly>
+            <PackageManagerTabs v-model="selectedPM" />
           </div>
         </div>
         <div class="relative group">


### PR DESCRIPTION
## Current behaviour
We keep track of the selected package manager when we change it in the package. But it's not clear that I had selected that package manager in the first place when trying to install local connector.

https://github.com/user-attachments/assets/4c9a76a2-4536-4a8b-8f72-d6c89f428494


## New behaviour

https://github.com/user-attachments/assets/47fef397-18ca-4aa0-8db5-78b34f86ea03

