### PR TITLE
fix: add default theme for no-js users

### DIFF
--- a/app/assets/main.css
+++ b/app/assets/main.css
@@ -5,6 +5,7 @@
   box-sizing: border-box;
 }
 
+:root:not([data-theme='light']),
 :root[data-theme='dark'] {
   /* background colors */
   --bg: var(--bg-color, oklch(0.145 0 0));


### PR DESCRIPTION
I simply added that if the theme isn't defined, the colors from the dark theme are used.

This won't be a problem for JS users, as the browser won't apply the colors until the head is complete, and nuxt-theme determines the current theme in the head.

I used :not() to avoid unnecessary variables and improve debugging experience

Closes #939 #1059