### PR TITLE
fix: remove empty area in packge page

### DIFF
--- a/app/pages/package/[...package].vue
+++ b/app/pages/package/[...package].vue
@@ -1140,7 +1140,7 @@ function handleClick(event: MouseEvent) {
       'install install'
       'vulns   vulns'
       'readme  sidebar';
-    grid-template-rows: auto auto auto 1fr;
+    grid-template-rows: auto auto auto auto 1fr;
   }
 }
 


### PR DESCRIPTION
fixes: #701 

Before:
<img width="1356" height="810" alt="Screenshot 2026-02-02 at 9 50 24 AM" src="https://github.com/user-attachments/assets/e6c9b2f0-613a-4f37-9fe2-55141af05b8f" />


After:
<img width="1360" height="809" alt="Screenshot 2026-02-02 at 9 50 39 AM" src="https://github.com/user-attachments/assets/7c818795-9c9d-4e1c-af45-24f5ace9ebc3" />
