### PR TITLE
chore: provide avatar across npmx

### DIFF
--- a/app/components/Org/Avatar.vue
+++ b/app/components/Org/Avatar.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    orgName: string
+    size?: 'sm' | 'md' | 'lg'
+  }>(),
+  {
+    size: 'md',
+  },
+)
+
+const hasError = ref(false)
+
+// GitHub provides org avatars at https://github.com/{org}.png
+const avatarUrl = computed(() => `https://github.com/${props.orgName}.png?size=128`)
+
+function onError() {
+  hasError.value = true
+}
+
+// Reset error state when org name changes
+watch(
+  () => props.orgName,
+  () => {
+    hasError.value = false
+  },
+)
+
+const sizeClasses = computed(() => {
+  switch (props.size) {
+    case 'sm':
+      return 'size-10 text-lg'
+    case 'lg':
+      return 'size-16 text-2xl'
+    default:
+      return 'size-14 text-2xl'
+  }
+})
+</script>
+
+<template>
+  <div
+    class="shrink-0 rounded-lg bg-bg-muted border border-border flex items-center justify-center overflow-hidden"
+    :class="sizeClasses"
+    role="img"
+    :aria-label="`Avatar for @${orgName}`"
+  >
+    <img
+      v-if="!hasError"
+      :src="avatarUrl"
+      alt=""
+      class="w-full h-full object-cover"
+      @error="onError"
+    />
+    <span v-else class="text-fg-subtle font-mono" aria-hidden="true">
+      {{ orgName.charAt(0).toUpperCase() }}
+    </span>
+  </div>
+</template>

--- a/app/components/SearchSuggestionCard.vue
+++ b/app/components/SearchSuggestionCard.vue
@@ -29,14 +29,9 @@ defineProps<{
       :data-suggestion-index="index"
       class="flex items-center gap-4 focus-visible:outline-none after:content-[''] after:absolute after:inset-0"
     >
-      <!-- Avatar placeholder -->
-      <div
-        class="w-10 h-10 shrink-0 flex items-center justify-center border border-border"
-        :class="type === 'org' ? 'rounded-lg bg-bg-muted' : 'rounded-full bg-bg-muted'"
-        aria-hidden="true"
-      >
-        <span class="text-lg text-fg-subtle font-mono">{{ name.charAt(0).toUpperCase() }}</span>
-      </div>
+      <!-- Avatar -->
+      <OrgAvatar v-if="type === 'org'" :org-name="name" size="sm" />
+      <UserAvatar v-else :username="name" size="sm" />
 
       <div class="min-w-0 flex-1">
         <div class="flex items-center gap-2">

--- a/app/components/User/Avatar.vue
+++ b/app/components/User/Avatar.vue
@@ -1,7 +1,13 @@
 <script setup lang="ts">
-const props = defineProps<{
-  username: string
-}>()
+const props = withDefaults(
+  defineProps<{
+    username: string
+    size?: 'sm' | 'md' | 'lg'
+  }>(),
+  {
+    size: 'lg',
+  },
+)
 
 const { data: gravatarUrl } = useLazyFetch(() => `/api/gravatar/${props.username}`, {
   transform: res => (res.hash ? `/_avatar/${res.hash}?s=128&d=404` : null),
@@ -9,26 +15,31 @@ const { data: gravatarUrl } = useLazyFetch(() => `/api/gravatar/${props.username
     return nuxtApp.static.data[key] ?? nuxtApp.payload.data[key]
   },
 })
+
+const sizeClasses = computed(() => {
+  switch (props.size) {
+    case 'sm':
+      return 'size-10 text-lg'
+    case 'md':
+      return 'size-14 text-2xl'
+    default:
+      return 'size-16 text-2xl'
+  }
+})
 </script>
 
 <template>
   <!-- Avatar -->
   <div
-    class="size-16 shrink-0 rounded-full bg-bg-muted border border-border flex items-center justify-center overflow-hidden"
+    class="shrink-0 rounded-full bg-bg-muted border border-border flex items-center justify-center overflow-hidden"
+    :class="sizeClasses"
     role="img"
     :aria-label="`Avatar for ${username}`"
   >
     <!-- If Gravatar was fetched, display it -->
-    <img
-      v-if="gravatarUrl"
-      :src="gravatarUrl"
-      alt=""
-      width="64"
-      height="64"
-      class="w-full h-full object-cover"
-    />
+    <img v-if="gravatarUrl" :src="gravatarUrl" alt="" class="w-full h-full object-cover" />
     <!-- Else fallback to initials -->
-    <span v-else class="text-2xl text-fg-subtle font-mono" aria-hidden="true">
+    <span v-else class="text-fg-subtle font-mono" aria-hidden="true">
       {{ username.charAt(0).toUpperCase() }}
     </span>
   </div>

--- a/app/pages/@[org].vue
+++ b/app/pages/@[org].vue
@@ -140,15 +140,8 @@ defineOgImageComponent('Default', {
     <!-- Header -->
     <header class="mb-8 pb-8 border-b border-border">
       <div class="flex flex-wrap items-end gap-4">
-        <!-- Org avatar placeholder -->
-        <div
-          class="size-16 shrink-0 rounded-lg bg-bg-muted border border-border flex items-center justify-center"
-          aria-hidden="true"
-        >
-          <span class="text-2xl text-fg-subtle font-mono">{{
-            orgName.charAt(0).toUpperCase()
-          }}</span>
-        </div>
+        <!-- Org avatar -->
+        <OrgAvatar :org-name="orgName" size="lg" />
         <div>
           <h1 class="font-mono text-2xl sm:text-3xl font-medium">@{{ orgName }}</h1>
           <p v-if="status === 'success'" class="text-fg-muted text-sm mt-1">

--- a/app/pages/~[username]/orgs.vue
+++ b/app/pages/~[username]/orgs.vue
@@ -190,14 +190,7 @@ defineOgImageComponent('Default', {
             >
               <div class="flex items-start gap-4 mb-4">
                 <!-- Org avatar -->
-                <div
-                  class="w-14 h-14 rounded-lg bg-bg-muted border border-border flex items-center justify-center flex-shrink-0"
-                  aria-hidden="true"
-                >
-                  <span class="text-2xl text-fg-subtle font-mono">{{
-                    org.name.charAt(0).toUpperCase()
-                  }}</span>
-                </div>
+                <OrgAvatar :org-name="org.name" />
                 <div class="min-w-0 flex-1">
                   <h3 class="font-mono text-lg text-fg truncate">@{{ org.name }}</h3>
                   <!-- Role badge -->


### PR DESCRIPTION
Currently we have avatar only for user, not for orgs and search option. I think we can improve it.


<img width="1520" height="500" alt="org1" src="https://github.com/user-attachments/assets/ff092b4c-988a-4906-9e0f-9261306d5fb5" />
<img width="1520" height="500" alt="org2" src="https://github.com/user-attachments/assets/5841d0ef-6a66-44cd-9115-f251ad819e8e" />
<img width="1570" height="702" alt="pooya" src="https://github.com/user-attachments/assets/8257d0c3-60fc-4ef0-ac75-aad6bb129475" />
