### PR TITLE
feat: add border to switch styles

### DIFF
--- a/app/components/Settings/Toggle.client.vue
+++ b/app/components/Settings/Toggle.client.vue
@@ -22,7 +22,7 @@ const checked = defineModel<boolean>({
     </span>
     <span
       class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border-2 transition-colors duration-200 ease-in-out motion-reduce:transition-none cursor-pointer"
-      :class="checked ? 'bg-accent border-transparent' : 'bg-bg border border-border'"
+      :class="checked ? 'bg-accent border-transparent shadow-sm' : 'bg-bg border border-border'"
       aria-hidden="true"
     >
       <span


### PR DESCRIPTION
Dark Before:

<img width="694" height="266" alt="image" src="https://github.com/user-attachments/assets/e7eef2ee-49e6-4cc2-a674-cf34e1c777b7" />

Dark After:

<img width="693" height="299" alt="image" src="https://github.com/user-attachments/assets/b2c56ce0-a1be-4c1a-8372-440924fbb01a" />

Light Before:

<img width="689" height="293" alt="image" src="https://github.com/user-attachments/assets/ca4fb8e2-6f36-4358-a2d4-30306d42abf5" />

Light After:

<img width="689" height="292" alt="image" src="https://github.com/user-attachments/assets/51764ce1-7bad-479d-9151-e7b3096494dd" />



This is added to improve the contrast. It's still not great but a follow-up can change the actual border colour when in prefers-contrast: more, with this change that's at least *some* contrast.