### PR TITLE
chore: remove un(directly)used dependency and cleanup Knip config

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "includeEntryExports": true,
   "ignoreExportsUsedInFile": true,
-  "ignoreBinaries": ["simple-git-hooks", "lint-staged", "lex"],
+  "ignoreBinaries": ["simple-git-hooks", "lint-staged"],
   "ignore": ["shared/types/lexicons/**"],
   "workspaces": {
     ".": {
@@ -28,7 +28,6 @@
         "server/**/*.ts!",
         "shared/**/*.ts!",
         "test/**/*.ts",
-        "tests/**/*.ts",
         "lunaria/**/*.ts",
         "modules/**/*.ts!",
         "i18n/**/*.ts!"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "typescript": "5.9.3",
     "unocss": "66.6.0",
     "unplugin-vue-router": "0.19.2",
-    "vite-plugin-pwa": "1.2.0",
     "vite-plus": "0.0.0-833c515fa25cef20905a7f9affb156dfa6f151ab",
     "vitest": "npm:@voidzero-dev/vite-plus-test@0.0.0-833c515fa25cef20905a7f9affb156dfa6f151ab",
     "vitest-environment-nuxt": "1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,9 +222,6 @@ importers:
       unplugin-vue-router:
         specifier: 0.19.2
         version: 0.19.2(@vue/compiler-sfc@3.5.27)(vue-router@4.6.4(vue@3.5.27(typescript@5.9.3)))(vue@3.5.27(typescript@5.9.3))
-      vite-plugin-pwa:
-        specifier: 1.2.0
-        version: 1.2.0(@vite-pwa/assets-generator@1.0.2)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(workbox-build@7.4.0)(workbox-window@7.4.0)
       vite-plus:
         specifier: 0.0.0-833c515fa25cef20905a7f9affb156dfa6f151ab
         version: 0.0.0-833c515fa25cef20905a7f9affb156dfa6f151ab(@types/node@24.10.9)(esbuild@0.27.2)(happy-dom@20.4.0)(jiti@2.6.1)(terser@5.46.0)(typescript@5.9.3)(yaml@2.8.2)


### PR DESCRIPTION
vite-plugin-pwa is indeed used but it's a @vite-pwa/nuxt dependency, no need to declare it directly at top level.

I then followed Knip configuration hints to clean it up.

```
Configuration hints (5)
nuxt             docs  …ip.json  Remove from ignoreDependencies
…mple-git-hooks        …ip.json  Remove from ignoreBinaries
lint-staged            …ip.json  Remove from ignoreBinaries
lex                    …ip.json  Remove from ignoreBinaries
tests/**/*.ts          …ip.json  Refine project pattern (no mat…
```