### PR TITLE
feat: add file icons for Glimmer JS and Glimmer TS

### DIFF
--- a/app/utils/file-icons.ts
+++ b/app/utils/file-icons.ts
@@ -27,8 +27,8 @@ const EXTENSION_ICONS: Record<string, string> = {
   'vue': 'i-vscode-icons-file-type-vue',
   'svelte': 'i-vscode-icons-file-type-svelte',
   'astro': 'i-vscode-icons-file-type-astro',
-  'gjs': 'i-vscode-icons-file-type-glimmer-js',
-  'gts': 'i-vscode-icons-file-type-glimmer-ts',
+  'gjs': 'i-vscode-icons-file-type-glimmer',
+  'gts': 'i-vscode-icons-file-type-glimmer',
 
   // Config/Data
   'json': 'i-vscode-icons-file-type-json',


### PR DESCRIPTION
Testin' with https://npmx.dev/code/ember-primitives/v/0.53.0/src/viewport/in-viewport.gts


This branch:
- https://npmxdev-git-fork-nullvoxpopuli-patch-2-poetry.vercel.app/code/ember-primitives/v/0.53.0/src/viewport/in-viewport.gts
<img width="294" height="248" alt="image" src="https://github.com/user-attachments/assets/eba1419f-40a1-4ab0-9217-9c3f8b90eab6" />



Edit! oh -- looks like iconify drops the suffix: https://icon-sets.iconify.design/vscode-icons/?icon-filter=glimmer&keyword=vscode

<details><summary>old info</summary>

https://github.com/vscode-icons/vscode-icons/wiki/ListOfFiles

<img width="982" height="166" alt="image" src="https://github.com/user-attachments/assets/f5bb07bc-ca07-44b8-b8b6-ee93f640c3bf" />


https://github.com/vscode-icons/vscode-icons/blob/master/icons/file_type_glimmer.svg


</details>