### PR TITLE
chore: update example env openssl command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-#secure password, can use openssl rand --hex 32
+#secure password, can use openssl rand -hex 32
 NUXT_SESSION_PASSWORD=""


### PR DESCRIPTION
The current .env.example openssl command is broken and doesn't work so I updated it to work properly!