### PR TITLE
chore: include new deps to vite optimized deps

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -266,12 +266,15 @@ export default defineNuxtConfig({
     optimizeDeps: {
       include: [
         '@vueuse/core',
+        '@vueuse/integrations/useFocusTrap',
         'vue-data-ui/vue-ui-sparkline',
         'vue-data-ui/vue-ui-xy',
         'virtua/vue',
         'semver',
         'validate-npm-package-name',
         '@atproto/lex',
+        'fast-npm-meta',
+        '@floating-ui/vue',
       ],
     },
   },


### PR DESCRIPTION
From time to time we add some dependencies that should be optimized, this PR adds the following dependencies:
- `@vueuse/integrations/useFocusTrap`
- `fast-npm-meta`
- `@floating-ui/vue`

<img width="690" height="89" alt="image" src="https://github.com/user-attachments/assets/4146a1e2-df13-41f7-863b-a7de2a0b4e8f" />
