### PR TITLE
fix: remove max-width for readme container on larger screens

### DIFF
--- a/app/components/Readme.vue
+++ b/app/components/Readme.vue
@@ -5,7 +5,7 @@ defineProps<{
 </script>
 
 <template>
-  <article class="readme prose prose-invert max-w-[70ch]" v-html="html" />
+  <article class="readme prose prose-invert max-w-[70ch] lg:max-w-none" v-html="html" />
 </template>
 
 <style scoped>


### PR DESCRIPTION
Removes the max-width for the README container on larger screens where it's not needed but instead creates a small layout issue.

**bug**
<img width="619" height="273" alt="image" src="https://github.com/user-attachments/assets/4e7180a2-523d-49e4-9393-7c7b9119a661" />

**fix**
<img width="613" height="264" alt="image" src="https://github.com/user-attachments/assets/cd45fa0f-ed67-4244-846c-fa692f958b26" />
