### PR TITLE
fix: initial search debounce

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -32,7 +32,7 @@ async function search() {
 
 const handleInput = isTouchDevice()
   ? search
-  : debounce(search, 300, { leading: false, trailing: true })
+  : debounce(search, 250, { leading: false, trailing: true })
 
 useSeoMeta({
   title: () => $t('seo.home.title'),


### PR DESCRIPTION
Resolves: #764 

Even though it is not the complete fix or improvement, hope it is good starting point
I've removed the immediate redirection for initial search

> leading: true option. It will cause function to be immediately called 