### PR TITLE
chore: include nitro in frameworks

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -7,6 +7,7 @@ const { focused: isSearchFocused } = useFocus(searchInputRef)
 const frameworks = ref([
   { name: 'nuxt', package: 'nuxt' },
   { name: 'vue', package: 'vue' },
+  { name: 'nitro', package: 'nitro' },
   { name: 'react', package: 'react' },
   { name: 'svelte', package: 'svelte' },
   { name: 'vite', package: 'vite' },


### PR DESCRIPTION
Actually in the framework list, everything is related to frontend or frontend focused. I think we can include one backend thing which may look good.