### PR TITLE
fix: display tooltips on focus for install size + create command

### DIFF
--- a/app/components/Terminal/Install.vue
+++ b/app/components/Terminal/Install.vue
@@ -205,7 +205,7 @@ const copyCreateCommand = () => copyCreate(getFullCreateCommand())
             >
               <NuxtLink
                 :to="`/package/${createPackageInfo.packageName}`"
-                class="inline-flex items-center justify-center min-w-6 min-h-6 -m-1 p-1 text-fg-muted hover:text-fg text-xs transition-colors focus-visible:outline focus-visible:outline-accent/70 rounded"
+                class="inline-flex items-center justify-center min-w-6 min-h-6 -m-1 p-1 text-fg-muted hover:text-fg text-xs transition-colors focus-visible:outline-2 focus-visible:outline-accent/70 rounded"
               >
                 <span class="i-carbon:information w-3 h-3" aria-hidden="true" />
                 <span class="sr-only">{{

--- a/app/pages/package/[...package].vue
+++ b/app/pages/package/[...package].vue
@@ -865,7 +865,7 @@ defineOgImageComponent('Package', {
               <TooltipApp :text="sizeTooltip">
                 <span
                   tabindex="0"
-                  class="inline-flex items-center justify-center min-w-6 min-h-6 -m-1 p-1 text-fg-subtle cursor-help focus-visible:outline focus-visible:outline-accent/70 rounded"
+                  class="inline-flex items-center justify-center min-w-6 min-h-6 -m-1 p-1 text-fg-subtle cursor-help focus-visible:outline-2 focus-visible:outline-accent/70 rounded"
                 >
                   <span class="i-carbon:information w-3 h-3" aria-hidden="true" />
                 </span>


### PR DESCRIPTION
Previously these were not keyboard/tap accessible

<img width="620" height="224" alt="SCR-20260204-jiuw" src="https://github.com/user-attachments/assets/01f20af9-76f7-4786-941a-7483f04f1338" />

<img width="497" height="201" alt="SCR-20260204-jiwt" src="https://github.com/user-attachments/assets/b9038bb9-6c79-4046-9884-ea174ee02ac2" />
