### PR TITLE
fix: prevent package manager tabs hydration mismatch

### DIFF
--- a/app/pages/[...package].vue
+++ b/app/pages/[...package].vue
@@ -13,6 +13,8 @@ definePageMeta({
 
 const router = useRouter()
 
+const isMounted = useMounted()
+
 const { packageName, requestedVersion, orgName } = usePackageRoute()
 
 if (import.meta.server) {
@@ -836,10 +838,10 @@ defineOgImageComponent('Package', {
               v-for="pm in packageManagers"
               :key="pm.id"
               role="tab"
-              :aria-selected="selectedPM === pm.id"
+              :aria-selected="isMounted && selectedPM === pm.id"
               class="px-2 py-1.5 font-mono text-xs rounded transition-colors duration-150 border border-solid focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/50 inline-flex items-center gap-1.5"
               :class="
-                selectedPM === pm.id
+                isMounted && selectedPM === pm.id
                   ? 'bg-bg shadow text-fg border-border'
                   : 'text-fg-subtle hover:text-fg border-transparent'
               "
@@ -921,10 +923,10 @@ defineOgImageComponent('Package', {
               v-for="pm in packageManagers"
               :key="pm.id"
               role="tab"
-              :aria-selected="selectedPM === pm.id"
+              :aria-selected="isMounted && selectedPM === pm.id"
               class="px-2 py-1.5 font-mono text-xs rounded transition-colors duration-150 border border-solid focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/50 inline-flex items-center gap-1.5"
               :class="
-                selectedPM === pm.id
+                isMounted && selectedPM === pm.id
                   ? 'bg-bg shadow text-fg border-border'
                   : 'text-fg-subtle hover:text-fg border-transparent'
               "


### PR DESCRIPTION
1. Open a package page, e.g., https://npmx.dev/vue
2. Select a tab that excludes `npm`
3. Refresh the page

You will get something like:
<img width="753" height="171" alt="image" src="https://github.com/user-attachments/assets/d7ad9d34-e87f-4396-9d6f-1e619b2bb004" />

Closes #306