### PR TITLE
fix: deduplicate when dependencies === transitive dependencies

### DIFF
--- a/app/pages/package/[...package].vue
+++ b/app/pages/package/[...package].vue
@@ -882,7 +882,7 @@ onKeyStroke(
               <span class="text-fg-muted">{{ getDependencyCount(displayVersion) }}</span>
 
               <!-- Separator and total transitive deps -->
-              <template v-if="getDependencyCount(displayVersion) > 0">
+              <template v-if="getDependencyCount(displayVersion) !== totalDepsCount">
                 <span class="text-fg-subtle mx-1">/</span>
 
                 <ClientOnly>


### PR DESCRIPTION
## Before

<img width="450" height="112" alt="image" src="https://github.com/user-attachments/assets/22c0c93b-4d41-47de-ac50-9caeafdc7c4a" />

<img width="480" height="118" alt="{D7F66734-DECA-457E-86D0-DE5DEC93432F}" src="https://github.com/user-attachments/assets/f2e2120b-0792-4783-b77e-419537f09ea4" />


## After

<img width="408" height="105" alt="image" src="https://github.com/user-attachments/assets/1b8806e7-e7ff-420c-b3d9-f89735f0e44c" />

<img width="460" height="114" alt="{3A1D5502-7EDF-49F3-87CE-E38CA7F542B9}" src="https://github.com/user-attachments/assets/92a93ae4-fb16-4ab7-aea1-c81f8dc85014" />

