### PR TITLE
style: compare page search icon vertical center

### DIFF
--- a/app/components/compare/PackageSelector.vue
+++ b/app/components/compare/PackageSelector.vue
@@ -87,7 +87,7 @@ function handleBlur() {
           {{ $t('compare.selector.search_label') }}
         </label>
         <span
-          class="absolute inset-is-3 top-1/2 -translate-y-1/2 text-fg-subtle"
+          class="absolute inset-is-3 top-1/2 -translate-y-1/2 text-fg-subtle flex"
           aria-hidden="true"
         >
           <span class="i-carbon:search w-4 h-4" />


### PR DESCRIPTION
|current|after|
|---|---|
|<img width="641" height="285" alt="image" src="https://github.com/user-attachments/assets/62d4156d-dc9f-428f-a427-a1d23f993fdc" />|<img width="570" height="261" alt="image" src="https://github.com/user-attachments/assets/102f5816-3fd5-40e6-8680-dd8fff4800fd" />|