### PR TITLE
fix: consistent error display in development and production

### DIFF
--- a/app/error.vue
+++ b/app/error.vue
@@ -5,9 +5,9 @@ const props = defineProps<{
   error: NuxtError
 }>()
 
-const status = computed(() => props.error.status || 500)
+const status = computed(() => props.error.statusCode || 500)
 const statusText = computed(() => {
-  if (props.error.statusText) return props.error.statusText
+  if (props.error.statusMessage) return props.error.statusMessage
   switch (status.value) {
     case 404:
       return 'Page not found'


### PR DESCRIPTION
development and production environment are displaying different error message for non-existent package. I think the local environment is correct here. In production it is likely due to how Nuxt serializes/hydrates errors differently - in production maybe there are ISR/SSR stuffs. 

Production:
<img width="1430" height="856" alt="prod" src="https://github.com/user-attachments/assets/2d332281-1900-489e-8a1d-5adac81edc38" />

Development:
<img width="1430" height="856" alt="dev" src="https://github.com/user-attachments/assets/8d779268-75b8-4da2-9d9e-1b0ecff08eac" />
