### PR TITLE
perf: avoid unnecessary npm request for custom badge 

### DIFF
--- a/server/api/registry/badge/[...pkg].get.ts
+++ b/server/api/registry/badge/[...pkg].get.ts
@@ -30,8 +30,8 @@ export default defineCachedEventHandler(
 
       const label = `./ ${packageName}`
 
-      const packument = await fetchNpmPackage(packageName)
-      const value = requestedVersion ?? packument['dist-tags']?.latest ?? 'unknown'
+      const value =
+        requestedVersion ?? (await fetchNpmPackage(packageName))['dist-tags']?.latest ?? 'unknown'
 
       const leftWidth = measureTextWidth(label)
       const rightWidth = measureTextWidth(value)


### PR DESCRIPTION
If a version is specified for a custom tag, an npm request does not need to be made.