### PR TITLE
fix: consistently use tilde for usernames

### DIFF
--- a/app/components/PackageMaintainers.vue
+++ b/app/components/PackageMaintainers.vue
@@ -196,7 +196,7 @@ watch(
             }"
             class="link-subtle font-mono text-sm shrink-0"
           >
-            @{{ maintainer.name }}
+            ~{{ maintainer.name }}
           </NuxtLink>
           <span v-else class="font-mono text-sm text-fg-muted">{{ maintainer.email }}</span>
 


### PR DESCRIPTION
`~` is for users, `@` is for orgs

Currently, you click `@some-maintainer` and it takes you to `/~some-maintainer`:

<img width="172" height="107" alt="Screenshot 2026-01-31 at 21 40 54" src="https://github.com/user-attachments/assets/cc322357-82c5-46e6-9be7-c523f9b49dcb" />
<br/>↓<br/>
<img width="602" height="244" alt="Screenshot 2026-01-31 at 21 41 07" src="https://github.com/user-attachments/assets/bc1b2dd5-bf2a-4ca4-af67-2cec877cf82a" />
