### PR TITLE
feat: allow align attribute in readme

### DIFF
--- a/server/utils/readme.ts
+++ b/server/utils/readme.ts
@@ -143,16 +143,17 @@ const ALLOWED_ATTR: Record<string, string[]> = {
   source: ['src', 'srcset', 'type', 'media'],
   th: ['colspan', 'rowspan', 'align'],
   td: ['colspan', 'rowspan', 'align'],
-  h3: ['id', 'data-level'],
-  h4: ['id', 'data-level'],
-  h5: ['id', 'data-level'],
-  h6: ['id', 'data-level'],
+  h3: ['id', 'data-level', 'align'],
+  h4: ['id', 'data-level', 'align'],
+  h5: ['id', 'data-level', 'align'],
+  h6: ['id', 'data-level', 'align'],
   blockquote: ['data-callout'],
   details: ['open'],
   code: ['class'],
   pre: ['class', 'style'],
   span: ['class', 'style'],
   div: ['class', 'style', 'align'],
+  p: ['align'],
 }
 
 // GitHub-style callout types


### PR DESCRIPTION
Fixes projen readme rendering

<img width="2171" height="1101" alt="image" src="https://github.com/user-attachments/assets/efc5b1e5-2800-4e3c-980d-328211bc6d69" />
