### PR TITLE
refactor: share `encodePackageName` utility function

### DIFF
--- a/app/utils/package-name.ts
+++ b/app/utils/package-name.ts
@@ -1,4 +1,5 @@
 import validatePackageName from 'validate-npm-package-name'
+import { encodePackageName } from '#shared/utils/npm'
 
 /**
  * Normalize a package name for comparison by removing common variations.
@@ -77,11 +78,7 @@ export async function checkPackageExists(
   options: Parameters<typeof $fetch>[1] = {},
 ): Promise<boolean> {
   try {
-    const encodedName = name.startsWith('@')
-      ? `@${encodeURIComponent(name.slice(1))}`
-      : encodeURIComponent(name)
-
-    await $fetch(`${NPM_REGISTRY}/${encodedName}`, {
+    await $fetch(`${NPM_REGISTRY}/${encodePackageName(name)}`, {
       ...options,
       method: 'HEAD',
     })

--- a/server/api/registry/analysis/[...pkg].get.ts
+++ b/server/api/registry/analysis/[...pkg].get.ts
@@ -18,6 +18,7 @@ import {
   ERROR_PACKAGE_ANALYSIS_FAILED,
 } from '#shared/utils/constants'
 import { parseRepoUrl } from '#shared/utils/git-providers'
+import { encodePackageName } from '#shared/utils/npm'
 import { getLatestVersion, getLatestVersionBatch } from 'fast-npm-meta'
 
 export default defineCachedEventHandler(
@@ -75,13 +76,6 @@ export default defineCachedEventHandler(
     },
   },
 )
-
-function encodePackageName(name: string): string {
-  if (name.startsWith('@')) {
-    return `@${encodeURIComponent(name.slice(1))}`
-  }
-  return encodeURIComponent(name)
-}
 
 /**
  * Fetch @types package info including deprecation status using fast-npm-meta.

--- a/server/utils/dependency-resolver.ts
+++ b/server/utils/dependency-resolver.ts
@@ -1,5 +1,6 @@
 import type { Packument, PackumentVersion, DependencyDepth } from '#shared/types'
 import { mapWithConcurrency } from '#shared/utils/async'
+import { encodePackageName } from '#shared/utils/npm'
 import { maxSatisfying } from 'semver'
 
 /** Concurrency limit for fetching packuments during dependency resolution */
@@ -21,11 +22,7 @@ export const TARGET_PLATFORM = {
 export const fetchPackument = defineCachedFunction(
   async (name: string): Promise<Packument | null> => {
     try {
-      const encodedName = name.startsWith('@')
-        ? `@${encodeURIComponent(name.slice(1))}`
-        : encodeURIComponent(name)
-
-      return await $fetch<Packument>(`https://registry.npmjs.org/${encodedName}`)
+      return await $fetch<Packument>(`https://registry.npmjs.org/${encodePackageName(name)}`)
     } catch (error) {
       if (import.meta.dev) {
         // oxlint-disable-next-line no-console -- log npm registry failures for debugging


### PR DESCRIPTION
Use the `encodePackageName` utility in `#shared/utils/npm` everywhere instead of duplicating them. I think it's safe (?) since `#shared/utils/*` can work anywhere.

PS I used explicit imports as I prefer them 😄 The codebase currently has a mix of explicit and auto/hidden imports and I'm not sure which is preferred.