### PR TITLE
fix: vertically align mobile menu button

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -185,7 +185,7 @@ onKeyStroke(
         <!-- Mobile: Menu button (always visible, toggles menu) -->
         <button
           type="button"
-          class="sm:hidden p-2 -m-2 text-fg-subtle hover:text-fg transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 rounded"
+          class="sm:hidden flex items-center p-2 -m-2 text-fg-subtle hover:text-fg transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 rounded"
           :aria-label="showMobileMenu ? $t('common.close') : $t('nav.open_menu')"
           :aria-expanded="showMobileMenu"
           @click="showMobileMenu = !showMobileMenu"


### PR DESCRIPTION
Before:

<img width="153" height="84" alt="image" src="https://github.com/user-attachments/assets/0d89a197-09b5-4ca5-bdfd-98268fdecfc4" />

<img width="153" height="84" alt="image" src="https://github.com/user-attachments/assets/58ec5ed2-5eb0-4de0-bc2f-4e890fe40c48" />


After:

<img width="153" height="84" alt="image" src="https://github.com/user-attachments/assets/49780289-5f0f-49fd-a612-6234cafbcce1" />

<img width="153" height="84" alt="image" src="https://github.com/user-attachments/assets/14bcafe6-f6fd-47c3-9401-32cc758578c2" />
