### PR TITLE
feat: package analytics download file custom name

### DIFF
--- a/app/components/PackageDownloadAnalytics.vue
+++ b/app/components/PackageDownloadAnalytics.vue
@@ -456,7 +456,7 @@ const config = computed(() => ({
           loadFile(url, `${packageName}-${selectedGranularity.value}.csv`)
           URL.revokeObjectURL(url)
         },
-        svg: ({ blob }: { blob: Blob}) => {
+        svg: ({ blob }: { blob: Blob }) => {
           const url = URL.createObjectURL(blob)
           loadFile(url, `${packageName}-${selectedGranularity.value}.svg`)
           URL.revokeObjectURL(url)


### PR DESCRIPTION
<img width="447" height="258" alt="image" src="https://github.com/user-attachments/assets/cdfd46a6-02cc-4a79-8991-a6bbc2d33e73" />

All downloaded files now have default filenames that lack distinctiveness.