### PR TITLE
chore: add `.gitattributes` to fix LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
It is a pain running `pnpm vite fmt` on Windows (WebStorm plugin for oxc doesn't allow lint on save), I know I can fix on my local...