### PR TITLE
fix: display images on top of other elements in README

### DIFF
--- a/app/components/Readme.vue
+++ b/app/components/Readme.vue
@@ -85,6 +85,8 @@ function handleClick(event: MouseEvent) {
   /* Contain all children */
   overflow: hidden;
   min-width: 0;
+  /* Contain all children z-index values inside this container */
+  isolation: isolate;
 }
 
 /* README headings - styled by visual level (data-level), not semantic level */
@@ -402,6 +404,8 @@ function handleClick(event: MouseEvent) {
   display: revert-layer;
   border-radius: 8px;
   margin: 1rem 0;
+  position: relative;
+  z-index: 1;
 }
 
 .readme :deep(video) {


### PR DESCRIPTION
Resolves #1006

Note: I noticed that the other PR has kind of stalled, so decided to try and fix that myself. Feel free to close this one if it is considered a bad OSS practice.

The change is to display the image on top of other elements with z-index, npm does the same

<details>
<summary>npmx (fixed)</summary>
<img width="772" height="367" alt="image" src="https://github.com/user-attachments/assets/1959cf47-3e2b-4ca6-bf8d-79c42619aae7" />
</details>

<details>
<summary>npm</summary>
<img width="760" height="386" alt="image" src="https://github.com/user-attachments/assets/4087d39c-e389-4177-a494-174ba6d5931b" />

</details>