### PR TITLE
chore: remove redundant strip types flag from cli dev command

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -45,5 +45,8 @@
     "@types/validate-npm-package-name": "4.0.2",
     "tsdown": "0.20.1",
     "typescript": "5.9.3"
+  },
+  "engines": {
+    "node": ">=24"
   }
 }


### PR DESCRIPTION
`--experimental-strip-types` [is not needed from v.22.18.0 or later](https://nodejs.org/en/learn/typescript/run-natively). Also specified the minimum expected version (24) with the engines field, so anyone running with a lower version will get a meaningful error.