### PR TITLE
chore: `test:browser` failing on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test:browser:update": "playwright test --update-snapshots",
     "test:nuxt": "vite test --project nuxt",
     "test:types": "nuxt prepare && vue-tsc -b --noEmit && pnpm --filter npmx-connector test:types",
-    "test:unit": "vite test --project unit"
+    "test:unit": "vite test --project unit",
+    "start:playwright:webserver": "NODE_ENV=test pnpm build && pnpm preview --port 5678"
   },
   "dependencies": {
     "@atproto/lex": "0.0.13",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig<ConfigOptions>({
   reporter: 'html',
   timeout: 120_000,
   webServer: {
-    command: 'NODE_ENV=test pnpm build && pnpm preview --port 5678',
+    command: 'pnpm start:playwright:webserver',
     url: baseURL,
     reuseExistingServer: false,
     timeout: 120_000,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,3 +33,5 @@ patchedDependencies:
   '@jsr/deno__doc@0.189.1': patches/@jsr__deno__doc@0.189.1.patch
 
 savePrefix: ''
+
+shellEmulator: true


### PR DESCRIPTION
PW web server command using `NODE_ENV=test pnpm...`, on my Windows laptop cannot run `test:browser` script.

This PR includes:
- shell emulator enabled at pnpm workspace
- new script using the PW web server command
- PW start command runs the new script

<img width="808" height="386" alt="error starting playwright web server" src="https://github.com/user-attachments/assets/fe1fc98a-d6b7-4a17-bb60-ef3f31dcb2cb" />
