### PR TITLE
chore: resolve broken alert rendering in nested list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,7 +334,7 @@ To add a new locale:
    cp i18n/locales/uk-UA.json lunaria/files/uk-UA.json
    ```
 
-   > **Important:**
+   > ⚠**Important:**
    > This file must be committed. Lunaria uses git history to track translation progress, so the build will fail if this file is missing.
 
 5. If the language is `right-to-left`, add `dir: 'rtl'` (see `ar-EG` in config for example)


### PR DESCRIPTION
Fixed a small rendering issue here. GitHub alerts (like [[!IMPORTANT](https://github.com/orgs/community/discussions/16925)]) don't render correctly when indented inside lists. I switched it to standard bold text (**Important:**) .

<img width="901" height="188" alt="image" src="https://github.com/user-attachments/assets/53f02266-45e7-4cc1-8517-843331fdaf2e" />
