### PR TITLE
fix(docs): disable formatting for hero component

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -4,12 +4,13 @@ seo:
   description: A fast, modern browser for the npm registry
 ---
 
-## ::u-page-hero
+<!-- prettier-ignore-start -->
 
+::u-page-hero
+---
 title: npmx.dev
 description: A fast, modern browser for the npm registry. Speed first, URL compatible, and simple.
 links:
-
 - label: Get Started
   to: /getting-started/introduction
   color: neutral
@@ -22,10 +23,10 @@ links:
   size: xl
   icon: i-simple-icons-github
   variant: outline
-
 ---
-
 ::
+
+<!-- prettier-ignore-end -->
 
 ::u-page-section{title="What you can do"}
 #features


### PR DESCRIPTION
Fixing a small regression from https://github.com/npmx-dev/npmx.dev/pull/333 that makes the hero section look like this:

<img width="1143" height="630" alt="image" src="https://github.com/user-attachments/assets/2ed96119-1f14-4701-88f0-efab7d9df8f1" />


Now it looks like this again:

<img width="1144" height="618" alt="image" src="https://github.com/user-attachments/assets/a581d71a-63b7-4355-8fbd-2eee16145744" />
