### PR TITLE
fix: resolve relative markdown links to repository blob URLs

### DIFF
--- a/server/utils/readme.ts
+++ b/server/utils/readme.ts
@@ -183,7 +183,8 @@ function slugify(text: string): string {
 /**
  * Resolve a relative URL to an absolute URL.
  * If repository info is available, resolve to provider's raw file URLs.
- * Otherwise, fall back to jsdelivr CDN.
+ * For markdown files (.md), use blob URLs so they render properly.
+ * Otherwise, fall back to jsdelivr CDN (except for .md files which are left unchanged).
  */
 function resolveUrl(url: string, packageName: string, repoInfo?: RepositoryInfo): string {
   if (!url) return url
@@ -207,7 +208,10 @@ function resolveUrl(url: string, packageName: string, repoInfo?: RepositoryInfo)
     // for non-HTTP protocols (javascript:, data:, etc.), don't return, treat as relative
   }
 
-  // Use provider's raw URL base when repository info is available
+  // Check if this is a markdown file link
+  const isMarkdownFile = /\.md$/i.test(url.split('?')[0]?.split('#')[0] ?? '')
+
+  // Use provider's URL base when repository info is available
   // This handles assets that exist in the repo but not in the npm tarball
   if (repoInfo?.rawBaseUrl) {
     // Normalize the relative path (remove leading ./)
@@ -232,7 +236,16 @@ function resolveUrl(url: string, packageName: string, repoInfo?: RepositoryInfo)
       }
     }
 
-    return `${repoInfo.rawBaseUrl}/${relativePath}`
+    // For markdown files, use blob URL so they render on the provider's site
+    // For other files, use raw URL for direct access
+    const baseUrl = isMarkdownFile ? repoInfo.blobBaseUrl : repoInfo.rawBaseUrl
+    return `${baseUrl}/${relativePath}`
+  }
+
+  // For markdown files without repo info, leave unchanged (like npm does)
+  // This avoids 404s from jsdelivr which doesn't render markdown
+  if (isMarkdownFile) {
+    return url
   }
 
   // Fallback: relative URLs → jsdelivr CDN (may 404 if asset not in npm tarball)


### PR DESCRIPTION
## Summary

Resolves relative markdown (.md) links in READMEs to the source repository's blob URLs instead of raw URLs or jsdelivr CDN.

## Problem

As reported in #617, relative links to other markdown files in READMEs were resolving incorrectly:
- Links pointed to \cdn.jsdelivr.net/npm/...\ which returns 404 for files not in the npm tarball
- Even when files existed, jsdelivr serves raw markdown text (not rendered)
- Users expected to navigate to the rendered documentation on GitHub/GitLab/etc.

**Example from issue:**
```
Link in README: ./docs/03-customization/README.md
Was resolving to: https://cdn.jsdelivr.net/npm/robindoc/docs/03-customization/README.md (404)
Should resolve to: https://github.com/robindoc/robindoc/blob/HEAD/docs/03-customization/README.md
```

## Solution

1. **Added \getBlobBaseUrl\ to all git providers** - Returns the base URL for viewing rendered files (e.g., \/blob/\ for GitHub, \/src/\ for Gitea/Codeberg, \/-/blob/\ for GitLab)

2. **Updated \RepositoryInfo\ interface** - Now includes \\blobBaseUrl\\ alongside \\rawBaseUrl\\

3. **Modified \\resolveUrl\\ logic for \\.md\\ files:**
   - If repo info available → use \\blobBaseUrl\\ (renders on provider)
   - If no repo info → leave URL unchanged (matches npm behavior)
   - Non-\\.md\\ files → unchanged behavior (raw URLs or jsdelivr)

## Supported Providers

- GitHub
- GitLab (including self-hosted instances)
- Bitbucket
- Codeberg
- Gitee
- Sourcehut
- Tangled
- Radicle
- Forgejo
- Gitea

Fixes #617

---
*Found this helpful? [☕ Buy me a coffee](https://ko-fi.com/jarvisdev)*