### PR TITLE
fix: reorder link to create package to be before copy

### DIFF
--- a/app/components/Terminal/Install.vue
+++ b/app/components/Terminal/Install.vue
@@ -200,6 +200,16 @@ const copyCreateCommand = () => copyCreate(getFullCreateCommand())
             <span class="text-fg-subtle font-mono text-sm select-none"
               ># {{ $t('package.create.title') }}</span
             >
+            <NuxtLink
+              :to="`/package/${createPackageInfo.packageName}`"
+              class="text-fg-muted hover:text-fg text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/50 rounded"
+              :title="$t('package.create.view', { packageName: createPackageInfo.packageName })"
+            >
+              <span class="i-carbon:information w-3 h-3 mt-1" aria-hidden="true" />
+              <span class="sr-only">{{
+                $t('package.create.view', { packageName: createPackageInfo.packageName })
+              }}</span>
+            </NuxtLink>
           </div>
 
           <div
@@ -217,14 +227,6 @@ const copyCreateCommand = () => copyCreate(getFullCreateCommand())
                 >{{ i > 0 ? ' ' : '' }}{{ part }}</span
               ></code
             >
-            <NuxtLink
-              :to="`/package/${createPackageInfo.packageName}`"
-              class="text-fg-muted hover:text-fg text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/50 rounded"
-              :title="`View ${createPackageInfo.packageName}`"
-            >
-              <span class="i-carbon:arrow-right rtl-flip w-3 h-3 mt-1" aria-hidden="true" />
-              <span class="sr-only">View {{ createPackageInfo.packageName }}</span>
-            </NuxtLink>
             <button
               type="button"
               class="px-2 py-0.5 font-mono text-xs text-fg-muted bg-bg-subtle/80 border border-border rounded transition-colors duration-200 opacity-0 group-hover/createcmd:opacity-100 hover:(text-fg border-border-hover) active:scale-95 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/50"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -193,7 +193,8 @@
     },
     "create": {
       "title": "Create new project",
-      "copy_command": "Copy create command"
+      "copy_command": "Copy create command",
+      "view": "{packageName} has the same maintainer. Click for more details."
     },
     "run": {
       "title": "Run",

--- a/lunaria/files/en-US.json
+++ b/lunaria/files/en-US.json
@@ -193,7 +193,8 @@
     },
     "create": {
       "title": "Create new project",
-      "copy_command": "Copy create command"
+      "copy_command": "Copy create command",
+      "view": "{packageName} has the same maintainer. Click for more details."
     },
     "run": {
       "title": "Run",


### PR DESCRIPTION
Switch colours to align more closely with standard link colours.

<details>
<summary>Before</summary>

<img width="315" height="212" alt="image" src="https://github.com/user-attachments/assets/5bf1d0e9-dd26-43cd-831e-72fab19a8a3f" />

<img width="291" height="199" alt="image" src="https://github.com/user-attachments/assets/4c244d07-ef43-4cc9-aab1-5e1a5d96836c" />

</details>

<details>
<summary>After</summary>

<img width="385" height="241" alt="image" src="https://github.com/user-attachments/assets/268be5c1-f359-472a-8c44-fafcab953287" />

<img width="333" height="243" alt="image" src="https://github.com/user-attachments/assets/72395fc7-27ef-478d-8fa1-11fbb3c01fdf" />


</details>