### PR TITLE
fix: horizontal scrolling on pakage docs pages

### DIFF
--- a/app/pages/package-docs/[...path].vue
+++ b/app/pages/package-docs/[...path].vue
@@ -253,6 +253,7 @@ const showEmptyState = computed(() => docsData.value?.status !== 'ok')
 /* Individual symbol articles */
 .docs-content .docs-symbol {
   @apply mb-10 pb-10 border-b border-border/30 last:border-0;
+  word-break: break-word;
 }
 
 .docs-content .docs-symbol:target {


### PR DESCRIPTION
closes #835 

## Changes

1. Added `word-break: break-word` to the `.docs-symbol` container to ensure long names wrap gracefully