### PR TITLE
chore: update i18n contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -408,7 +408,7 @@ See how `es`, `es-ES`, and `es-419` are configured in [config/i18n.ts](./config/
    <p>{{ $t('greeting', { name: userName }) }}</p>
    ```
 
-4. Don't concatenate string messages in the vue templates, some languages can have different word order. Use placeholders instead.
+4. Don't concatenate string messages in the Vue templates, some languages can have different word order. Use placeholders instead.
 
    **Bad:**
 


### PR DESCRIPTION
This PR includes the following changes to CONTRIBUTING.md file:
- add link to unicode.org plural rules spec
- use underscore instead dash for translation keys
- don't concatenate strings in vue templates: link to vue-i18n component and some examples
- fix some typos (coderabbitai)