### PR TITLE
fix: gracefully handle docs failures

### DIFF
--- a/server/utils/docs/client.ts
+++ b/server/utils/docs/client.ts
@@ -7,7 +7,7 @@
  * @module server/utils/docs/client
  */
 
-import { doc } from '@deno/doc'
+import { doc, type DocNode } from '@deno/doc'
 import type { DenoDocNode, DenoDocResult } from '#shared/types/deno-doc'
 
 // =============================================================================
@@ -33,10 +33,15 @@ export async function getDocNodes(packageName: string, version: string): Promise
   }
 
   // Generate docs using @deno/doc WASM
-  const result = await doc([typesUrl], {
-    load: createLoader(),
-    resolve: createResolver(),
-  })
+  let result: Record<string, DocNode[]>
+  try {
+    result = await doc([typesUrl], {
+      load: createLoader(),
+      resolve: createResolver(),
+    })
+  } catch {
+    return { version: 1, nodes: [] }
+  }
 
   // Collect all nodes from all specifiers
   const allNodes: DenoDocNode[] = []


### PR DESCRIPTION
Small change so we don't consider a failure of docs generation to be
error level, since _many_ packages fail this (anything using node built
ins right now).

edit: @devdumpling before we merge this - im unable to cause the error again locally and can't see the logs for the preview deployment. do you think this change is redundant? my intention was to catch the various WASM errors we were seeing so they don't pollute the logs