### PR TITLE
chore: remove @iconify-json/solar

### DIFF
--- a/app/components/ProvenanceBadge.vue
+++ b/app/components/ProvenanceBadge.vue
@@ -35,10 +35,7 @@ const title = computed(() =>
     class="inline-flex items-center justify-center gap-1 text-xs font-mono text-fg-muted hover:text-fg transition-colors duration-200 min-w-6 min-h-6"
     :title="title"
   >
-    <span
-      class="i-solar-shield-check-outline shrink-0"
-      :class="compact ? 'w-3.5 h-3.5' : 'w-4 h-4'"
-    />
+    <span class="i-lucide-shield-check shrink-0" :class="compact ? 'w-3.5 h-3.5' : 'w-4 h-4'" />
     <span v-if="!compact" class="sr-only sm:not-sr-only">{{
       $t('badges.provenance.verified')
     }}</span>
@@ -48,10 +45,7 @@ const title = computed(() =>
     class="inline-flex items-center gap-1 text-xs font-mono text-fg-muted"
     :title="title"
   >
-    <span
-      class="i-solar-shield-check-outline shrink-0"
-      :class="compact ? 'w-3.5 h-3.5' : 'w-4 h-4'"
-    />
+    <span class="i-lucide-shield-check shrink-0" :class="compact ? 'w-3.5 h-3.5' : 'w-4 h-4'" />
     <span v-if="!compact" class="sr-only sm:not-sr-only">{{
       $t('badges.provenance.verified')
     }}</span>

--- a/app/pages/package/[...package].vue
+++ b/app/pages/package/[...package].vue
@@ -526,7 +526,7 @@ defineOgImageComponent('Package', {
               class="inline-flex items-center justify-center gap-1.5 text-fg-muted hover:text-fg transition-colors duration-200 min-w-6 min-h-6"
               :title="$t('package.verified_provenance')"
             >
-              <span class="i-solar:shield-check-outline w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+              <span class="i-lucide-shield-check w-3.5 h-3.5 shrink-0" aria-hidden="true" />
             </a>
             <span
               v-if="requestedVersion && latestVersion && resolvedVersion !== latestVersion.version"
@@ -848,7 +848,7 @@ defineOgImageComponent('Package', {
                 class="text-fg-subtle hover:text-fg transition-colors duration-200 inline-flex items-center justify-center min-w-6 min-h-6 -m-1 p-1"
                 :title="$t('package.stats.inspect_dependency_tree')"
               >
-                <span class="i-solar:eye-scan-outline w-3.5 h-3.5" aria-hidden="true" />
+                <span class="i-lucide-view w-3.5 h-3.5" aria-hidden="true" />
                 <span class="sr-only">{{ $t('package.stats.inspect_dependency_tree') }}</span>
               </a>
             </dd>

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@iconify-json/carbon": "1.2.18",
     "@iconify-json/lucide": "1.2.87",
     "@iconify-json/simple-icons": "1.2.68",
-    "@iconify-json/solar": "1.2.5",
     "@iconify-json/svg-spinners": "1.2.4",
     "@iconify-json/vscode-icons": "1.2.40",
     "@intlify/shared": "11.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,6 @@ importers:
       '@iconify-json/simple-icons':
         specifier: 1.2.68
         version: 1.2.68
-      '@iconify-json/solar':
-        specifier: 1.2.5
-        version: 1.2.5
       '@iconify-json/svg-spinners':
         specifier: 1.2.4
         version: 1.2.4
@@ -1472,9 +1469,6 @@ packages:
 
   '@iconify-json/simple-icons@1.2.68':
     resolution: {integrity: sha512-bQPl1zuZlX6AnofreA1v7J+hoPncrFMppqGboe/SH54jZO37meiBUGBqNOxEpc0HKfZGxJaVVJwZd4gdMYu3hw==}
-
-  '@iconify-json/solar@1.2.5':
-    resolution: {integrity: sha512-WMAiNwchU8zhfrySww6KQBRIBbsQ6SvgIu2yA+CHGyMima/0KQwT5MXogrZPJGoQF+1Ye3Qj6K+1CiyNn3YkoA==}
 
   '@iconify-json/svg-spinners@1.2.4':
     resolution: {integrity: sha512-ayn0pogFPwJA1WFZpDnoq9/hjDxN+keeCMyThaX4d3gSJ3y0mdKUxIA/b1YXWGtY9wVtZmxwcvOIeEieG4+JNg==}
@@ -10922,10 +10916,6 @@ snapshots:
       '@iconify/types': 2.0.0
 
   '@iconify-json/simple-icons@1.2.68':
-    dependencies:
-      '@iconify/types': 2.0.0
-
-  '@iconify-json/solar@1.2.5':
     dependencies:
       '@iconify/types': 2.0.0
 


### PR DESCRIPTION
We used barely two icons from this set, pulling in additional 6.5 MB dependency. This PR replaces solar icons: shield-check and eye-scan, with lucide icons: shield-check and view, respectively. They are virtually the same.