### PR TITLE
feat: set color scheme meta data value based on user settings

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -21,6 +21,16 @@ const localeMap = locales.value.reduce(
   {} as Record<string, Directions>,
 )
 
+const darkMode = usePreferredDark()
+const colorMode = useColorMode()
+const colorScheme = computed(() => {
+  return {
+    system: darkMode ? 'dark light' : 'light dark',
+    light: 'only light',
+    dark: 'only dark',
+  }[colorMode.preference]
+})
+
 useHead({
   htmlAttrs: {
     'lang': () => locale.value,
@@ -30,6 +40,7 @@ useHead({
   titleTemplate: titleChunk => {
     return titleChunk ? titleChunk : 'npmx - Better npm Package Browser'
   },
+  meta: [{ name: 'color-scheme', content: colorScheme }],
 })
 
 if (import.meta.server) {

--- a/lunaria/styles.ts
+++ b/lunaria/styles.ts
@@ -301,8 +301,6 @@ export const CustomStyles = html`
       --ln-color-missing: var(--ln-color-black);
       --ln-color-outdated: #fb923c;
       --ln-color-done: #c084fc;
-  
-      color-scheme: dark;
     }
   
     html {


### PR DESCRIPTION
Fixes #677.

This sets the `color-scheme` to an appropriate value as described in #677.


App >  | system | light | dark |
-- | -- | -- | --
dark | dark light | only light | only dark
light | light dark | only light | only dark
^ OS