### PR TITLE
perf: use stale data and revalidate on client side

### DIFF
--- a/app/composables/useCachedFetch.ts
+++ b/app/composables/useCachedFetch.ts
@@ -1,3 +1,5 @@
+import type { CachedFetchResult } from '#shared/utils/fetch-cache-config'
+
 /**
  * Type for the cachedFetch function attached to event context.
  */
@@ -9,13 +11,18 @@ export type CachedFetchFunction = <T = unknown>(
     headers?: Record<string, string>
   },
   ttl?: number,
-) => Promise<T>
+) => Promise<CachedFetchResult<T>>
 
 /**
  * Get the cachedFetch function from the current request context.
  *
  * IMPORTANT: This must be called in the composable setup context (outside of
  * useAsyncData handlers). The returned function can then be used inside handlers.
+ *
+ * The returned function returns a wrapper object with staleness metadata:
+ * - `data`: The response data
+ * - `isStale`: Whether the data came from stale cache
+ * - `cachedAt`: Unix timestamp when cached, or null if fresh fetch
  *
  * @example
  * ```ts
@@ -25,15 +32,18 @@ export type CachedFetchFunction = <T = unknown>(
  *
  *   return useLazyAsyncData(
  *     () => `package:${toValue(name)}`,
- *     // Use it inside the handler
- *     () => cachedFetch<Packument>(`https://registry.npmjs.org/${toValue(name)}`)
+ *     // Use it inside the handler - destructure { data } or { data, isStale }
+ *     async () => {
+ *       const { data } = await cachedFetch<Packument>(`https://registry.npmjs.org/${toValue(name)}`)
+ *       return data
+ *     }
  *   )
  * }
  * ```
  * @public
  */
 export function useCachedFetch(): CachedFetchFunction {
-  // On client, return a function that just uses $fetch
+  // On client, return a function that just uses $fetch (no caching, not stale)
   if (import.meta.client) {
     return async <T = unknown>(
       url: string,
@@ -43,8 +53,9 @@ export function useCachedFetch(): CachedFetchFunction {
         headers?: Record<string, string>
       } = {},
       _ttl?: number,
-    ): Promise<T> => {
-      return (await $fetch(url, options as Parameters<typeof $fetch>[1])) as T
+    ): Promise<CachedFetchResult<T>> => {
+      const data = (await $fetch(url, options as Parameters<typeof $fetch>[1])) as T
+      return { data, isStale: false, cachedAt: null }
     }
   }
 
@@ -67,7 +78,8 @@ export function useCachedFetch(): CachedFetchFunction {
       headers?: Record<string, string>
     } = {},
     _ttl?: number,
-  ): Promise<T> => {
-    return (await $fetch(url, options as Parameters<typeof $fetch>[1])) as T
+  ): Promise<CachedFetchResult<T>> => {
+    const data = (await $fetch(url, options as Parameters<typeof $fetch>[1])) as T
+    return { data, isStale: false, cachedAt: null }
   }
 }

