### PR TITLE
fix: badge label with empty string should not occupy width

### DIFF
--- a/server/api/registry/badge/[type]/[...pkg].get.ts
+++ b/server/api/registry/badge/[type]/[...pkg].get.ts
@@ -292,7 +292,7 @@ export default defineCachedEventHandler(
       const rawLabelColor = labelColor ?? '#0a0a0a'
       const finalLabelColor = rawLabelColor?.startsWith('#') ? rawLabelColor : `#${rawLabelColor}`
 
-      const leftWidth = measureTextWidth(finalLabel)
+      const leftWidth = finalLabel.trim().length === 0 ? 0 : measureTextWidth(finalLabel)
       const rightWidth = measureTextWidth(
         finalValue,
         CHARS_WIDTH[strategyKey as keyof typeof CHARS_WIDTH],


### PR DESCRIPTION
The left side is not rendered when the label result is an empty string.