### PR TITLE
fix: support git protocol in readme

### DIFF
--- a/shared/utils/git-providers.ts
+++ b/shared/utils/git-providers.ts
@@ -265,8 +265,8 @@ export function normalizeGitUrl(input: string): string | null {
 
   const normalized = raw.replace(/^git\+/, '')
 
-  // Handle ssh:// URLs by converting to https://
-  if (/^ssh:\/\//i.test(normalized)) {
+  // Handle ssh:// and git:// URLs by converting to https://
+  if (/^(ssh|git):\/\//i.test(normalized)) {
     try {
       const url = new URL(normalized)
       const path = url.pathname.replace(/^\/*/, '')


### PR DESCRIPTION
A microfix for link formatting in readmes. Because there was no condition here, the existing logic didn't work in certain scenarios (for example [here](https://npmx.dev/robindoc/v/3.7.9#user-content-advantages)). Judging by the method comment, this logic was originally planned, but apparently got lost.

Partially closes issue #617, but I think I still need to think about where to navigate users. For now, it's more likely to be a fix for what's expected already