### PR TITLE
feat: add a link to docs site from footer

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -90,6 +90,14 @@ onMounted(() => {
         <p class="text-xs text-fg-muted m-0 sm:hidden">{{ $t('non_affiliation_disclaimer') }}</p>
         <div class="flex items-center gap-4 sm:gap-6">
           <a
+            href="https://docs.npmx.dev"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="link-subtle font-mono text-xs min-h-11 min-w- flex items-center"
+          >
+            {{ $t('footer.docs') }}
+          </a>
+          <a
             href="https://repo.npmx.dev"
             target="_blank"
             rel="noopener noreferrer"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -9,6 +9,7 @@
   "non_affiliation_disclaimer": "not affiliated with npm, Inc.",
   "trademark_disclaimer": "npm is a registered trademark of npm, Inc. This site is not affiliated with npm, Inc.",
   "footer": {
+    "docs": "docs",
     "source": "source",
     "social": "social",
     "chat": "chat"


### PR DESCRIPTION
## Why

There's no link to the doc site which makes it less discoverable.

## Testing

A docs link now exists in the footer.

<img width="2358" height="294" alt="CleanShot 2026-01-28 at 08 13 57@2x" src="https://github.com/user-attachments/assets/c44b5679-29ad-4a90-b48e-e498dea832a2" />
