### PR TITLE
test: correct import specifier casing

### DIFF
--- a/test/nuxt/components/compare/ComparisonGrid.spec.ts
+++ b/test/nuxt/components/compare/ComparisonGrid.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
-import ComparisonGrid from '~/components/Compare/ComparisonGrid.vue'
+import ComparisonGrid from '~/components/compare/ComparisonGrid.vue'
 
 describe('ComparisonGrid', () => {
   describe('header rendering', () => {

--- a/test/nuxt/components/compare/FacetRow.spec.ts
+++ b/test/nuxt/components/compare/FacetRow.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
-import FacetRow from '~/components/Compare/FacetRow.vue'
+import FacetRow from '~/components/compare/FacetRow.vue'
 
 // Mock useRelativeDates for DateTime component
 vi.mock('~/composables/useSettings', () => ({

--- a/test/nuxt/components/compare/FacetSelector.spec.ts
+++ b/test/nuxt/components/compare/FacetSelector.spec.ts
@@ -1,6 +1,6 @@
 import type { ComparisonFacet } from '#shared/types/comparison'
 import { CATEGORY_ORDER, FACET_INFO, FACETS_BY_CATEGORY } from '#shared/types/comparison'
-import FacetSelector from '~/components/Compare/FacetSelector.vue'
+import FacetSelector from '~/components/compare/FacetSelector.vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, ref } from 'vue'
 import { mountSuspended } from '@nuxt/test-utils/runtime'

--- a/test/nuxt/components/compare/PackageSelector.spec.ts
+++ b/test/nuxt/components/compare/PackageSelector.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
-import PackageSelector from '~/components/Compare/PackageSelector.vue'
+import PackageSelector from '~/components/compare/PackageSelector.vue'
 
 // Mock $fetch for useNpmSearch
 const mockFetch = vi.fn()


### PR DESCRIPTION
This trips typescript up. The directory is `compare`, not `Compare`.
