### PR TITLE
chore: explicitly install Corepack in CI

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -18,7 +18,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - run: corepack enable
+
+      - name: Install Corepack
+        run: npm install -g corepack
+
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: lts/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - run: corepack enable
+
+      - name: Install Corepack
+        run: npm install -g corepack
+
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: lts/*
@@ -37,7 +40,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - run: corepack enable
+
+      - name: Install Corepack
+        run: npm install -g corepack
+
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: lts/*
@@ -65,7 +71,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - run: corepack enable
+
+      - name: Install Corepack
+        run: npm install -g corepack
+
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: lts/*
@@ -82,7 +91,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - run: corepack enable
+
+      - name: Install Corepack
+        run: npm install -g corepack
+
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: lts/*
@@ -104,7 +116,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - run: corepack enable
+
+      - name: Install Corepack
+        run: npm install -g corepack
+
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: lts/*

--- a/.github/workflows/lunaria.yml
+++ b/.github/workflows/lunaria.yml
@@ -28,7 +28,9 @@ jobs:
           # Makes the action clone the entire git history
           fetch-depth: 0
 
-      - run: corepack enable
+      - name: Install Corepack
+        run: npm install -g corepack
+
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: lts/*


### PR DESCRIPTION
> [!NOTE]
> This PR has an alternative: #455

Following Node.js decision not to include Corepack in future versions of Node.js, to prevent any surprises and benefit from potential fixes in Corepack, I suggest we install the latest version of Corepack explicitly on CI instead of just hoping it's there.