### PR TITLE
fix: correct package name copy tooltip hiding

### DIFF
--- a/app/pages/package/[...package].vue
+++ b/app/pages/package/[...package].vue
@@ -1200,11 +1200,10 @@ defineOgImageComponent('Package', {
   transition:
     opacity 0.25s 0.1s,
     translate 0.15s 0.1s,
-    clip 0s 0.35s,
-    clip-path 0s 0.35s,
-    height 0s 0.35s,
-    width 0s 0.35s;
-  transition-behavior: allow-discrete;
+    clip 0.01s 0.34s allow-discrete,
+    clip-path 0.01s 0.34s allow-discrete,
+    height 0.01s 0.34s allow-discrete,
+    width 0.01s 0.34s allow-discrete;
 }
 
 .group:hover .copy-button,
@@ -1216,11 +1215,7 @@ defineOgImageComponent('Package', {
   width: auto;
   transition:
     opacity 0.15s,
-    translate 0.15s,
-    clip 0.15s,
-    clip-path 0s,
-    height 0s,
-    width 0s;
+    translate 0.15s;
 }
 
 @media (hover: none) {


### PR DESCRIPTION
I spent a lot of time debugging to find the cause, but:

- All classes work correctly
- All styles and their weights are correct
- All elements are in place and inserted correctly.

The hover state remains on the element. JS mouseLeave works correctly (both on button and group), everything is checked correctly, everything works as expected, but the element remains visible.

We can disable the transition and this bug will go away, but explicitly set `display:none` also works

Relates #594 #473 

Closes #834 