### PR TITLE
fix(i18n): add missing i18n strings for like button + tooltip

### DIFF
--- a/app/pages/package/[...package].vue
+++ b/app/pages/package/[...package].vue
@@ -609,7 +609,9 @@ onKeyStroke(
                 <button
                   @click="likeAction"
                   type="button"
-                  :title="$t('package.likes.like')"
+                  :title="
+                    likesData?.userHasLiked ? $t('package.likes.unlike') : $t('package.likes.like')
+                  "
                   class="inline-flex items-center gap-1.5 font-mono text-sm text-fg hover:text-fg-muted transition-colors duration-200"
                   :aria-label="
                     likesData?.userHasLiked ? $t('package.likes.unlike') : $t('package.likes.like')

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -183,8 +183,7 @@
       "code": "code",
       "docs": "docs",
       "fund": "fund",
-      "compare": "compare",
-      "like": "like"
+      "compare": "compare"
     },
     "likes": {
       "like": "Like this package",

--- a/lunaria/files/en-GB.json
+++ b/lunaria/files/en-GB.json
@@ -183,8 +183,7 @@
       "code": "code",
       "docs": "docs",
       "fund": "fund",
-      "compare": "compare",
-      "like": "like"
+      "compare": "compare"
     },
     "likes": {
       "like": "Like this package",

--- a/lunaria/files/en-US.json
+++ b/lunaria/files/en-US.json
@@ -183,8 +183,7 @@
       "code": "code",
       "docs": "docs",
       "fund": "fund",
-      "compare": "compare",
-      "like": "like"
+      "compare": "compare"
     },
     "likes": {
       "like": "Like this package",


### PR DESCRIPTION
Fixes #956 

Before:
<img width="151" height="86" alt="package links like" src="https://github.com/user-attachments/assets/52939144-50b8-4397-8874-5b21776dc8b7" />

After:
<img width="178" height="92" alt="Like this package" src="https://github.com/user-attachments/assets/9c6ba068-b21a-4bba-8f32-f42da722f436" />

<img width="180" height="86" alt="Unlike this package" src="https://github.com/user-attachments/assets/5c23d8f9-a7e6-4aff-8329-242db61ad5fd" />
