### PR TITLE
chore: update nuxt/nitro `compatibilityDate`

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -113,7 +113,7 @@ export default defineNuxtConfig({
     typedPages: true,
   },
 
-  compatibilityDate: '2024-04-03',
+  compatibilityDate: '2026-01-31',
 
   nitro: {
     experimental: {


### PR DESCRIPTION
I assume this was an oversight