### PR TITLE
fix: prevent modal from taking full width on mobile screen

### DIFF
--- a/app/components/Modal.client.vue
+++ b/app/components/Modal.client.vue
@@ -25,7 +25,7 @@ defineExpose({
     <dialog
       ref="dialogRef"
       closedby="any"
-      class="w-full bg-bg border border-border rounded-lg shadow-xl max-h-[90vh] overflow-y-auto overscroll-contain m-0 m-auto p-6 text-fg focus-visible:outline focus-visible:outline-accent/70"
+      class="w-[calc(100%-2rem)] bg-bg border border-border rounded-lg shadow-xl max-h-[90vh] overflow-y-auto overscroll-contain m-0 m-auto p-6 text-fg focus-visible:outline focus-visible:outline-accent/70"
       :aria-labelledby="modalTitleId"
       v-bind="$attrs"
     >


### PR DESCRIPTION
Currently in mobile screen, modal is taking full width. I think we can improve this. 

Before:
<img width="785" height="830" alt="modal-previous" src="https://github.com/user-attachments/assets/a6a9c8a0-42be-484a-853d-3cd89a0d2ad5" />

After:
<img width="753" height="615" alt="modal-now" src="https://github.com/user-attachments/assets/a4c1b46f-9634-4b00-9ffb-6566af57ad8b" />

