### PR TITLE
fix: format the content of the download csv file

### DIFF
--- a/app/components/PackageDownloadAnalytics.vue
+++ b/app/components/PackageDownloadAnalytics.vue
@@ -489,11 +489,17 @@ const config = computed(() => {
             // Extract multiline date format template and replace newlines with spaces in CSV
             // This ensures CSV compatibility by converting multiline date ranges to single-line format
             const PLACEHOLDER_CHAR = '\0'
-            const multilineDateTemplate = $t('package.downloads.date_range_multiline', { 
+            const multilineDateTemplate = $t('package.downloads.date_range_multiline', {
               start: PLACEHOLDER_CHAR,
               end: PLACEHOLDER_CHAR,
-            }).replaceAll(PLACEHOLDER_CHAR, '').trim()
-            const blob = new Blob([csvStr.replace('data:text/csv;charset=utf-8,', '').replaceAll(`\n${multilineDateTemplate}`, ` ${multilineDateTemplate}`)])
+            })
+              .replaceAll(PLACEHOLDER_CHAR, '')
+              .trim()
+            const blob = new Blob([
+              csvStr
+                .replace('data:text/csv;charset=utf-8,', '')
+                .replaceAll(`\n${multilineDateTemplate}`, ` ${multilineDateTemplate}`),
+            ])
             const url = URL.createObjectURL(blob)
             loadFile(
               url,


### PR DESCRIPTION
|current|after|
|---|---|
|<img width="388" height="289" alt="image" src="https://github.com/user-attachments/assets/4263ba89-2fcd-43d7-9ca5-9d25fa484779" />|<img width="377" height="259" alt="image" src="https://github.com/user-attachments/assets/4050b815-d946-4f63-aab6-e1b01eba7b01" />|