### PR TITLE
fix: package docs responsiveness

### DIFF
--- a/app/pages/package-docs/[...path].vue
+++ b/app/pages/package-docs/[...path].vue
@@ -475,7 +475,8 @@ const showEmptyState = computed(() => docsData.value?.status !== 'ok')
 
 .docs-content .docs-symbol-name,
 .docs-content .docs-members dl dd,
-.docs-content .docs-members dl dt code {
+.docs-content .docs-members dl dt code,
+.docs-content .docs-section .docs-symbol .docs-description {
   word-break: break-all;
 }
 </style>


### PR DESCRIPTION
Minor css fixes to prevent horizontal scrollbars on mobile screens. Added word break for

- Symbol names
- `code` blocks in `dt`
- Docs descriptions

Closes #835