### PR TITLE
fix: revert well-known/skills to middleware approach

### DIFF
--- a/server/middleware/well-known-skills.ts
+++ b/server/middleware/well-known-skills.ts
@@ -6,8 +6,17 @@ import { CACHE_MAX_AGE_ONE_HOUR, CACHE_MAX_AGE_ONE_YEAR } from '#shared/utils/co
 
 /**
  * Serves /.well-known/skills endpoints for `npx skills add` CLI.
+ * Middleware pattern allows non-matching paths to pass through to Nuxt.
  */
-export default defineCachedEventHandler(
+export default defineEventHandler(event => {
+  const url = getRequestURL(event)
+  const match = url.pathname.match(/^\/(.+?)\/\.well-known\/skills\/(.*)$/)
+  if (!match) return
+
+  return cachedHandler(event)
+})
+
+const cachedHandler = defineCachedEventHandler(
   async (event: H3Event) => {
     const url = getRequestURL(event)
     const match = url.pathname.match(/^\/(.+?)\/\.well-known\/skills\/(.*)$/)!

--- a/server/routes/[pkg]/[scope]/well-known-skills.ts
+++ b/server/routes/[pkg]/[scope]/well-known-skills.ts
@@ -1,1 +1,0 @@
-export { default } from '../.well-known-skills'


### PR DESCRIPTION
#634 broke `/.well-known/skills` endpoints. Nitro's file-based routing interprets `.well-known-skills.ts` as a filename, generating wrong URL patterns:

- **Generated:** `/:pkg/.well-known-skills`
- **Expected:** `/:pkg/.well-known/skills/**`

Broken URLs (prod):
- https://npmx.dev/claude-skills-frontend/.well-known/skills/index.json → 404
- https://npmx.dev/claude-skills-frontend/.well-known-skills → 500

Fixed URLs (preview):
- https://npmxdev-git-fork-onmax-fix-well-known-skills-routing-poetry.vercel.app/claude-skills-frontend/.well-known/skills/index.json

This reverts to the middleware approach from #630 which uses regex matching to handle the path correctly. ISR caching rules in nuxt.config.ts remain unchanged.

### Why two handlers?

Middleware runs on every request, so we need:
1. Outer `defineEventHandler` - checks URL match, returns `undefined` for non-matching paths (passes through to Nuxt)
2. Inner `defineCachedEventHandler` - only caches matching requests

Routes could use a single `defineCachedEventHandler` because file-based routing only sends matching URLs to that handler.