### PR TITLE
fix: add readme codeblock bg, remove duplicated styles

### DIFF
--- a/app/components/Readme.vue
+++ b/app/components/Readme.vue
@@ -165,48 +165,7 @@ function handleClick(event: MouseEvent) {
 }
 
 .readme :deep(.readme-code-block) {
-  display: block;
-  width: 100%;
-  position: relative;
-}
-
-.readme :deep(.readme-copy-button) {
-  position: absolute;
-  top: 0.4rem;
-  inset-inline-end: 0.4rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.25rem;
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--bg-subtle) 80%, transparent);
-  border: 1px solid var(--border);
-  color: var(--fg-subtle);
-  opacity: 0;
-  transition:
-    opacity 0.2s ease,
-    color 0.2s ease,
-    border-color 0.2s ease;
-}
-
-.readme :deep(.readme-code-block:hover .readme-copy-button),
-.readme :deep(.readme-copy-button:focus-visible) {
-  opacity: 1;
-}
-
-.readme :deep(.readme-copy-button:hover) {
-  color: var(--fg);
-  border-color: var(--border-hover);
-}
-
-.readme :deep(.readme-copy-button > span) {
-  width: 1rem;
-  height: 1rem;
-  display: inline-block;
-  pointer-events: none;
-}
-
-.readme :deep(.readme-code-block) {
+  @apply bg-bg-subtle;
   display: block;
   width: 100%;
   position: relative;


### PR DESCRIPTION
Implements #931 
Also removed some duplicated code regarding the code block and its copy button

Before:
<img width="795" height="368" alt="image" src="https://github.com/user-attachments/assets/0204785f-c7a9-493d-8351-92fed7b98e34" />

<img width="784" height="378" alt="image" src="https://github.com/user-attachments/assets/3df8c6f1-a6e8-40cf-8c4a-2816e8e21f8b" />

After:
<img width="799" height="379" alt="image" src="https://github.com/user-attachments/assets/8119f43c-a0f0-4587-985c-f0b40e59938d" />

<img width="831" height="396" alt="image" src="https://github.com/user-attachments/assets/08574059-bf04-4048-a4f0-8da0d95a5cfe" />
