### PR TITLE
fix: redundant mobile menu close logic

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -185,19 +185,14 @@ onKeyStroke(
           <HeaderAccountMenu />
         </div>
 
-        <!-- Mobile: Menu button (always visible, toggles menu) -->
+        <!-- Mobile: Menu button (always visible, click to open menu) -->
         <button
           type="button"
           class="sm:hidden flex items-center p-2 -m-2 text-fg-subtle hover:text-fg transition-colors duration-200 focus-visible:outline-accent/70 rounded"
-          :aria-label="showMobileMenu ? $t('common.close') : $t('nav.open_menu')"
-          :aria-expanded="showMobileMenu"
-          @click="showMobileMenu = !showMobileMenu"
+          :aria-label="$t('nav.open_menu')"
+          @click="showMobileMenu = true"
         >
-          <span
-            class="w-6 h-6 inline-block"
-            :class="showMobileMenu ? 'i-carbon:close' : 'i-carbon:menu'"
-            aria-hidden="true"
-          />
+          <span class="w-6 h-6 inline-block i-carbon:menu" aria-hidden="true" />
         </button>
       </div>
     </nav>


### PR DESCRIPTION
## Description

Refactored the mobile menu trigger in the header to act strictly as an "Open" trigger. Previously, the button attempted to toggle between a hamburger and a close icon. However, because the HeaderMobileMenu overlay covers the header when active, the close icon was invisible/inaccessible, creating redundant logic and potential state confusion.

## Changes

- Updated the mobile menu button to always display the `i-carbon:menu` icon.
- Simplified `@click` logic from a toggle to strictly setting `showMobileMenu = true`.
- Standardized `aria-label` to always reflect "Open Menu" for better accessibility consistency.

## Before & After

| Before | After |
| :--- | :--- |
| <video src="https://github.com/user-attachments/assets/440c143e-2c07-4809-9511-fae5c979a293" width="300" controls></video> | <video src="https://github.com/user-attachments/assets/71f18ad6-fc93-4ac5-9159-e28fef0b4acc" width="300" controls></video> |