### PR TITLE
fix: tighten code display for ascii art

### DIFF
--- a/app/assets/main.css
+++ b/app/assets/main.css
@@ -281,6 +281,9 @@ html.light .shiki span {
   white-space: pre;
   word-break: normal;
   overflow-wrap: normal;
+  /* Makes unicode and ascii art work properly */
+  line-height: 1.25;
+  display: inline-block;
 }
 
 .readme-content ul,


### PR DESCRIPTION
I noticed that some ascii art wasn't dispalying correctly. I didn't test this throughout but it seemed like a quick fix.

Before the fix:

<img width="1344" height="1222" alt="CleanShot 2026-01-29 at 22 42 07@2x" src="https://github.com/user-attachments/assets/da787a3a-cae5-4d6d-85f9-e2a9ed14ede7" />

After the fix:

<img width="1188" height="814" alt="CleanShot 2026-01-29 at 22 42 14@2x" src="https://github.com/user-attachments/assets/2cd26b33-559e-4783-9006-46ad8757d35e" />

red lines are for debug

Checked on https://npmx.dev/table