### PR TITLE
fix: don't navigate when there is no search content

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -7,6 +7,7 @@ const { focused: isSearchFocused } = useFocus(searchInputRef)
 
 async function search() {
   const query = searchQuery.value.trim()
+  if (!query) return
   await navigateTo({
     path: '/search',
     query: query ? { q: query } : undefined,


### PR DESCRIPTION
Do not use the navigation when there is no search content on the home page search.