### PR TITLE
feat: add scrollbar styling for Firefox

### DIFF
--- a/app/assets/main.css
+++ b/app/assets/main.css
@@ -173,6 +173,14 @@ button {
   background: #404040;
 }
 
+/* Scrollbar styling for Firefox */
+@supports not selector(::-webkit-scrollbar) {
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--border) var(--bg);
+  }
+}
+
 /* Shiki theme colors */
 html.light .shiki,
 html.light .shiki span {


### PR DESCRIPTION
Despite these standard properties being supported in every browser I figured people probably prefer the extra control provided by the `::-webkit-scrollbar` styles and so I've only applied these new styles where those ones aren't supported (of the big 3 this is Firefox).