### PR TITLE
fix: search box jumping around when navigating to the search page

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -146,7 +146,7 @@ onKeyStroke(
           @blur="handleSearchBlur"
         />
         <ul
-          v-if="!isSearchExpanded"
+          v-if="!isSearchExpanded && isConnected && npmUser"
           :class="{ hidden: showFullSearch }"
           class="hidden sm:flex items-center gap-4 sm:gap-6 list-none m-0 p-0"
         >


### PR DESCRIPTION
Currently, the ul is rendered on non-search pages, even if it's empty. This causes the flex parent to apply some spacing between the empty ul and the search box.

If you are on e.g. the settings page, then type into the search box, and you are navigated to the search page, the previous condition removed the ul at that point, causing the search box to move slightly as the additional flex gap was removed.

This should fix the issue to some degree, as there is no need to render the empty ul if the li v-if conditions are not also met.