### PR TITLE
fix: atproto oauth missing `response_type`

### DIFF
--- a/server/utils/atproto/oauth.ts
+++ b/server/utils/atproto/oauth.ts
@@ -31,6 +31,7 @@ export function getOauthClientMetadata() {
     application_type: 'web',
     token_endpoint_auth_method: 'none',
     dpop_bound_access_tokens: true,
+    response_types: ['code'],
   }) as OAuthClientMetadataInput
 }
 


### PR DESCRIPTION
https://atproto.com/specs/oauth#client-id-metadata-document
`response_types (array of strings, required): code must be included.`