### PR TITLE
feat: add RTL support to `DependencyPathPopup`

### DIFF
--- a/app/components/DependencyPathPopup.vue
+++ b/app/components/DependencyPathPopup.vue
@@ -71,7 +71,7 @@ function parsePackageString(pkg: string): { name: string; version: string } {
       :aria-expanded="isOpen"
       @click.stop="togglePopup"
     >
-      <span class="i-carbon-tree-view w-3 h-3" aria-hidden="true" />
+      <span class="i-carbon:tree-view w-3 h-3" aria-hidden="true" />
       <span>{{ $t('package.vulnerabilities.path') }}</span>
     </button>
 
@@ -89,7 +89,7 @@ function parsePackageString(pkg: string): { name: string; version: string } {
           class="font-mono text-xs"
           :style="{ paddingLeft: `${idx * 12}px` }"
         >
-          <span v-if="idx > 0" class="text-fg-subtle mr-1">└─</span>
+          <span v-if="idx > 0" class="text-fg-subtle me-1">└─</span>
           <NuxtLink
             :to="{
               name: 'package',
@@ -107,7 +107,7 @@ function parsePackageString(pkg: string): { name: string; version: string } {
           >
             {{ pathItem }}
           </NuxtLink>
-          <span v-if="idx === path.length - 1" class="ml-1 text-amber-500">⚠</span>
+          <span v-if="idx === path.length - 1" class="ms-1 text-amber-500">⚠</span>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
We should review popop padding, using left: we should use ltr from current locale. I'll do that in another PR.

releated to #317