### PR TITLE
fix: missing response_types in OAuth schema

### DIFF
--- a/shared/schemas/oauth.ts
+++ b/shared/schemas/oauth.ts
@@ -10,4 +10,5 @@ export const OAuthMetadataSchema = object({
   application_type: string(),
   token_endpoint_auth_method: string(),
   dpop_bound_access_tokens: boolean(),
+  response_types: array(string()),
 })


### PR DESCRIPTION
we fucked up in #666 
it works for real this time
<img width="1178" height="355" alt="image" src="https://github.com/user-attachments/assets/aa126d2b-f2ba-4051-8c1f-ce984add41a2" />
