### PR TITLE
feat: link package headers to package pages

### DIFF
--- a/app/components/Compare/ComparisonGrid.vue
+++ b/app/components/Compare/ComparisonGrid.vue
@@ -24,7 +24,7 @@ defineProps<{
         >
           <NuxtLink
             :to="`/package/${header}`"
-            class="font-mono text-sm font-medium text-fg truncate"
+            class="link-subtle font-mono text-sm font-medium text-fg truncate"
             :title="header"
           >
             {{ header }}


### PR DESCRIPTION
### User story
When user want to find a good package and compared multiple packages and want to look into a specific package, the user has to type the same package names in the search input again.

### Solution
This PR allows to navigate directly from each header of the comparison table.

### Deploy preview
https://npmxdev-git-fork-shuuji3-feat-allow-navigate-to-p-54f516-poetry.vercel.app/compare?packages=vue,nuxt,vite

### Screenshot
<img width="1053" height="667" alt="Screenshot of comparison page, the header is now clickable link" src="https://github.com/user-attachments/assets/50b9201b-d3b4-445c-b180-d72f77566caf" />

