### PR TITLE
fix: correct package-page layout for large content

### DIFF
--- a/app/pages/[...package].vue
+++ b/app/pages/[...package].vue
@@ -1090,6 +1090,7 @@ function handleClick(event: MouseEvent) {
       'install install'
       'vulns   vulns'
       'readme  sidebar';
+    grid-template-rows: auto auto auto 1fr;
   }
 }
 


### PR DESCRIPTION
To prevent the elements from being stretched into equal parts, we clearly indicate that the first parts take up automatic space, and the last one is stretched (_and thus presses the first ones to the top, and the last one also remains at the top_)

#593 #546 

_Example package with long versions list: https://npmxdev-git-fork-alexdln-fix-package-page-large-layout-poetry.vercel.app/astro_