### PR TITLE
fix: horizontal scroll on mobile viewports

### DIFF
--- a/app/pages/[...package].vue
+++ b/app/pages/[...package].vue
@@ -674,7 +674,7 @@ defineOgImageComponent('Package', {
           </h2>
           <!-- Package manager tabs -->
           <div
-            class="flex items-center gap-1 p-0.5 bg-bg-subtle border border-border-subtle rounded-md"
+            class="flex items-center gap-1 p-0.5 bg-bg-subtle border border-border-subtle rounded-md overflow-x-auto"
             role="tablist"
             :aria-label="$t('package.install.pm_label')"
           >
@@ -905,7 +905,7 @@ defineOgImageComponent('Package', {
   gap: 2rem;
 
   /* Mobile: single column, sidebar above readme */
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(0, 1fr);
   grid-template-areas:
     'header'
     'install'


### PR DESCRIPTION
## What
- Adds a scrollbar on the package manager tabs (let me know if that's not what we want!)
- Shrink grid column to 0 if needed.

## Before

https://github.com/user-attachments/assets/f79ea734-c75c-4cbc-9db5-972fccbe27e5

## After

https://github.com/user-attachments/assets/5ac46409-1bb1-4fc9-a607-e76fa9600c72


