### PR TITLE
fix(i18n): update Japanese translation

### DIFF
--- a/i18n/locales/ja-JP.json
+++ b/i18n/locales/ja-JP.json
@@ -28,10 +28,10 @@
     "updating": "（更新中...）",
     "no_results": "\"{query}\" に一致するパッケージは見つかりませんでした",
     "title": "検索",
-    "title_search": "EN TEXT TO REPLACE: search: {search}",
-    "title_packages": "EN TEXT TO REPLACE: search packages",
-    "meta_description": "EN TEXT TO REPLACE: Search results for '{search}'",
-    "meta_description_packages": "EN TEXT TO REPLACE: Search npm packages",
+    "title_search": "検索: {search}",
+    "title_packages": "パッケージを検索",
+    "meta_description": "'{search}' の検索結果",
+    "meta_description_packages": "npmパッケージを検索",
     "not_taken": "{name} は使用可能です",
     "claim_prompt": "このパッケージ名をnpmで取得する",
     "claim_button": "\"{name}\" を取得",
@@ -123,7 +123,7 @@
     "no_description": "説明はありません",
     "show_full_description": "詳細な説明を表示",
     "not_latest": "（最新ではありません）",
-    "verified_provenance": "検証済みプロバナンス",
+    "verified_provenance": "検証済みprovenance",
     "view_permalink": "このバージョンのパーマリンクを表示",
     "navigation": "パッケージナビゲーション",
     "copy_name": "パッケージ名をコピー",
@@ -198,7 +198,7 @@
     "create": {
       "title": "新しいプロジェクトを作成",
       "copy_command": "作成コマンドをコピー",
-      "view": "{packageName} は同じメンテナによって管理されています。クリックして詳細を表示。"
+      "view": "{packageName} は同じメンテナにより管理されています。詳細を確認するにはクリックしてください。"
     },
     "run": {
       "title": "実行",
@@ -210,23 +210,23 @@
       "view_on_github": "GitHubで表示",
       "toc_title": "目次",
       "callout": {
-        "note": "EN TEXT TO REPLACE: Note",
-        "tip": "EN TEXT TO REPLACE: Tip",
-        "important": "EN TEXT TO REPLACE: Important",
-        "warning": "EN TEXT TO REPLACE: Warning",
-        "caution": "EN TEXT TO REPLACE: Caution"
+        "note": "メモ",
+        "tip": "ヒント",
+        "important": "重要",
+        "warning": "警告",
+        "caution": "注意"
       }
     },
     "provenance_section": {
-      "title": "EN TEXT TO REPLACE: Provenance",
-      "built_and_signed_on": "EN TEXT TO REPLACE: Built and signed on {provider}",
-      "view_build_summary": "EN TEXT TO REPLACE: View build summary",
-      "source_commit": "EN TEXT TO REPLACE: Source Commit",
-      "build_file": "EN TEXT TO REPLACE: Build File",
-      "public_ledger": "EN TEXT TO REPLACE: Public Ledger",
-      "transparency_log_entry": "EN TEXT TO REPLACE: Transparency log entry",
-      "view_more_details": "EN TEXT TO REPLACE: View more details",
-      "error_loading": "EN TEXT TO REPLACE: Failed to load provenance details"
+      "title": "Provenance",
+      "built_and_signed_on": "{provider} でビルドおよび署名済み",
+      "view_build_summary": "ビルドサマリーを表示",
+      "source_commit": "ソースコミット",
+      "build_file": "ビルドファイル",
+      "public_ledger": "パブリックレジャー",
+      "transparency_log_entry": "透明性ログエントリ",
+      "view_more_details": "詳細を表示",
+      "error_loading": "provenance詳細情報の読み込みに失敗しました"
     },
     "keywords_title": "キーワード",
     "compatibility": "互換性",
@@ -290,7 +290,7 @@
       "date_range": "{start} から {end}",
       "date_range_multiline": "{start}\nから {end}",
       "analyze": "ダウンロード数を分析",
-      "community_distribution": "EN TEXT TO REPLACE: View community adoption distribution",
+      "community_distribution": "コミュニティの採用分布を表示",
       "modal_title": "ダウンロード数",
       "granularity": "粒度",
       "granularity_daily": "日次",
