### PR TITLE
fix(docs): fix and prevent broken docs landing page

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -4,27 +4,24 @@ seo:
   description: A fast, modern browser for the npm registry
 ---
 
-## ::u-page-hero
-
+::u-page-hero
+---
 title: npmx.dev
 description: A fast, modern browser for the npm registry. Speed first, URL compatible, and simple.
 links:
-
-- label: Get Started
-  to: /getting-started/introduction
-  color: neutral
-  size: xl
-  trailingIcon: i-lucide-arrow-right
-- label: View on GitHub
-  to: https://github.com/npmx-dev/npmx.dev
-  target: \_blank
-  color: neutral
-  size: xl
-  icon: i-simple-icons-github
-  variant: outline
-
+  - label: Get Started
+    to: /getting-started/introduction
+    color: neutral
+    size: xl
+    trailingIcon: i-lucide-arrow-right
+  - label: View on GitHub
+    to: https://github.com/npmx-dev/npmx.dev
+    target: _blank
+    color: neutral
+    size: xl
+    icon: i-simple-icons-github
+    variant: outline
 ---
-
 ::
 
 ::u-page-section{title="What you can do"}

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "*.{js,ts,mjs,cjs,vue}": [
       "vite lint --fix"
     ],
-    "*.{js,ts,mjs,cjs,vue,json,yml,md,html,css}": [
+    "!(docs/content/index.md)*.{js,ts,mjs,cjs,vue,json,yml,md,html,css}": [
       "vite fmt"
     ]
   },


### PR DESCRIPTION
Currently, the [docs landing page](https://docs.npmx.dev/) has a broken hero section:

<img width="1493" height="544" alt="image" src="https://github.com/user-attachments/assets/b48ee051-db9d-4a3f-8a24-72a9e73b5896" />

This is due to `vite fmt` detecting the frontmatter as invalid and formatting it, thereby breaking the syntax.

After excluding `docs/content/index.md` from `vite fmt`:
<img width="1463" height="661" alt="image" src="https://github.com/user-attachments/assets/27681b88-4c11-4480-b3f6-f5dc7dcf7536" />


