### PR TITLE
ci: split a11y tests using matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
 
   a11y:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mode: [dark, light]
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -115,10 +118,11 @@ jobs:
       - name: 🏗️ Build project
         run: pnpm build
 
-      - name: ♿ Accessibility audit (Lighthouse - dark & light mode)
+      - name: ♿ Accessibility audit (Lighthouse - ${{ matrix.mode }} mode)
         run: ./scripts/lighthouse-a11y.sh
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          LIGHTHOUSE_COLOR_MODE: ${{ matrix.mode }}
 
   knip:
     runs-on: ubuntu-latest

--- a/scripts/lighthouse-a11y.sh
+++ b/scripts/lighthouse-a11y.sh
@@ -7,12 +7,20 @@
 
 set -e
 
-echo "🌙 Running Lighthouse accessibility audit (dark mode)..."
-LIGHTHOUSE_COLOR_MODE=dark pnpx @lhci/cli autorun --upload.githubStatusContextSuffix="/dark"
+case "${LIGHTHOUSE_COLOR_MODE}" in
+  dark)
+    echo "🌙 Running Lighthouse accessibility audit (dark mode)..."
+    pnpx @lhci/cli autorun --upload.githubStatusContextSuffix="/dark"
+    ;;
+  light)
+    echo "☀️ Running Lighthouse accessibility audit (light mode)..."
+    pnpx @lhci/cli autorun --upload.githubStatusContextSuffix="/light"
+    ;;
+  *)
+    echo "⚠️ Missing or invalid LIGHTHOUSE_COLOR_MODE. Use 'dark' or 'light'."
+    exit 1
+    ;;
+esac
 
 echo ""
-echo "☀️  Running Lighthouse accessibility audit (light mode)..."
-LIGHTHOUSE_COLOR_MODE=light pnpx @lhci/cli autorun --upload.githubStatusContextSuffix="/light"
-
-echo ""
-echo "✅ Accessibility audits completed for both color modes"
+echo "✅ Accessibility audit completed"


### PR DESCRIPTION
This PR splits a11y tests into two (light and dark). It's currently the longest running CI job (5m 40s on average), and I expect splitting jobs to provide roughly 1 minute of CI run time savings on average, making it roughly as long as the 2nd longest running job, effectively removing the bottleneck.

Before:

<img width="679" height="483" alt="image" src="https://github.com/user-attachments/assets/fec26cf9-3a83-40be-bf8c-3d7738ae3358" />

https://github.com/npmx-dev/npmx.dev/actions/runs/21621466460

After:

<img width="679" height="581" alt="image" src="https://github.com/user-attachments/assets/6892b198-614f-440e-99c8-b3d51ad28985" />

https://github.com/npmx-dev/npmx.dev/actions/runs/21625057371