### PR TITLE
style: improve contributors layout

### DIFF
--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -181,7 +181,10 @@ const { data: contributors, status: contributorsStatus } = useFetch<GitHubContri
           <div v-else-if="contributorsStatus === 'error'" class="text-fg-subtle text-sm">
             {{ $t('about.contributors.error') }}
           </div>
-          <div v-else-if="contributors?.length" class="flex flex-wrap gap-2">
+          <div
+            v-else-if="contributors?.length"
+            class="grid grid-cols-[repeat(auto-fill,48px)] justify-center gap-2"
+          >
             <a
               v-for="contributor in contributors"
               :key="contributor.id"


### PR DESCRIPTION
our contributors grid looks different in different mobile version specially on right side there is space. i think we can slightly improve it.

Example 1:
<img width="655" height="922" alt="two" src="https://github.com/user-attachments/assets/288bd7da-7e9c-4f96-90da-f7d350a93a10" />

Example 2: 
<img width="655" height="922" alt="one" src="https://github.com/user-attachments/assets/dfa99af1-8d2b-4349-b4a6-d7057309d07f" />

New: 
<img width="655" height="922" alt="new" src="https://github.com/user-attachments/assets/851907fa-fd83-4b9e-aa5f-6988ebb05033" />


