### PR TITLE
style: revise the badge char width

### DIFF
--- a/server/api/registry/badge/[type]/[...pkg].get.ts
+++ b/server/api/registry/badge/[type]/[...pkg].get.ts
@@ -332,7 +332,7 @@ export default defineCachedEventHandler(
     }
   },
   {
-    maxAge: 0,
+    maxAge: CACHE_MAX_AGE_ONE_HOUR,
     swr: true,
     getKey: event => {
       const type = getRouterParam(event, 'type') ?? 'version'


### PR DESCRIPTION
https://npmx.dev/api/registry/badge/engines/vite

When configuring the engines badges via the API, I found that the calculated character width was too large and didn't look appropriate. Therefore, I adjusted the character width for the badge type (the characters for this type of badge are predictable and take up relatively little space).

|current|after|
|---|---|
|<img width="345" height="64" alt="image" src="https://github.com/user-attachments/assets/87ecdd54-e3bb-4520-9f5a-319adf7fa528" />|<img width="321" height="78" alt="image" src="https://github.com/user-attachments/assets/d70a0cd3-50f6-4add-a313-5165231f96dc" />|