### PR TITLE
fix(i18n): set readme text direction to `'auto'`

### DIFF
--- a/app/components/Readme.vue
+++ b/app/components/Readme.vue
@@ -61,6 +61,7 @@ function handleClick(event: MouseEvent) {
 <template>
   <article
     class="readme prose prose-invert max-w-[70ch] lg:max-w-none px-1"
+    dir="auto"
     v-html="html"
     :style="{
       '--i18n-note': '\'' + $t('package.readme.callout.note') + '\'',


### PR DESCRIPTION
We don't know the language used in the readme, so we shouldn't force/inherit the direction.

before:
<img width="400" height="953" alt="Code_2026-02-05_22-39-52" src="https://github.com/user-attachments/assets/8d6165f3-cac3-4448-9176-3f811ee6da76" />
after:
<img width="400" height="983" alt="Code_2026-02-05_22-39-59" src="https://github.com/user-attachments/assets/ac344232-bf74-4c53-801b-3474727dd97a" />
