### PR TITLE
fix: angular should be lowercase in the footer

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -14,7 +14,7 @@ const frameworks = ref([
   { name: 'next', package: 'next' },
   { name: 'astro', package: 'astro' },
   { name: 'typescript', package: 'typescript' },
-  { name: 'Angular', package: '@angular/core' },
+  { name: 'angular', package: '@angular/core' },
 ])
 
 async function search() {


### PR DESCRIPTION
Angular is the only tech starting with a capital letter right now:

<img width="1085" height="173" alt="image" src="https://github.com/user-attachments/assets/e5763f59-ca83-4927-8c39-6a8a04053aa0" />
