### PR TITLE
feat: load package like data add loading effect

### DIFF
--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -620,7 +620,11 @@ onKeyStroke(
               <!-- Package likes -->
               <TooltipApp
                 :text="
-                  likesData?.userHasLiked ? $t('package.likes.unlike') : $t('package.likes.like')
+                  isLoadingLikeData
+                    ? $t('common.loading')
+                    : likesData?.userHasLiked
+                      ? $t('package.likes.unlike')
+                      : $t('package.likes.like')
                 "
                 position="bottom"
                 class="items-center"


### PR DESCRIPTION
When the network speed is slow, you can see a loading effect on the left-hand tabs. 

However, the "like" data on the right-hand side defaults to 0, only suddenly changing to the returned number after loading is complete, which looks rather abrupt. Adding a loading effect, similar to the left-hand side, would look much better.