### PR TITLE
feat: call out latest version in version list

### DIFF
--- a/app/components/PackageVersions.vue
+++ b/app/components/PackageVersions.vue
@@ -330,7 +330,7 @@ function getTagVersions(tag: string): VersionDisplay[] {
       <!-- Dist-tag rows (limited to MAX_VISIBLE_TAGS) -->
       <div v-for="row in visibleTagRows" :key="row.id">
         <div
-          class="flex items-center gap-2 pr-2"
+          class="flex items-center gap-2 pe-2"
           :class="row.tag === 'latest' ? 'bg-bg-subtle rounded-lg' : ''"
         >
           <!-- Expand button (only if there are more versions to show) -->
@@ -424,7 +424,7 @@ function getTagVersions(tag: string): VersionDisplay[] {
         <!-- Expanded versions -->
         <div
           v-if="expandedTags.has(row.tag) && getTagVersions(row.tag).length > 1"
-          class="ms-4 ps-2 border-is border-border space-y-0.5 pr-2"
+          class="ms-4 ps-2 border-is border-border space-y-0.5 pe-2"
         >
           <div v-for="v in getTagVersions(row.tag).slice(1)" :key="v.version" class="py-1">
             <div class="flex items-center justify-between gap-2">
@@ -554,7 +554,7 @@ function getTagVersions(tag: string): VersionDisplay[] {
                 />
                 {{ row.primaryVersion.version }}
               </NuxtLink>
-              <div class="flex items-center gap-2 shrink-0 pr-2">
+              <div class="flex items-center gap-2 shrink-0 pe-2">
                 <DateTime
                   v-if="row.primaryVersion.time"
                   :datetime="row.primaryVersion.time"
@@ -630,7 +630,7 @@ function getTagVersions(tag: string): VersionDisplay[] {
                       {{ group.versions[0]?.version }}
                     </NuxtLink>
                   </div>
-                  <div class="flex items-center gap-2 shrink-0 pr-2">
+                  <div class="flex items-center gap-2 shrink-0 pe-2">
                     <DateTime
                       v-if="group.versions[0]?.time"
                       :datetime="group.versions[0]?.time"


### PR DESCRIPTION
Calls out the latest version in the list, to make it clear that latest has special significance.

Opted to preserve the existing order for now, although there are arguments for always putting the latest version at the top.

I also ensure that the latest tag always appears in the visible rows, forcing it to the bottom if it would otherwise be hidden. This ensures the latest tag is always visible and prominent.

<img width="446" height="804" alt="image" src="https://github.com/user-attachments/assets/d06c50c8-6443-4edc-ade3-b5f21e071aa5" />