### PR TITLE
fix: handle trailing slashes on catchall paths

### DIFF
--- a/app/composables/usePackageRoute.ts
+++ b/app/composables/usePackageRoute.ts
@@ -13,7 +13,7 @@ export function usePackageRoute() {
   const route = useRoute('package')
 
   const parsedRoute = computed(() => {
-    const segments = route.params.package || []
+    const segments = route.params.package?.filter(Boolean) || []
 
     // Find the /v/ separator for version
     const vIndex = segments.indexOf('v')

--- a/app/pages/docs/[...path].vue
+++ b/app/pages/docs/[...path].vue
@@ -11,7 +11,7 @@ const route = useRoute('docs')
 const router = useRouter()
 
 const parsedRoute = computed(() => {
-  const segments = route.params.path || []
+  const segments = route.params.path?.filter(Boolean) || []
   const vIndex = segments.indexOf('v')
 
   if (vIndex === -1 || vIndex >= segments.length - 1) {


### PR DESCRIPTION
Reworked the trailing slash as agreed in #649. Specifically, we show the page for both paths with and without a trailing slash (`/package` and `/package/`).

Essentially, we simply forgot to handle slash correctly and just needed to remove it.

I did this for package and docs. But for code, I added a slightly more complex logic, since this is the standard behavior for FS View

There was also a bug in the code where the file was considered found on the first match, which caused a 500 error before. I added a check to ensure that the file found is actually lastpart.

I'm not closing the previous PR yet, as it might be worth checking whether redirects are really not needed

Closes (?) #648 