### PR TITLE
fix: youtube readme styling

### DIFF
--- a/app/components/Readme.vue
+++ b/app/components/Readme.vue
@@ -409,6 +409,19 @@ function handleClick(event: MouseEvent) {
   display: revert-layer;
 }
 
+/* Override HTML align attribute float behavior on images and containers.
+   Matches npm registry behavior: display as block instead of floating. */
+.readme :deep(img[align='right']),
+.readme :deep(img[align='left']) {
+  float: none;
+}
+
+.readme :deep(div[align='right']),
+.readme :deep(div[align='left']) {
+  float: none;
+  text-align: start;
+}
+
 .readme :deep(hr) {
   border: none;
   border-top: 1px solid var(--border);


### PR DESCRIPTION
resolves https://github.com/npmx-dev/npmx.dev/issues/1006

<img width="1113" height="726" alt="youtube" src="https://github.com/user-attachments/assets/34706f11-3262-4b28-b871-77f533b5513c" />
