### PR TITLE
chore: rename provenance workflow

### DIFF
--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -1,4 +1,4 @@
-name: ci
+name: provenance
 
 on:
   push:


### PR DESCRIPTION
It was mistakenly labeled as "ci", resulting in two "ci" workflows listed in Actions.