### PR TITLE
fix: change search view mode icons

### DIFF
--- a/app/components/ViewModeToggle.vue
+++ b/app/components/ViewModeToggle.vue
@@ -18,7 +18,7 @@ const viewMode = defineModel<ViewMode>({ default: 'cards' })
       :aria-label="$t('filters.view_mode.cards')"
       @click="viewMode = 'cards'"
     >
-      <span class="i-carbon-grid w-4 h-4" aria-hidden="true" />
+      <span class="i-carbon-horizontal-view w-4 h-4" aria-hidden="true" />
       <span class="sr-only">{{ $t('filters.view_mode.cards') }}</span>
     </button>
     <button
@@ -29,7 +29,7 @@ const viewMode = defineModel<ViewMode>({ default: 'cards' })
       :aria-label="$t('filters.view_mode.table')"
       @click="viewMode = 'table'"
     >
-      <span class="i-carbon-list w-4 h-4" aria-hidden="true" />
+      <span class="i-carbon-table-split w-4 h-4" aria-hidden="true" />
       <span class="sr-only">{{ $t('filters.view_mode.table') }}</span>
     </button>
   </div>


### PR DESCRIPTION
I think these more accurately reflect the two modes and emphasises that the latter is a table.

New:
<img width="473" height="58" alt="image" src="https://github.com/user-attachments/assets/f4ab880b-77d4-44e7-9feb-d3d800c4a668" />

Current:
<img width="473" height="58" alt="image" src="https://github.com/user-attachments/assets/4fb81f6b-dc62-46bf-8c80-c90655545bf1" />
