### PR TITLE
docs: remove gitpod as a playground platform

### DIFF
--- a/docs/content/2.guide/1.features.md
+++ b/docs/content/2.guide/1.features.md
@@ -88,7 +88,6 @@ Quick access to online development environments detected from package READMEs:
 | :icon{name="i-lucide-pen-tool"} [CodePen](https://codepen.io)                  | Social development environment for front-end |
 | :icon{name="i-simple-icons-jsfiddle"} [JSFiddle](https://jsfiddle.net)         | Online editor for web snippets               |
 | :icon{name="i-simple-icons-replit"} [Replit](https://replit.com)               | Collaborative browser-based IDE              |
-| :icon{name="i-simple-icons-gitpod"} [Gitpod](https://gitpod.io)                | Cloud development environments               |
 
 ### Custom badges
 


### PR DESCRIPTION
Gitpod has rebranded as [Ona](https://ona.com) and is more enterprise-oriented than individual online IDE friendly now.

There are a few options you could take here, but as an avid Gitpod user (and community hero, even!) for years who has had to get over it, my personal suggestion is just to remove it.

#### Alternatives to this PR

You could instead choose to update the entry to Ona (link and text), but it has no nice icon in the Simple Icons set. And it's something that is less likely for an individual to use as a playground anymore.

You could instead choose to just leave the link and let the redirect to happen, but that's kicking the can down the road and advertising a service that has been sunset. (i.e. close this PR! That's fine!)

An alternative platform that *is* more or less a drop-in replacement for Gitpod that you don't currently have listed is [Firebase Studio](https://firebase.studio), but I don't think it has its own icon either. (There is a distinct Firebase Studio logo separate from just Firebase.)