### PR TITLE
fix(ui): fix cramped stats grid on smaller screens

### DIFF
--- a/app/pages/package/[...package].vue
+++ b/app/pages/package/[...package].vue
@@ -786,7 +786,7 @@ defineOgImageComponent('Package', {
 
         <!-- Stats grid -->
         <dl
-          class="grid grid-cols-2 sm:grid-cols-11 gap-3 sm:gap-4 py-4 sm:py-6 mt-4 sm:mt-6 border-t border-b border-border"
+          class="grid grid-cols-2 sm:grid-cols-7 md:grid-cols-11 gap-3 sm:gap-4 py-4 sm:py-6 mt-4 sm:mt-6 border-t border-b border-border"
         >
           <div class="space-y-1 sm:col-span-2">
             <dt class="text-xs text-fg-subtle uppercase tracking-wider">


### PR DESCRIPTION
Before, stats grid had 11 columns from 640px. This resulted in cramped ui:

<img width="640" height="141" alt="Zrzut ekranu 2026-02-4 o 11 58 31" src="https://github.com/user-attachments/assets/da2d1bb5-78fd-409b-a985-6530b93b185c" />

After, we create fewer columns on `sm`:

<img width="640" height="174" alt="Zrzut ekranu 2026-02-4 o 11 58 41" src="https://github.com/user-attachments/assets/59748a16-19da-4a08-ad64-9d28b55d9667" />

And only after we have more space on `md`, we add 11 columns back:

<img width="795" height="119" alt="Zrzut ekranu 2026-02-4 o 11 58 58" src="https://github.com/user-attachments/assets/ede134c6-7e00-4b7c-8575-52d88f4439fb" />