--- a/app/composables/useRepoMeta.ts
+++ b/app/composables/useRepoMeta.ts
@@ -145,11 +145,12 @@ const githubAdapter: ProviderAdapter = {
     // Using UNGH to avoid API limitations of the Github API
     let res: UnghRepoResponse | null = null
     try {
-      res = await cachedFetch<UnghRepoResponse>(
+      const { data } = await cachedFetch<UnghRepoResponse>(
         `https://ungh.cc/repos/${ref.owner}/${ref.repo}`,
         { headers: { 'User-Agent': 'npmx' } },
         REPO_META_TTL,
       )
+      res = data
     } catch {
       return null
     }
@@ -210,11 +211,12 @@ const gitlabAdapter: ProviderAdapter = {
     const projectPath = encodeURIComponent(`${ref.owner}/${ref.repo}`)
     let res: GitLabProjectResponse | null = null
     try {
-      res = await cachedFetch<GitLabProjectResponse>(
+      const { data } = await cachedFetch<GitLabProjectResponse>(
         `https://${baseHost}/api/v4/projects/${projectPath}`,
         { headers: { 'User-Agent': 'npmx' } },
         REPO_META_TTL,
       )
+      res = data
     } catch {
       return null
     }
@@ -265,11 +267,12 @@ const bitbucketAdapter: ProviderAdapter = {
   async fetchMeta(cachedFetch, ref, links) {
     let res: BitbucketRepoResponse | null = null
     try {
-      res = await cachedFetch<BitbucketRepoResponse>(
+      const { data } = await cachedFetch<BitbucketRepoResponse>(
         `https://api.bitbucket.org/2.0/repositories/${ref.owner}/${ref.repo}`,
         { headers: { 'User-Agent': 'npmx' } },
         REPO_META_TTL,
       )
+      res = data
     } catch {
       return null
     }
@@ -322,11 +325,12 @@ const codebergAdapter: ProviderAdapter = {
   async fetchMeta(cachedFetch, ref, links) {
     let res: GiteaRepoResponse | null = null
     try {
-      res = await cachedFetch<GiteaRepoResponse>(
+      const { data } = await cachedFetch<GiteaRepoResponse>(
         `https://codeberg.org/api/v1/repos/${ref.owner}/${ref.repo}`,
         { headers: { 'User-Agent': 'npmx' } },
         REPO_META_TTL,
       )
+      res = data
     } catch {
       return null
     }
@@ -379,11 +383,12 @@ const giteeAdapter: ProviderAdapter = {
   async fetchMeta(cachedFetch, ref, links) {
     let res: GiteeRepoResponse | null = null
     try {
-      res = await cachedFetch<GiteeRepoResponse>(
+      const { data } = await cachedFetch<GiteeRepoResponse>(
         `https://gitee.com/api/v5/repos/${ref.owner}/${ref.repo}`,
         { headers: { 'User-Agent': 'npmx' } },
         REPO_META_TTL,
       )
+      res = data
     } catch {
       return null
     }
@@ -469,11 +474,12 @@ const giteaAdapter: ProviderAdapter = {
     // so caching may not apply for self-hosted instances
     let res: GiteaRepoResponse | null = null
     try {
-      res = await cachedFetch<GiteaRepoResponse>(
+      const { data } = await cachedFetch<GiteaRepoResponse>(
         `https://${ref.host}/api/v1/repos/${ref.owner}/${ref.repo}`,
         { headers: { 'User-Agent': 'npmx' } },
         REPO_META_TTL,
       )
+      res = data
     } catch {
       return null
     }
@@ -577,7 +583,7 @@ const tangledAdapter: ProviderAdapter = {
     // Tangled doesn't have a public JSON API, but we can scrape the star count
     // from the HTML page (it's in the hx-post URL as countHint=N)
     try {
-      const html = await cachedFetch<string>(
+      const { data: html } = await cachedFetch<string>(
         `https://tangled.org/${ref.owner}/${ref.repo}`,
         { headers: { 'User-Agent': 'npmx', 'Accept': 'text/html' } },
         REPO_META_TTL,
@@ -594,7 +600,7 @@ const tangledAdapter: ProviderAdapter = {
       if (atUriMatch) {
         try {
           //Get counts of records that reference this repo in the atmosphere using constellation
-          const allLinks = await cachedFetch<ConstellationAllLinksResponse>(
+          const { data: allLinks } = await cachedFetch<ConstellationAllLinksResponse>(
             `https://constellation.microcosm.blue/links/all?target=${atUri}`,
             { headers: { 'User-Agent': 'npmx' } },
             REPO_META_TTL,
@@ -655,11 +661,12 @@ const radicleAdapter: ProviderAdapter = {
   async fetchMeta(cachedFetch, ref, links) {
     let res: RadicleProjectResponse | null = null
     try {
-      res = await cachedFetch<RadicleProjectResponse>(
+      const { data } = await cachedFetch<RadicleProjectResponse>(
         `https://seed.radicle.at/api/v1/projects/${ref.repo}`,
         { headers: { 'User-Agent': 'npmx' } },
         REPO_META_TTL,
       )
+      res = data
     } catch {
       return null
     }
@@ -720,11 +727,12 @@ const forgejoAdapter: ProviderAdapter = {
 
     let res: GiteaRepoResponse | null = null
     try {
-      res = await cachedFetch<GiteaRepoResponse>(
+      const { data } = await cachedFetch<GiteaRepoResponse>(
         `https://${ref.host}/api/v1/repos/${ref.owner}/${ref.repo}`,
         { headers: { 'User-Agent': 'npmx' } },
         REPO_META_TTL,
       )
+      res = data
     } catch {
       return null
     }

--- a/shared/types/npm-registry.ts
+++ b/shared/types/npm-registry.ts
@@ -83,6 +83,7 @@ export interface NpmPerson {
  * Note: Not covered by @npm/types (see https://github.com/npm/types/issues/28)
  */
 export interface NpmSearchResponse {
+  isStale: boolean
   objects: NpmSearchResult[]
   total: number
   time: string

--- a/shared/utils/fetch-cache-config.ts
+++ b/shared/utils/fetch-cache-config.ts
@@ -80,3 +80,17 @@ export function isCacheEntryStale(entry: CachedFetchEntry): boolean {
   const expiresAt = entry.cachedAt + entry.ttl * 1000
   return now > expiresAt
 }
+
+/**
+ * Result returned by cachedFetch with staleness metadata.
+ * This allows consumers to know if the data came from stale cache
+ * and potentially trigger client-side revalidation.
+ */
+export interface CachedFetchResult<T> {
+  /** The response data */
+  data: T
+  /** Whether the data came from stale cache (past TTL) */
+  isStale: boolean
+  /** Unix timestamp when the data was cached, or null if fresh fetch */
+  cachedAt: number | null
+}


### PR DESCRIPTION
this aims to resolve the initial 'cliff' of data fetching when there's stale data - we return the stale data and revalidate on the client