### PR TITLE
fix(ui): use Node.js instead of Node in engines on Compare page

### DIFF
--- a/app/composables/usePackageComparison.ts
+++ b/app/composables/usePackageComparison.ts
@@ -326,7 +326,7 @@ function computeFacetValue(
       }
       return {
         raw: engines.node,
-        display: `Node ${engines.node}`,
+        display: `Node.js ${engines.node}`,
         status: 'neutral',
       }
     }


### PR DESCRIPTION
Node.js is the correct engine name