### PR TITLE
feat: put env string next to 'npmx'

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -213,14 +213,16 @@ onKeyStroke(
           :to="{ name: 'index' }"
           :aria-label="$t('header.home')"
           dir="ltr"
-          class="inline-flex items-center gap-1 header-logo font-mono text-lg font-medium text-fg hover:text-fg/90 transition-colors duration-200 rounded"
+          class="relative inline-flex items-center gap-1 header-logo font-mono text-lg font-medium text-fg hover:text-fg/90 transition-colors duration-200 rounded"
         >
-          <AppLogo class="w-8 h-8 rounded-lg" />
-          <span>npmx</span>
-          <sup class="text-sm ms--1.5 italic text-fg-muted">
-            <!-- TODO: improve styling and show 'alpha' until March 3 annoucement -->
-            {{ env === 'release' ? '' : env }}
-          </sup>
+          <AppLogo class="w-7 h-7 rounded-lg" />
+          <span class="pb-0.5">npmx</span>
+          <span
+            aria-hidden="true"
+            class="scale-35 transform-origin-br font-mono tracking-wide text-accent absolute bottom-0.5 -inset-ie-1"
+          >
+            {{ env === 'release' ? 'alpha' : env }}
+          </span>
         </NuxtLink>
       </div>
       <!-- Spacer when logo is hidden on desktop -->

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -34,16 +34,18 @@ defineOgImageComponent('Default', {
       >
         <h1
           dir="ltr"
-          class="flex items-center justify-center gap-2 header-logo font-mono text-5xl sm:text-7xl md:text-8xl font-medium tracking-tight mb-2 motion-safe:animate-fade-in motion-safe:animate-fill-both"
+          class="relative flex items-center justify-center gap-2 header-logo font-mono text-5xl sm:text-7xl md:text-8xl font-medium tracking-tight mb-2 motion-safe:animate-fade-in motion-safe:animate-fill-both"
         >
           <AppLogo
             class="w-12 h-12 -ms-3 sm:w-20 sm:h-20 sm:-ms-5 md:w-24 md:h-24 md:-ms-6 rounded-2xl sm:rounded-3xl"
           />
           <span class="pb-4">npmx</span>
-          <sup class="text-3xl italic text-fg-muted">
-            <!-- TODO: improve styling and show 'alpha' until March 3 annoucement -->
-            {{ env === 'release' ? '' : env }}
-          </sup>
+          <span
+            aria-hidden="true"
+            class="scale-15 transform-origin-br font-mono tracking-widest text-accent absolute bottom-3 -inset-ie-1.5"
+          >
+            {{ env === 'release' ? 'alpha' : env }}
+          </span>
         </h1>
 
         <p


### PR DESCRIPTION
How about adding the env name ('dev', 'preview', 'canary', or 'alphe' (for 'release' env)) next to the "npmx" like Elk (https://main.elk.zone vs https://elk.zone) in addition to the footer?

The logo color is already different but sometimes not enough to distinguish (ref. https://discord.com/channels/1464542801676206113/1464544843740217455/1467534525218295889 😄)

We could drop "alpha" for production if it's preferable.

Closes #1135 

---
<img width="963" height="588" alt="Screenshot of home page with 'dev' string right next to 'npmx' name" src="https://github.com/user-attachments/assets/5bbb2b3d-4c70-4556-a865-f038865a1aef" />

<img width="903" height="482" alt="Screenshot of home page with 'dev' string right next to 'npmx' name (light theme)" src="https://github.com/user-attachments/assets/b6e5e130-1733-4372-bdf0-d68738fedc38" />

<img width="903" height="482" alt="Screenshot of home page with 'alpha' string right next to 'npmx' name" src="https://github.com/user-attachments/assets/885336b4-85e7-4c85-94b5-149dd9fd8674" />
(manually changed string to 'alpha' here, color is not for 'release')

---
<img width="963" height="588" alt="Screenshot of header title with 'dev' string" src="https://github.com/user-attachments/assets/00a0c259-60b1-41f9-89eb-2c6d9586bc9f" />

<img width="903" height="482" alt="Screenshot of header title with 'dev' string (light theme)" src="https://github.com/user-attachments/assets/7e47c4af-0fee-4b74-af18-34c785cbf2d0" />

<img width="903" height="482" alt="Screenshot of header title with 'alpha' string" src="https://github.com/user-attachments/assets/42807012-84c7-4264-ba40-e49a670b2b2f" />
(same)
