### PR TITLE
fix(a11y): use pixels for spacing to allow for better text zoom

### DIFF
--- a/uno.config.ts
+++ b/uno.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
   ].filter(Boolean),
   transformers: [transformerDirectives(), transformerVariantGroup()],
   theme: {
+    spacing: { DEFAULT: '4px' },
     font: {
       mono: "'Geist Mono', monospace",
       sans: "'Geist', system-ui, -apple-system, sans-serif",


### PR DESCRIPTION
Browsers have two kinds of zoom:

1. The regular type which scales the size of everything.
2. Text specific zoom which is meant for scaling text specifically.

While `rem` units have long been held as a best practice unit over `px`, that’s really only true of text. If we use `rem` for spacing, we lose the distinction between the two aforementioned kinds of zoom. This problem has been noted by [Ashlee Boyer](https://discord.com/channels/1464542801676206113/1468265913072619624/1468281692707098860) and [Josh Comeau](https://www.joshwcomeau.com/css/surprising-truth-about-pixels-and-accessibility/) in recent years. In my experience, this newer best practice has proliferated throughout the design systems space (at least for those who care about accessibility).

The goal of this PR is to restore the distinction and, in turn, act as a first step for improving the experience of zooming text for the app. **Simply changing from `0.25rem` as the spacing unit to `4px` should have no consequences for anyone not using text zoom**, as `16px` is the default font size and `4px` would’ve been the computed size of the unit. For those using text zoom, this change will mean that anything using spacing units will no longer increase with the text size. This gives more room for the text in place which in turn helps with readability.

Like I said, this is a first step. I do think we will find places where `rem` makes sense to be used for spacing, but I think we can handle them in future PRs. There’s other places where `rem` use could be problematic, such as `border-radius` and some sizing. This first step sets the stage for us to better design the text zoom experience.

## Testing

In **Safari**, you can change the text zoom by either:

1. Holding <kbd>option</kbd> while opening the “View” menu. The “Zoom In” and “Zoom Out” options will change to “Make Text Bigger” and “Make Text Smaller” respectively.
2. There are also convenient shortcuts: <kbd><kbd>command</kbd><kbd>option</kbd><kbd>+</kbd></kbd> and <kbd><kbd>command</kbd><kbd>option</kbd><kbd>-</kbd></kbd>.

In **Chromium**-based browsers, you can set the text size in <chrome://settings/appearance>. There are two options: using relative named sizes and changing the specific pixel size.

In **Firefox**, in <about:preferences> you can change the default font size or you can enable ”Zoom text only” for the default zoom level.

If you are testing for “regressions” I’d recommend sticking to the default text zoom. Like I said, this change should have no effect on that experience. The zoomed text experience might feel visually off. That’s normal. This is an accessibility preference taking precedence over design. We can improve the design of this experience, but we will need to specifically cater to that preference.