### PR TITLE
fix: polish versions layout

### DIFF
--- a/app/components/PackageDependencies.vue
+++ b/app/components/PackageDependencies.vue
@@ -187,12 +187,10 @@ const sortedOptionalDependencies = computed(() => {
             </NuxtLink>
             <span
               v-if="peer.optional"
-              class="shrink-0 text-fg-muted hover:text-fg transition-colors duration-200 cursor-help inline-flex items-center"
+              class="px-1 py-0.5 font-mono text-[10px] text-fg-subtle bg-bg-muted border border-border rounded shrink-0"
               :title="$t('package.dependencies.optional')"
-              :aria-label="$t('package.dependencies.optional')"
-              role="img"
             >
-              <span aria-hidden="true" class="i-carbon:information w-3 h-3 block" />
+              {{ $t('package.dependencies.optional') }}
             </span>
           </div>
           <NuxtLink


### PR DESCRIPTION
A minor revision and improvement of another PR (#549 ) based on what was discussed and implemented in the previous PR.

I've finalized the overall layout. Each version can take up a maximum of 40% of the page. If possible, the version is not cropped, but the title is. If neither fits, both are cropped. Content is always at the edges.

I also removed the span between the name and version. I see it was added during the RTL improvements, but I checked that everything looks great in RTL without it now.

The layout on the mobile version has also improved

Example with optional deps - [vitest](https://npmx.dev/vitest)

Closes #532
closes #549