### PR TITLE
refactor: use an `<article>` element for for package readme

### DIFF
--- a/app/components/PackageSkeleton.vue
+++ b/app/components/PackageSkeleton.vue
@@ -150,7 +150,7 @@
       </div>
 
       <!-- Sidebar: order-1 lg:order-2 space-y-8 -->
-      <aside class="order-1 lg:order-2 space-y-8">
+      <div class="order-1 lg:order-2 space-y-8">
         <!-- Maintainers -->
         <section>
           <h2
@@ -249,7 +249,7 @@
             </li>
           </ul>
         </section>
-      </aside>
+      </div>
     </div>
   </article>
 </template>

--- a/app/pages/[...package].vue
+++ b/app/pages/[...package].vue
@@ -923,7 +923,7 @@ function handleClick(event: MouseEvent) {
 
       <div class="area-sidebar">
         <!-- Sidebar -->
-        <aside class="sticky top-20 space-y-6 sm:space-y-8 min-w-0 overflow-hidden">
+        <div class="sticky top-20 space-y-6 sm:space-y-8 min-w-0 overflow-hidden">
           <!-- Maintainers (with admin actions when connected) -->
           <PackageMaintainers :package-name="pkg.name" :maintainers="pkg.maintainers" />
 
@@ -1031,7 +1031,7 @@ function handleClick(event: MouseEvent) {
             :peer-dependencies-meta="displayVersion.peerDependenciesMeta"
             :optional-dependencies="displayVersion.optionalDependencies"
           />
-        </aside>
+        </div>
       </div>
     </article>
 


### PR DESCRIPTION
As discussed in https://github.com/npmx-dev/npmx.dev/pull/503#discussion_r2749739592 and https://github.com/npmx-dev/npmx.dev/pull/503#discussion_r2749740907, @rshigg and I noticed that a package’s readme would be better wrapped with an `<article>` element as it’s a standalone document. It’s alright that it’s a descendant of another `<article>` element (which wraps the page’s main contents).

Worth noting that an `<article>` element and its corresponding `article` ARIA role is not a navigational landmark, so this change will only impact users when they are traversing through the page.