### PR TITLE
feat(ui): display all engines in Compatibility section and make common ones pretty

### DIFF
--- a/app/components/Package/Compatibility.vue
+++ b/app/components/Package/Compatibility.vue
@@ -23,16 +23,21 @@ function getName(engine: string): string {
 function getIcon(engine: string): string {
   return engineIcons[engine] || 'i-carbon:code'
 }
+
+const sortedEngines = computed(() => {
+  const entries = Object.entries(props.engines ?? {})
+  return entries.sort(([a], [b]) => a.localeCompare(b))
+})
 </script>
 <template>
   <CollapsibleSection
-    v-if="engines && Object.keys(engines).length"
+    v-if="sortedEngines.length"
     :title="$t('package.compatibility')"
     id="compatibility"
   >
     <dl class="space-y-2">
       <div
-        v-for="(version, engine) in engines"
+        v-for="[engine, version] in sortedEngines"
         :key="engine"
         class="flex justify-between gap-4 py-1"
       >

--- a/shared/utils/package-analysis.ts
+++ b/shared/utils/package-analysis.ts
@@ -12,10 +12,7 @@ export type TypesStatus =
 export interface PackageAnalysis {
   moduleFormat: ModuleFormat
   types: TypesStatus
-  engines?: {
-    node?: string
-    npm?: string
-  }
+  engines?: Record<string, string>
   /** Associated create-* package if it exists */
   createPackage?: CreatePackageInfo
 }
@@ -306,12 +303,7 @@ export function analyzePackage(
   return {
     moduleFormat,
     types,
-    engines: pkg.engines
-      ? {
-          node: pkg.engines.node,
-          npm: pkg.engines.npm,
-        }
-      : undefined,
+    engines: pkg.engines,
     createPackage: options?.createPackage,
   }
 }

--- a/test/unit/shared/utils/package-analysis.spec.ts
+++ b/test/unit/shared/utils/package-analysis.spec.ts
@@ -217,12 +217,17 @@ describe('analyzePackage', () => {
       name: 'test',
       main: 'index.js',
       engines: {
+        bun: '>=1.0.0',
         node: '>=18',
         npm: '>=9',
       },
     })
 
-    expect(result.engines).toEqual({ node: '>=18', npm: '>=9' })
+    expect(result.engines).toEqual({
+      bun: '>=1.0.0',
+      node: '>=18',
+      npm: '>=9',
+    })
   })
 
   it('detects @types package when typesPackage info is provided', () => {


### PR DESCRIPTION
This PR makes Compatibility section more generic, making it display any engine that is actually set in packument. On top of that, it makes the list prettier by not displaying raw machine-oriented data but icons and labels for most popular engines.

**Before (1):**

<img width="313" height="113" alt="image" src="https://github.com/user-attachments/assets/5bfa47a1-652e-4b34-9af2-6ab6c1635092" />

https://npmx.dev/package/rollup

**After (1):** 

<img width="313" height="113" alt="image" src="https://github.com/user-attachments/assets/75675d2c-2269-49e5-bfb0-0fa8a98a1bfc" />

**Before (2):**

(nothing to display)

https://npmx.dev/package/react-jsx-parser

**After (2):**

<img width="313" height="76" alt="image" src="https://github.com/user-attachments/assets/ac22a18b-6480-4257-840c-c428b1e1f187" />
