### PR TITLE
feat: install pinned versions by default

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,8 @@ packages:
   - 'cli'
   - 'docs'
 
+savePrefix: ''
+
 overrides:
   sharp: 0.34.5
   vite: npm:@voidzero-dev/vite-plus-core@latest


### PR DESCRIPTION
Since we use pinned dependencies (see #54) we should probably also make sure that new added dependencies default to a pinned version. 