### PR TITLE
fix: improve large chart readability on mobile

### DIFF
--- a/app/components/PackageDownloadAnalytics.vue
+++ b/app/components/PackageDownloadAnalytics.vue
@@ -463,7 +463,7 @@ const config = computed(() => {
   return {
     theme: isDarkMode.value ? 'dark' : 'default',
     chart: {
-      height: isMobile.value ? 850 : 600,
+      height: isMobile.value ? 950 : 600,
       userOptions: {
         buttons: {
           pdf: false,
@@ -508,15 +508,17 @@ const config = computed(() => {
       grid: {
         stroke: colors.value.border,
         labels: {
+          fontSize: isMobile.value ? 24 : 16,
           axis: {
             yLabel: $t('package.downloads.y_axis_label', {
               granularity: $t(`package.downloads.granularity_${selectedGranularity.value}`),
             }),
             xLabel: packageName,
             yLabelOffsetX: 12,
-            fontSize: 24,
+            fontSize: isMobile.value ? 32 : 24,
           },
           xAxisLabels: {
+            show: !isMobile.value,
             values: chartData.value?.dates,
             showOnlyAtModulo: true,
             modulo: 12,
@@ -554,7 +556,7 @@ const config = computed(() => {
         },
       },
       zoom: {
-        maxWidth: 500,
+        maxWidth: isMobile.value ? 350 : 500,
         customFormat:
           displayedGranularity.value !== 'weekly'
             ? undefined


### PR DESCRIPTION
## Simplified UI on mobile:
-  no x axis labels
- increased scale labels & axis names font sizes
- slight increase of the chart height
- slightly narrower minimap

| Before | After |
|-|-|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/00abfa29-5a65-4b68-ae0e-8f6f531fde93" />| <img width="300"  alt="image" src="https://github.com/user-attachments/assets/e157426f-20ff-4943-a91f-bbe52f89136d" />|