### PR TITLE
fix: connector modal legibility

### DIFF
--- a/app/components/Header/ConnectorModal.vue
+++ b/app/components/Header/ConnectorModal.vue
@@ -81,10 +81,8 @@ function handleDisconnect() {
     <form v-else class="space-y-4" @submit.prevent="handleConnect">
       <!-- Contributor-only notice -->
       <div class="p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg">
-        <div class="space-y-2">
-          <span
-            class="inline-block px-2 py-0.5 text-xs font-bold uppercase tracking-wider bg-amber-500/20 text-amber-400 rounded"
-          >
+        <div>
+          <span class="inline-block text-xs font-bold uppercase tracking-wider text-fg rounded">
             {{ $t('connector.modal.contributor_badge') }}
           </span>
           <p class="text-sm text-fg-muted">
@@ -94,7 +92,7 @@ function handleDisconnect() {
                   href="https://github.com/npmx-dev/npmx.dev/blob/main/CONTRIBUTING.md#local-connector-cli"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="text-amber-400 hover:underline"
+                  class="text-blue-400 hover:underline"
                 >
                   {{ $t('connector.modal.contributor_link') }}
                 </a>
@@ -213,7 +211,7 @@ function handleDisconnect() {
         role="alert"
         class="p-3 text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-md"
       >
-        <p class="font-mono text-sm text-fg font-bold">
+        <p class="inline-block text-xs font-bold uppercase tracking-wider text-fg rounded">
           {{ $t('connector.modal.warning') }}
         </p>
         <p class="text-sm text-fg-muted">


### PR DESCRIPTION
Currently the connector modal looks like this:

<img width="619" height="810" alt="image" src="https://github.com/user-attachments/assets/806744aa-9b13-4832-b1ac-955912387934" />

This PR fixes the label fonts on the callouts to be uniform and legible, as well as the link to the contributing guide:

<img width="609" height="796" alt="image" src="https://github.com/user-attachments/assets/26e9a953-da4d-4160-b8fb-1b4094da801d" />
