### PR TITLE
fix: visible focus rendering of footer's privacy policy link

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -14,13 +14,13 @@ const isHome = computed(() => route.name === 'index')
           <BuildEnvironment v-if="!isHome" footer />
         </div>
         <!-- Desktop: Show all links. Mobile: Links are in MobileMenu -->
-        <div class="hidden sm:flex items-center gap-6">
+        <div class="hidden sm:flex items-center gap-6 min-h-11">
           <NuxtLink :to="{ name: 'about' }" class="link-subtle font-mono text-xs flex items-center">
             {{ $t('footer.about') }}
           </NuxtLink>
           <NuxtLink
             :to="{ name: 'privacy' }"
-            class="link-subtle font-mono text-xs min-h-11 flex items-center gap-1"
+            class="link-subtle font-mono text-xs flex items-center gap-1"
           >
             {{ $t('privacy_policy.title') }}
           </NuxtLink>


### PR DESCRIPTION
When navigating through the footer elements using the keyboard, the focus rendering for the "Privacy Policy" link differs from other similar links:

https://github.com/user-attachments/assets/3057e984-5e35-45ee-a2fe-dab4f6870926

This happens because the `.min-h-11` class is applied only to this specific link, while the other footer links do not use it.

Since I'm not sure about the expected footer's rendering I preserved the existing layout by moving the `.min-h-11` class from the link itself to its container. This keeps the same minimum height while ensuring consistent focus rendering across all footer links.

After the fix:

https://github.com/user-attachments/assets/81bd4441-1da4-41d8-b623-13b60ed91dd9

