### PR TITLE
chore: replace `corepack enable` with pnpm/action-setup

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -18,11 +18,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - run: corepack enable
+
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: lts/*
-          cache: 'pnpm'
+
+      - uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
+        name: Install pnpm
+        with:
+          cache: true
 
       - name: 📦 Install dependencies
         run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - run: corepack enable
+
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: lts/*
-          cache: pnpm
+
+      - uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
+        name: Install pnpm
+        with:
+          cache: true
 
       - name: 📦 Install dependencies
         run: pnpm install
@@ -37,11 +41,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - run: corepack enable
+
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: lts/*
-          cache: pnpm
+
+      - uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
+        name: Install pnpm
+        with:
+          cache: true
 
       - name: 📦 Install dependencies
         run: pnpm install
@@ -65,11 +73,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - run: corepack enable
+
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: lts/*
-          cache: pnpm
+
+      - uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
+        name: Install pnpm
+        with:
+          cache: true
 
       - name: 📦 Install dependencies
         run: pnpm install
@@ -82,11 +94,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - run: corepack enable
+
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: lts/*
-          cache: pnpm
+
+      - uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
+        name: Install pnpm
+        with:
+          cache: true
 
       - name: 📦 Install dependencies
         run: pnpm install
@@ -104,11 +120,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - run: corepack enable
+
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: lts/*
-          cache: pnpm
+
+      - uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
+        name: Install pnpm
+        with:
+          cache: true
 
       - name: 📦 Install dependencies
         run: pnpm install

--- a/.github/workflows/lunaria.yml
+++ b/.github/workflows/lunaria.yml
@@ -28,11 +28,14 @@ jobs:
           # Makes the action clone the entire git history
           fetch-depth: 0
 
-      - run: corepack enable
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: lts/*
-          cache: pnpm
+
+      - uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
+        name: Install pnpm
+        with:
+          cache: true
 
       - name: 📦 Install dependencies
         run: pnpm install


### PR DESCRIPTION
> [!NOTE]
> This PR has an alternative: #452

Following Node.js decision not to include Corepack in future versions of Node.js, I suggest replacing it with pnpm/action-setup, which not only removes dependency on Corepack, but also fixes dependency caching which, if you study CI logs, despite being setup correctly, simply does not seem to work.

Without cache: https://github.com/npmx-dev/npmx.dev/actions/runs/21535589549/job/62060513946

With cache: https://github.com/npmx-dev/npmx.dev/actions/runs/21535614560/job/62060587748