### PR TITLE
feat(docs): add vscode extension docs

### DIFF
--- a/docs/content/2.guide/4.vscode-extension.md
+++ b/docs/content/2.guide/4.vscode-extension.md
@@ -1,0 +1,32 @@
+---
+title: VS Code Extension
+description: The npmx VS Code extension brings npmx.dev insights into your editor.
+navigation:
+  icon: i-simple-icons-visualstudiocode
+---
+
+## Installation
+
+Install from the <a href="https://marketplace.visualstudio.com/items?itemName=npmx-dev.vscode-npmx" target="_blank" rel="noopener noreferrer">VS Code Marketplace</a>, the <a href="https://open-vsx.org/extension/npmx-dev/vscode-npmx" target="_blank" rel="noopener noreferrer">Open VSX Registry</a> or run:
+
+```bash
+code --install-extension npmx-dev.vscode-npmx
+```
+
+## Features
+
+- **Hover Information** - Quick links to <a href="https://npmx.dev" target="_blank" rel="noopener noreferrer">npmx.dev</a> for package info and documentation, with provenance verification status
+- **Version Completion** - Autocomplete package versions with provenance filtering support
+- **Diagnostics**
+  - Deprecated package warnings
+  - Package replacement suggestions (via <a href="https://github.com/es-tooling/module-replacements" target="_blank" rel="noopener noreferrer">module-replacements</a>)
+  - Vulnerability detection
+
+## Supported Files
+
+- `package.json`
+- `pnpm-workspace.yaml`
+
+## Configuration
+
+For full configuration options and detailed usage, take a look at the <a href="https://github.com/npmx-dev/vscode-npmx#readme" target="_blank" rel="noopener noreferrer">GitHub repository</a>.


### PR DESCRIPTION
To get the word out about the [vs-code extension](https://github.com/npmx-dev/vscode-npmx), the npmx docs should have a section about them. Eventually the extension docs should probably live in the npmx docs entirely, although right now I think its better to keep the repo as the source of truth to avoid PR spam here while the extension evolves.

Also, we've gotten a request to support the extension in Cursor: https://github.com/npmx-dev/vscode-npmx/issues/26. Cursor requires a link to the extension on an official project page, otherwise it won't be reviewed and made available in extension search.

<details>
<summary>
Screenshots
</summary>

<img width="1243" height="734" alt="image" src="https://github.com/user-attachments/assets/28b6b491-0fcf-410c-a30c-a1dd96b4fef7" />
<img width="1285" height="735" alt="image" src="https://github.com/user-attachments/assets/292daa19-98fd-4a38-97be-2e4e0e63c4e6" />

</details>