### PR TITLE
ci: switch to arm64 runners

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   code:
     name: 🤖 Autofix code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   lint:
     name: 🔠 Lint project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -40,7 +40,7 @@ jobs:
 
   types:
     name: 💪 Type check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -62,7 +62,7 @@ jobs:
 
   unit:
     name: 🧪 Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -84,7 +84,7 @@ jobs:
 
   test:
     name: 🧪 Component tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -114,7 +114,7 @@ jobs:
 
   browser:
     name: 🖥️ Browser tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     container:
       image: mcr.microsoft.com/playwright:v1.58.0-noble
 
@@ -141,7 +141,7 @@ jobs:
 
   a11y:
     name: ♿ Accessibility audit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # See https://github.com/GoogleChrome/lighthouse/discussions/16834
     strategy:
       matrix:
         mode: [dark, light]
@@ -172,7 +172,7 @@ jobs:
 
   knip:
     name: 🧹 Unused code check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/lunaria.yml
+++ b/.github/workflows/lunaria.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   lunaria-overview:
     name: 🌝 Generate Lunaria Overview
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout


### PR DESCRIPTION
> **🍃 Eco friendly PR**
> Estimated **4665 kg CO₂e** savings per year
>  Calculations: [ci_arm64_co2e_savings_with_speedup.xlsx](https://github.com/user-attachments/files/25058666/ci_arm64_co2e_savings_with_speedup.xlsx)

Comparing, ([before](https://github.com/npmx-dev/npmx.dev/actions/runs/21650958414)/[after](https://github.com/npmx-dev/npmx.dev/actions/runs/21651256413); take into consideration missing cache) it seems to shave off:
- ~2 seconds from tsc
- ~2 seconds from unit tests
- ~6 seconds from components tests
- ~2 seconds from browser tests
leaving the rest pretty much intact. 