### PR TITLE
fix: don't rely on pkg.updated for update date

### DIFF
--- a/app/components/PackageTableRow.vue
+++ b/app/components/PackageTableRow.vue
@@ -17,8 +17,7 @@ const emit = defineEmits<{
 const pkg = computed(() => props.result.package)
 const score = computed(() => props.result.score)
 
-// Get the best available date: prefer result.updated (from packument), fall back to package.date
-const updatedDate = computed(() => props.result.updated ?? props.result.package.date)
+const updatedDate = computed(() => props.result.package.date)
 
 function formatDownloads(count?: number): string {
   if (count === undefined) return '-'

--- a/app/composables/useStructuredFilters.ts
+++ b/app/composables/useStructuredFilters.ts
@@ -225,7 +225,7 @@ export function useStructuredFilters(options: UseStructuredFiltersOptions) {
     const config = UPDATED_WITHIN_OPTIONS.find(o => o.value === within)
     if (!config?.days) return true
 
-    const updatedDate = new Date(pkg.updated ?? pkg.package.date)
+    const updatedDate = new Date(pkg.package.date)
     const cutoff = new Date()
     cutoff.setDate(cutoff.getDate() - config.days)
     return updatedDate >= cutoff
@@ -260,9 +260,7 @@ export function useStructuredFilters(options: UseStructuredFiltersOptions) {
         diff = (a.downloads?.weekly ?? 0) - (b.downloads?.weekly ?? 0)
         break
       case 'updated':
-        diff =
-          new Date(a.updated ?? a.package.date).getTime() -
-          new Date(b.updated ?? b.package.date).getTime()
+        diff = new Date(a.package.date).getTime() - new Date(b.package.date).getTime()
         break
       case 'name':
         diff = a.package.name.localeCompare(b.package.name)

--- a/app/pages/~[username]/index.vue
+++ b/app/pages/~[username]/index.vue
@@ -106,8 +106,8 @@ const filteredAndSortedPackages = computed(() => {
   switch (sortOption.value) {
     case 'updated':
       pkgs.sort((a, b) => {
-        const dateA = a.updated || a.package.date || ''
-        const dateB = b.updated || b.package.date || ''
+        const dateA = a.package.date || ''
+        const dateB = b.package.date || ''
         return dateB.localeCompare(dateA)
       })
       break


### PR DESCRIPTION
Fixes #535

It appears that the dates in `updated` field are not reliable at all (see #535 for details). Therefore I removed it and left only `package.date`, and now I get the exact results that I expected.