### PR TITLE
fix: make sure chevron in pagination result select is visible

### DIFF
--- a/app/components/PaginationControls.vue
+++ b/app/components/PaginationControls.vue
@@ -168,7 +168,7 @@ function handlePageSizeChange(event: Event) {
           class="absolute inset-ie-2 top-1/2 -translate-y-1/2 text-fg-subtle pointer-events-none"
           aria-hidden="true"
         >
-          <span class="i-carbon-chevron-down w-3 h-3" />
+          <span class="inline-block i-carbon-chevron-down w-3 h-3" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Making sure the “show amount of results / page“ select has its downwards chevron visible. 

<img width="340" height="87" alt="SCR-20260201-opzk" src="https://github.com/user-attachments/assets/c2457a77-d0b6-4418-936a-4d64a24eb9d6" />

<img width="285" height="81" alt="SCR-20260201-oqdt" src="https://github.com/user-attachments/assets/7e3c8535-75bf-4a53-a242-8d2d3063f34a" />


Repro on production:
Search for a package and swap the result list to list view so that the pagination is visible underneath, e.g. https://npmx.dev/search?q=vue   