### PR TITLE
fix: package like fail revert status

### DIFF
--- a/app/pages/package/[...package].vue
+++ b/app/pages/package/[...package].vue
@@ -421,19 +421,28 @@ const likeAction = async () => {
 
   isLikeActionPending.value = true
 
-  const result = await togglePackageLike(packageName.value, currentlyLiked, user.value?.handle)
+  try {
+    const result = await togglePackageLike(packageName.value, currentlyLiked, user.value?.handle)
 
-  isLikeActionPending.value = false
+    isLikeActionPending.value = false
 
-  if (result.success) {
-    // Update with server response
-    likesData.value = result.data
-  } else {
+    if (result.success) {
+      // Update with server response
+      likesData.value = result.data
+    } else {
+      // Revert on error
+      likesData.value = {
+        totalLikes: currentLikes,
+        userHasLiked: currentlyLiked,
+      }
+    }
+  } catch {
     // Revert on error
     likesData.value = {
       totalLikes: currentLikes,
       userHasLiked: currentlyLiked,
     }
+    isLikeActionPending.value = false
   }
 }
 


### PR DESCRIPTION
When I click "like" on the page, the API returns a 404 error, but the page state is not restored.

<img width="612" height="118" alt="截屏2026-02-04 22 27 00" src="https://github.com/user-attachments/assets/ffe1340c-bdd4-48a5-bac8-35de7a84cd3a" />
