### PR TITLE
fix: disable word break for README tables

### DIFF
--- a/app/assets/main.css
+++ b/app/assets/main.css
@@ -463,6 +463,7 @@ html.light .shiki span {
   border-collapse: collapse;
   margin: 1.5rem 0;
   font-size: 0.875rem;
+  word-break: keep-all;
 }
 
 .readme-content th,


### PR DESCRIPTION
Resolves #425 
In case of an overflow, a table becomes scrollable

<img width="374" height="666" alt="image" src="https://github.com/user-attachments/assets/3daebb6a-0f29-483a-af6c-589df60bde61" />
