### PR TITLE
fix: ignore outdated search responses

### DIFF
--- a/app/composables/useNpmRegistry.ts
+++ b/app/composables/useNpmRegistry.ts
@@ -337,6 +337,7 @@ export function useNpmSearch(
 
         const result = packumentToSearchResult(pkg, downloads?.downloads)
 
+        // If query changed/outdated, return empty search response
         if (q !== toValue(query)) {
           return emptySearchResponse
         }
@@ -361,6 +362,7 @@ export function useNpmSearch(
         60,
       )
 
+      // If query changed/outdated, return empty search response
       if (q !== toValue(query)) {
         return emptySearchResponse
       }


### PR DESCRIPTION
fixes #619 

Added check for outdated search results before updating incremental cache

