### PR TITLE
fix(i18n): correct `connected_as` user prefix symbol

### DIFF
--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -386,7 +386,7 @@
   "connector": {
     "status": {
       "connecting": "جارٍ الاتصال...",
-      "connected_as": "متصل كـ {'@'}{user}",
+      "connected_as": "متصل كـ ~{user}",
       "connected": "متصل",
       "connect_cli": "ربط واجهة سطر الأوامر المحلية",
       "aria_connecting": "جارٍ الاتصال بالموصل المحلي",

--- a/i18n/locales/az.json
+++ b/i18n/locales/az.json
@@ -344,7 +344,7 @@
   "connector": {
     "status": {
       "connecting": "qoşulur...",
-      "connected_as": "{'@'}{user} olaraq qoşulub",
+      "connected_as": "~{user} olaraq qoşulub",
       "connected": "qoşulub",
       "connect_cli": "lokal CLI qoş",
       "aria_connecting": "Lokal konnektora qoşulur",

--- a/i18n/locales/cs-CZ.json
+++ b/i18n/locales/cs-CZ.json
@@ -386,7 +386,7 @@
   "connector": {
     "status": {
       "connecting": "připojování...",
-      "connected_as": "připojeno jako {'@'}{user}",
+      "connected_as": "připojeno jako ~{user}",
       "connected": "připojeno",
       "connect_cli": "připojit lokální CLI",
       "aria_connecting": "Připojování k lokálnímu konektoru",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -392,7 +392,7 @@
   "connector": {
     "status": {
       "connecting": "conectando...",
-      "connected_as": "conectado como {'@'}{user}",
+      "connected_as": "conectado como ~{user}",
       "connected": "conectado",
       "connect_cli": "conectar CLI local",
       "aria_connecting": "Conectando al conector local",

--- a/i18n/locales/fr-FR.json
+++ b/i18n/locales/fr-FR.json
@@ -388,7 +388,7 @@
   "connector": {
     "status": {
       "connecting": "connexion...",
-      "connected_as": "connecté·e en tant que {'@'}{user}",
+      "connected_as": "connecté·e en tant que ~{user}",
       "connected": "connecté·e",
       "connect_cli": "connecter le CLI local",
       "aria_connecting": "Connexion au connecteur local",

--- a/i18n/locales/hu-HU.json
+++ b/i18n/locales/hu-HU.json
@@ -342,7 +342,7 @@
   "connector": {
     "status": {
       "connecting": "kapcsolódás...",
-      "connected_as": "csatlakoztatva: {'@'}{user}",
+      "connected_as": "csatlakoztatva: ~{user}",
       "connected": "csatlakoztatva",
       "connect_cli": "helyi CLI csatlakoztatása",
       "aria_connecting": "Kapcsolódás a helyi connectorhoz",

--- a/i18n/locales/ja-JP.json
+++ b/i18n/locales/ja-JP.json
@@ -388,7 +388,7 @@
   "connector": {
     "status": {
       "connecting": "接続中...",
-      "connected_as": "{'@'}{user} として接続済み",
+      "connected_as": "~{user} として接続済み",
       "connected": "接続済み",
       "connect_cli": "ローカルCLIに接続",
       "aria_connecting": "ローカルコネクタに接続中",

--- a/i18n/locales/pl-PL.json
+++ b/i18n/locales/pl-PL.json
@@ -396,7 +396,7 @@
   "connector": {
     "status": {
       "connecting": "łączenie...",
-      "connected_as": "połączono jako {'@'}{user}",
+      "connected_as": "połączono jako ~{user}",
       "connected": "połączono",
       "connect_cli": "połącz lokalne CLI",
       "aria_connecting": "Łączenie z lokalnym konektorem",

--- a/i18n/locales/ru-RU.json
+++ b/i18n/locales/ru-RU.json
@@ -340,7 +340,7 @@
   "connector": {
     "status": {
       "connecting": "подключение...",
-      "connected_as": "подключен как {'@'}{user}",
+      "connected_as": "подключен как ~{user}",
       "connected": "подключено",
       "connect_cli": "подключить локальный CLI",
       "aria_connecting": "Подключение к локальному коннектору",

--- a/i18n/locales/uk-UA.json
+++ b/i18n/locales/uk-UA.json
@@ -344,7 +344,7 @@
   "connector": {
     "status": {
       "connecting": "підключення...",
-      "connected_as": "підключений як {'@'}{user}",
+      "connected_as": "підключений як ~{user}",
       "connected": "підключено",
       "connect_cli": "підключити локальний CLI",
       "aria_connecting": "Підключення до локального сполучника",

--- a/lunaria/files/ar-EG.json
+++ b/lunaria/files/ar-EG.json
@@ -386,7 +386,7 @@
   "connector": {
     "status": {
       "connecting": "جارٍ الاتصال...",
-      "connected_as": "متصل كـ {'@'}{user}",
+      "connected_as": "متصل كـ ~{user}",
       "connected": "متصل",
       "connect_cli": "ربط واجهة سطر الأوامر المحلية",
       "aria_connecting": "جارٍ الاتصال بالموصل المحلي",

--- a/lunaria/files/az.json
+++ b/lunaria/files/az.json
@@ -344,7 +344,7 @@
   "connector": {
     "status": {
       "connecting": "qoşulur...",
-      "connected_as": "{'@'}{user} olaraq qoşulub",
+      "connected_as": "~{user} olaraq qoşulub",
       "connected": "qoşulub",
       "connect_cli": "lokal CLI qoş",
       "aria_connecting": "Lokal konnektora qoşulur",

--- a/lunaria/files/cs-CZ.json
+++ b/lunaria/files/cs-CZ.json
@@ -386,7 +386,7 @@
   "connector": {
     "status": {
       "connecting": "připojování...",
-      "connected_as": "připojeno jako {'@'}{user}",
+      "connected_as": "připojeno jako ~{user}",
       "connected": "připojeno",
       "connect_cli": "připojit lokální CLI",
       "aria_connecting": "Připojování k lokálnímu konektoru",

--- a/lunaria/files/es-419.json
+++ b/lunaria/files/es-419.json
@@ -392,7 +392,7 @@
   "connector": {
     "status": {
       "connecting": "conectando...",
-      "connected_as": "conectado como {'@'}{user}",
+      "connected_as": "conectado como ~{user}",
       "connected": "conectado",
       "connect_cli": "conectar CLI local",
       "aria_connecting": "Conectando al conector local",

--- a/lunaria/files/es-ES.json
+++ b/lunaria/files/es-ES.json
@@ -392,7 +392,7 @@
   "connector": {
     "status": {
       "connecting": "conectando...",
-      "connected_as": "conectado como {'@'}{user}",
+      "connected_as": "conectado como ~{user}",
       "connected": "conectado",
       "connect_cli": "conectar CLI local",
       "aria_connecting": "Conectando al conector local",

--- a/lunaria/files/fr-FR.json
+++ b/lunaria/files/fr-FR.json
@@ -388,7 +388,7 @@
   "connector": {
     "status": {
       "connecting": "connexion...",
-      "connected_as": "connecté·e en tant que {'@'}{user}",
+      "connected_as": "connecté·e en tant que ~{user}",
       "connected": "connecté·e",
       "connect_cli": "connecter le CLI local",
       "aria_connecting": "Connexion au connecteur local",

--- a/lunaria/files/hu-HU.json
+++ b/lunaria/files/hu-HU.json
@@ -342,7 +342,7 @@
   "connector": {
     "status": {
       "connecting": "kapcsolódás...",
-      "connected_as": "csatlakoztatva: {'@'}{user}",
+      "connected_as": "csatlakoztatva: ~{user}",
       "connected": "csatlakoztatva",
       "connect_cli": "helyi CLI csatlakoztatása",
       "aria_connecting": "Kapcsolódás a helyi connectorhoz",

--- a/lunaria/files/ja-JP.json
+++ b/lunaria/files/ja-JP.json
@@ -388,7 +388,7 @@
   "connector": {
     "status": {
       "connecting": "接続中...",
-      "connected_as": "{'@'}{user} として接続済み",
+      "connected_as": "~{user} として接続済み",
       "connected": "接続済み",
       "connect_cli": "ローカルCLIに接続",
       "aria_connecting": "ローカルコネクタに接続中",

--- a/lunaria/files/pl-PL.json
+++ b/lunaria/files/pl-PL.json
@@ -396,7 +396,7 @@
   "connector": {
     "status": {
       "connecting": "łączenie...",
-      "connected_as": "połączono jako {'@'}{user}",
+      "connected_as": "połączono jako ~{user}",
       "connected": "połączono",
       "connect_cli": "połącz lokalne CLI",
       "aria_connecting": "Łączenie z lokalnym konektorem",

--- a/lunaria/files/ru-RU.json
+++ b/lunaria/files/ru-RU.json
@@ -340,7 +340,7 @@
   "connector": {
     "status": {
       "connecting": "подключение...",
-      "connected_as": "подключен как {'@'}{user}",
+      "connected_as": "подключен как ~{user}",
       "connected": "подключено",
       "connect_cli": "подключить локальный CLI",
       "aria_connecting": "Подключение к локальному коннектору",

--- a/lunaria/files/uk-UA.json
+++ b/lunaria/files/uk-UA.json
@@ -344,7 +344,7 @@
   "connector": {
     "status": {
       "connecting": "підключення...",
-      "connected_as": "підключений як {'@'}{user}",
+      "connected_as": "підключений як ~{user}",
       "connected": "підключено",
       "connect_cli": "підключити локальний CLI",
       "aria_connecting": "Підключення до локального сполучника",


### PR DESCRIPTION
`{'@'}{user}` -> `~{user}`