### PR TITLE
fix: improve a11y for search results

### DIFF
--- a/app/components/Package/Card.vue
+++ b/app/components/Package/Card.vue
@@ -168,6 +168,7 @@ const pkgDescription = useMarkdown(() => ({
         :key="keyword"
         :pressed="props.filters?.keywords.includes(keyword)"
         :title="`Filter by ${keyword}`"
+        :data-result-index="index"
         @click.stop="emit('clickKeyword', keyword)"
       >
         {{ keyword }}


### PR DESCRIPTION
Bug Reproduction: When you navigate to the **tag button** using the Tab key and press ArrowUp or ArrowDown, the focus jumps back to the first result instead of the previous one.