@@ -627,9 +627,9 @@
   "badges": {
     "provenance": {
       "verified": "検証済み",
-      "verified_title": "検証済みプロバナンス",
+      "verified_title": "検証済みprovenance",
       "verified_via": "検証済み: {provider} 経由で公開",
-      "view_more_details": "EN TEXT TO REPLACE: View more details"
+      "view_more_details": "詳細を表示"
     },
     "jsr": {
       "title": "JSRでも利用可能",

--- a/lunaria/files/ja-JP.json
+++ b/lunaria/files/ja-JP.json
@@ -28,10 +28,10 @@
     "updating": "（更新中...）",
     "no_results": "\"{query}\" に一致するパッケージは見つかりませんでした",
     "title": "検索",
-    "title_search": "EN TEXT TO REPLACE: search: {search}",
-    "title_packages": "EN TEXT TO REPLACE: search packages",
-    "meta_description": "EN TEXT TO REPLACE: Search results for '{search}'",
-    "meta_description_packages": "EN TEXT TO REPLACE: Search npm packages",
+    "title_search": "検索: {search}",
+    "title_packages": "パッケージを検索",
+    "meta_description": "'{search}' の検索結果",
+    "meta_description_packages": "npmパッケージを検索",
     "not_taken": "{name} は使用可能です",
     "claim_prompt": "このパッケージ名をnpmで取得する",
     "claim_button": "\"{name}\" を取得",
@@ -123,7 +123,7 @@
     "no_description": "説明はありません",
     "show_full_description": "詳細な説明を表示",
     "not_latest": "（最新ではありません）",
-    "verified_provenance": "検証済みプロバナンス",
+    "verified_provenance": "検証済みprovenance",
     "view_permalink": "このバージョンのパーマリンクを表示",
     "navigation": "パッケージナビゲーション",
     "copy_name": "パッケージ名をコピー",
@@ -198,7 +198,7 @@
     "create": {
       "title": "新しいプロジェクトを作成",
       "copy_command": "作成コマンドをコピー",
-      "view": "{packageName} は同じメンテナによって管理されています。クリックして詳細を表示。"
+      "view": "{packageName} は同じメンテナにより管理されています。詳細を確認するにはクリックしてください。"
     },
     "run": {
       "title": "実行",
@@ -210,23 +210,23 @@
       "view_on_github": "GitHubで表示",
       "toc_title": "目次",
       "callout": {
-        "note": "EN TEXT TO REPLACE: Note",
-        "tip": "EN TEXT TO REPLACE: Tip",
-        "important": "EN TEXT TO REPLACE: Important",
-        "warning": "EN TEXT TO REPLACE: Warning",
-        "caution": "EN TEXT TO REPLACE: Caution"
+        "note": "メモ",
+        "tip": "ヒント",
+        "important": "重要",
+        "warning": "警告",
+        "caution": "注意"
       }
     },
     "provenance_section": {
-      "title": "EN TEXT TO REPLACE: Provenance",
-      "built_and_signed_on": "EN TEXT TO REPLACE: Built and signed on {provider}",
-      "view_build_summary": "EN TEXT TO REPLACE: View build summary",
-      "source_commit": "EN TEXT TO REPLACE: Source Commit",
-      "build_file": "EN TEXT TO REPLACE: Build File",
-      "public_ledger": "EN TEXT TO REPLACE: Public Ledger",
-      "transparency_log_entry": "EN TEXT TO REPLACE: Transparency log entry",
-      "view_more_details": "EN TEXT TO REPLACE: View more details",
-      "error_loading": "EN TEXT TO REPLACE: Failed to load provenance details"
+      "title": "Provenance",
+      "built_and_signed_on": "{provider} でビルドおよび署名済み",
+      "view_build_summary": "ビルドサマリーを表示",
+      "source_commit": "ソースコミット",
+      "build_file": "ビルドファイル",
+      "public_ledger": "パブリックレジャー",
+      "transparency_log_entry": "透明性ログエントリ",
+      "view_more_details": "詳細を表示",
+      "error_loading": "provenance詳細情報の読み込みに失敗しました"
     },
     "keywords_title": "キーワード",
     "compatibility": "互換性",
@@ -290,7 +290,7 @@
       "date_range": "{start} から {end}",
       "date_range_multiline": "{start}\nから {end}",
       "analyze": "ダウンロード数を分析",
-      "community_distribution": "EN TEXT TO REPLACE: View community adoption distribution",
+      "community_distribution": "コミュニティの採用分布を表示",
       "modal_title": "ダウンロード数",
       "granularity": "粒度",
       "granularity_daily": "日次",
@@ -627,9 +627,9 @@
   "badges": {
     "provenance": {
       "verified": "検証済み",
-      "verified_title": "検証済みプロバナンス",
+      "verified_title": "検証済みprovenance",
       "verified_via": "検証済み: {provider} 経由で公開",
-      "view_more_details": "EN TEXT TO REPLACE: View more details"
+      "view_more_details": "詳細を表示"
     },
     "jsr": {
       "title": "JSRでも利用可能",


### PR DESCRIPTION
- Update 20 strings
- Revert to the English word "provenance", instead of using the Katakana spelling "プロバナンス"
  - I could translate this term to "来歴", but it seems that this translation has not beeing popularized on the web yet.
  - (Addtional research: It's also used in the archive or history research papers (ref. [Google Scholar](https://scholar.google.com/scholar?hl=en&as_sdt=0%2C5&q=%E6%9D%A5%E6%AD%B4+provenance+&btnG=)))