### PR TITLE
chore: run lint without installing the repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,10 @@ jobs:
 
       - uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         name: Install pnpm
-        with:
-          cache: true
-
-      - name: 📦 Install dependencies
-        run: pnpm install
+        # pnpm cache skipped deliberately as the project is not actually installed here
 
       - name: 🔠 Lint project
-        run: pnpm lint
+        run: node scripts/lint.ts
 
   test:
     runs-on: ubuntu-latest

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -1,0 +1,33 @@
+/**
+ * This script runs oxlint and oxfmt in a CI environment, without the need to install the entire
+ * project. It reads the required version from pnpm-lock.yaml and executes the linters accordingly.
+ * It's "stupid by design" so it could work in minimal Node.js environments.
+ */
+
+import { spawnSync } from 'node:child_process'
+
+function getDependencyVersion(dependencyName: string): string {
+  const result = spawnSync('npm', ['pkg', 'get', `devDependencies.${dependencyName}`], {
+    encoding: 'utf8',
+  })
+
+  if (result.status) {
+    throw new Error(`Command failed: pnpm info ${dependencyName} version`)
+  }
+
+  return JSON.parse(result.stdout)
+}
+
+function runCommand(command: string, args: string[]) {
+  const result = spawnSync(command, args, { stdio: 'inherit' })
+
+  if (result.status) {
+    throw new Error(`Command failed: ${command} ${args.join(' ')}`)
+  }
+}
+
+const oxlintVersion = getDependencyVersion('oxlint')
+const oxfmtVersion = getDependencyVersion('oxfmt')
+
+runCommand('pnpx', [`oxlint@${oxlintVersion}`])
+runCommand('pnpx', [`oxfmt@${oxfmtVersion}`, '--check'])


### PR DESCRIPTION
> **🍃 Eco friendly PR**
> Estimated **23 kg CO₂e** savings per year
>  Calculations: [ci_co2e_savings.xlsx](https://github.com/user-attachments/files/25039698/ci_co2e_savings.xlsx)


This PR provides a 2-3x improvement in CI "lint" job speed by skipping repository installation. It does so by creating a custom script that reads pnpm-lock.yaml in a very stupid way, and runs `oxlint` and `oxfmt` directly via `pnpx`, crucially **without installing the repository first**.

Before:

<img width="659" height="517" alt="image" src="https://github.com/user-attachments/assets/ecc51e70-2738-4cd8-a2c6-5b3383b6eb84" />

https://github.com/npmx-dev/npmx.dev/actions/runs/21621466460

After:

<img width="659" height="517" alt="image" src="https://github.com/user-attachments/assets/be6098e8-c2ac-405e-bc50-92bf01a7b85d" />

https://github.com/npmx-dev/npmx.dev/actions/runs/21622175078