### PR TITLE
chore: remove duplicated footer content

### DIFF
--- a/app/components/Header/MobileMenu.client.vue
+++ b/app/components/Header/MobileMenu.client.vue
@@ -281,13 +281,6 @@ onUnmounted(deactivate)
                 <span class="flex-1">{{ $t('account_menu.connect_atmosphere') }}</span>
               </button>
             </div>
-
-            <!-- Footer -->
-            <div class="p-4 border-t border-border mt-auto">
-              <p class="font-mono text-xs text-fg-subtle text-center">
-                {{ $t('non_affiliation_disclaimer') }}
-              </p>
-            </div>
           </nav>
         </Transition>
       </div>


### PR DESCRIPTION
"not affiliated with npm inc." this is a part of footer content. But this content is showing also in our sidebar. I think we may remove the duplicate content here. 

Before: 
<img width="583" height="966" alt="before" src="https://github.com/user-attachments/assets/03ba70f3-8702-4065-8512-08c978bcad99" />

After:
<img width="583" height="966" alt="after" src="https://github.com/user-attachments/assets/0ffeeb73-ef9c-47fb-932f-c92a8b8dab5e" />
