### PR TITLE
fix: prevent avatars from being shrank

### DIFF
--- a/app/pages/@[org].vue
+++ b/app/pages/@[org].vue
@@ -143,10 +143,10 @@ defineOgImageComponent('Default', {
   <main class="container flex-1 py-8 sm:py-12 w-full">
     <!-- Header -->
     <header class="mb-8 pb-8 border-b border-border">
-      <div class="flex items-end gap-4">
+      <div class="flex flex-wrap items-end gap-4">
         <!-- Org avatar placeholder -->
         <div
-          class="w-16 h-16 rounded-lg bg-bg-muted border border-border flex items-center justify-center"
+          class="size-16 shrink-0 rounded-lg bg-bg-muted border border-border flex items-center justify-center"
           aria-hidden="true"
         >
           <span class="text-2xl text-fg-subtle font-mono">{{

--- a/app/pages/~[username]/index.vue
+++ b/app/pages/~[username]/index.vue
@@ -178,10 +178,10 @@ defineOgImageComponent('Default', {
   <main class="container flex-1 py-8 sm:py-12 w-full">
     <!-- Header -->
     <header class="mb-8 pb-8 border-b border-border">
-      <div class="flex items-end gap-4">
+      <div class="flex flex-wrap items-end gap-4">
         <!-- Avatar placeholder -->
         <div
-          class="w-16 h-16 rounded-full bg-bg-muted border border-border flex items-center justify-center"
+          class="size-16 shrink-0 rounded-full bg-bg-muted border border-border flex items-center justify-center"
           aria-hidden="true"
         >
           <span class="text-2xl text-fg-subtle font-mono">{{

--- a/app/pages/~[username]/orgs.vue
+++ b/app/pages/~[username]/orgs.vue
@@ -119,10 +119,10 @@ defineOgImageComponent('Default', {
   <main class="container flex-1 py-8 sm:py-12 w-full">
     <!-- Header -->
     <header class="mb-8 pb-8 border-b border-border">
-      <div class="flex items-center gap-4 mb-4">
+      <div class="flex flex-wrap items-center gap-4 mb-4">
         <!-- Avatar placeholder -->
         <div
-          class="w-16 h-16 rounded-full bg-bg-muted border border-border flex items-center justify-center"
+          class="size-16 shrink-0 rounded-full bg-bg-muted border border-border flex items-center justify-center"
           aria-hidden="true"
         >
           <span class="text-2xl text-fg-subtle font-mono">{{


### PR DESCRIPTION
Fixes #510 

Addresses the issue with two fixes:
- Explicitly disallows shrinking of avatars/org logos
- Allows flex wrap to prevent elements from shrinking too much

Before:

<img width="386" height="144" alt="image" src="https://github.com/user-attachments/assets/f8ac731c-9b80-4b46-8ec8-a3d2e4e1d813" />

"During" (fix 1):

<img width="386" height="144" alt="image" src="https://github.com/user-attachments/assets/d2bc16f2-22d0-4567-a83f-80c38d2744ba" />

After (both fixes):

<img width="386" height="205" alt="image" src="https://github.com/user-attachments/assets/a9877cfb-78cd-4045-9018-3ca2a1126a57" />
