### PR TITLE
fix(frontend): allow `align` attribute for `<div>` elements in readme

### DIFF
--- a/server/utils/readme.ts
+++ b/server/utils/readme.ts
@@ -151,7 +151,7 @@ const ALLOWED_ATTR: Record<string, string[]> = {
   code: ['class'],
   pre: ['class', 'style'],
   span: ['class', 'style'],
-  div: ['class', 'style'],
+  div: ['class', 'style', 'align'],
 }
 
 // GitHub-style callout types


### PR DESCRIPTION
Fixes #221