### PR TITLE
fix: collapsing behavior and padding

### DIFF
--- a/app/components/CollapsibleSection.vue
+++ b/app/components/CollapsibleSection.vue
@@ -125,10 +125,10 @@ useHead({
 
     <div
       :id="contentId"
-      class="grid ms-6 transition-[grid-template-rows] duration-200 ease-in-out collapsible-content overflow-hidden"
+      class="grid ms-6 grid-rows-[1fr] transition-[grid-template-rows] duration-200 ease-in-out collapsible-content overflow-hidden"
       :inert="!isOpen"
     >
-      <div class="min-h-0 min-w-0 p-1">
+      <div class="min-h-0 min-w-0">
         <slot />
       </div>
     </div>


### PR DESCRIPTION
 The current implementation already have the animation but it requires the default open state to be set.
- This PR fixes the collapse animation
- Removed the extra padding (p-1) It messes up with the collapse and some item's content will stick out, the <slots/> already handle their own spacing so IMHO it's unnecessary.

Before

https://github.com/user-attachments/assets/10bf507e-f8ba-42c5-b6b4-fbc1c0c2a009

After


https://github.com/user-attachments/assets/05f73b40-82d1-4204-bc00-f5c811a8db4e


