### PR TITLE
feat: allow align and style on img tag

### DIFF
--- a/server/utils/readme.ts
+++ b/server/utils/readme.ts
@@ -139,7 +139,7 @@ const ALLOWED_TAGS = [
 
 const ALLOWED_ATTR: Record<string, string[]> = {
   a: ['href', 'title', 'target', 'rel'],
-  img: ['src', 'alt', 'title', 'width', 'height', 'align', 'style'],
+  img: ['src', 'alt', 'title', 'width', 'height', 'align'],
   source: ['src', 'srcset', 'type', 'media'],
   th: ['colspan', 'rowspan', 'align'],
   td: ['colspan', 'rowspan', 'align'],


### PR DESCRIPTION
Fixes obsidium/v/2.0.0 package readme

<img width="2213" height="557" alt="image" src="https://github.com/user-attachments/assets/111017eb-2db2-4a47-865f-3f3a9a0778eb" />
Left is old, right is new