### PR TITLE
fix: update link path in search-suggestion-card

### DIFF
--- a/app/components/SearchSuggestionCard.vue
+++ b/app/components/SearchSuggestionCard.vue
@@ -14,7 +14,11 @@ defineProps<{
 <template>
   <BaseCard :isExactMatch="isExactMatch">
     <NuxtLink
-      :to="type === 'user' ? `/~${name}` : `/@${name}`"
+      :to="
+        type === 'user'
+          ? { name: '~username', params: { username: name } }
+          : { name: 'org', params: { org: name } }
+      "
       :data-suggestion-index="index"
       class="flex items-center gap-4 focus-visible:outline-none after:content-[''] after:absolute after:inset-0"
     >


### PR DESCRIPTION
The link on the search page in the recommendation card (_matched user or organization_) was broken. Essentially, it continued to lead to the old path, from which it hadn't been redirected.

The link simply got lost in the flurry of changes, so added a microfix with the new link format