### PR TITLE
style: fix alignment for invalid user

### DIFF
--- a/app/pages/~[username]/index.vue
+++ b/app/pages/~[username]/index.vue
@@ -175,10 +175,10 @@ defineOgImageComponent('Default', {
 </script>
 
 <template>
-  <main class="container flex-1 py-8 sm:py-12 w-full">
+  <main class="container flex-1 flex flex-col py-8 sm:py-12 w-full">
     <!-- Header -->
     <header class="mb-8 pb-8 border-b border-border">
-      <div class="flex flex-wrap items-end gap-4">
+      <div class="flex flex-wrap items-center gap-4">
         <!-- Avatar placeholder -->
         <div
           class="size-16 shrink-0 rounded-full bg-bg-muted border border-border flex items-center justify-center"
@@ -236,16 +236,8 @@ defineOgImageComponent('Default', {
       <NuxtLink to="/" class="btn">{{ $t('common.go_back_home') }}</NuxtLink>
     </div>
 
-    <!-- Empty state -->
-    <div v-else-if="results && results.total === 0" class="py-12 text-center">
-      <p class="text-fg-muted font-mono">
-        {{ $t('user.page.no_packages') }} <span class="text-fg">~{{ username }}</span>
-      </p>
-      <p class="text-fg-subtle text-sm mt-2">{{ $t('user.page.no_packages_hint') }}</p>
-    </div>
-
     <!-- Package list -->
-    <section v-else-if="results && packages.length > 0">
+    <section v-else-if="packages.length > 0">
       <h2 class="text-xs text-fg-subtle uppercase tracking-wider mb-4">
         {{ $t('user.page.packages_title') }}
       </h2>
@@ -254,7 +246,7 @@ defineOgImageComponent('Default', {
       <PackageListControls
         v-model:filter="filterText"
         v-model:sort="sortOption"
-        :placeholder="$t('user.page.filter_placeholder', { count: results.total })"
+        :placeholder="$t('user.page.filter_placeholder', { count: results?.total ?? 0 })"
         :total-count="packageCount"
         :filtered-count="filteredCount"
       />
@@ -278,5 +270,15 @@ defineOgImageComponent('Default', {
         @page-change="handlePageChange"
       />
     </section>
+
+    <!-- Empty state (no packages found for user) -->
+    <div v-else-if="status === 'success'" class="flex-1 flex items-center justify-center">
+      <div class="text-center">
+        <p class="text-fg-muted font-mono">
+          {{ $t('user.page.no_packages') }} <span class="text-fg">~{{ username }}</span>
+        </p>
+        <p class="text-fg-subtle text-sm mt-2">{{ $t('user.page.no_packages_hint') }}</p>
+      </div>
+    </div>
   </main>
 </template>


### PR DESCRIPTION
When the user is invalid, the username moves on the bottom. I think this should be on the middle like other valid user. 

https://npmx.dev/~danielroe
https://npmx.dev/~danielroe007