### PR TITLE
fix(ui): correct column dropdown positioning and mobile overflow

### DIFF
--- a/app/components/ColumnPicker.vue
+++ b/app/components/ColumnPicker.vue
@@ -87,7 +87,7 @@ function handleReset() {
         v-if="isOpen"
         ref="menuRef"
         :id="menuId"
-        class="absolute top-full right-0 sm:inset-is-auto sm:inset-ie-0 mt-2 w-60 bg-bg-subtle border border-border rounded-lg shadow-lg z-20"
+        class="absolute top-full inset-ie-0 sm:inset-is-auto sm:inset-ie-0 mt-2 w-60 bg-bg-subtle border border-border rounded-lg shadow-lg z-20"
         role="group"
         :aria-label="$t('filters.columns.show')"
       >


### PR DESCRIPTION
### Description

Fixed a layout issue with the Column Toggle dropdown where it was causing horizontal overflow on mobile devices and incorrectly overlapping the trigger button

| Before | After |
| :--- | :--- |
| <video src="https://github.com/user-attachments/assets/b6dbcfb7-e81b-4997-9bd3-6bc8918b433f" height="400" controls></video> | <img src="https://github.com/user-attachments/assets/b2753791-b980-46f2-a45c-043f7a429d34" height="600"> |