### PR TITLE
fix: exclude og-image from global route rule with enabled isr

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -87,7 +87,7 @@ export default defineNuxtConfig({
     '/': { prerender: true },
     '/opensearch.xml': { isr: true },
     '/**': { isr: getISRConfig(60, true) },
-    '/__og-image__/**': { isr: false, ssr: true },
+    '/__og-image__/**': { isr: getISRConfig(60) },
     '/api/**': { isr: 60 },
     '/200.html': { prerender: true },
     '/package/**': { isr: getISRConfig(60, true) },


### PR DESCRIPTION
## What
Currently, uncached images often return an error (followed by an additional redirect). Because of this, even if a preview is returned, it doesn't contain a valid image.

## How
The problem is [known and common](https://nuxtseo.com/docs/og-image/guides/route-rules#wildcard-route-rules-warning), but the author of og-image writes that the only way to solve it is to manually define all the routes. However, it was enough to simply explicitly override exact rule that were defined under the global rule

## Test

Open the path /__og-image__/image/package/{PACKAGE_NAME}/og.png

It should wait for the image to be generated (for comparison, you can go to production for unpopular packages)


Closes #960 