### PR TITLE
feat: update readme toc button to use new component

### DIFF
--- a/app/components/Button/Base.vue
+++ b/app/components/Button/Base.vue
@@ -25,7 +25,7 @@ const el = useTemplateRef('el')
 
 defineExpose({
   focus: () => el.value?.focus(),
-  buttonRef: el,
+  getBoundingClientRect: () => el.value?.getBoundingClientRect(),
 })
 </script>
 

--- a/app/components/ReadmeTocDropdown.vue
+++ b/app/components/ReadmeTocDropdown.vue
@@ -79,8 +79,8 @@ function toggle() {
   if (isOpen.value) {
     close()
   } else {
-    if (triggerRef.value?.buttonRef) {
-      const rect = triggerRef.value.buttonRef.getBoundingClientRect()
+    const rect = triggerRef.value?.getBoundingClientRect()
+    if (rect) {
       dropdownPosition.value = {
         top: rect.bottom + 4,
         right: rect.right,
@@ -101,7 +101,7 @@ function close() {
 function select(id: string) {
   scrollToAnchor(id, { scrollFn: props.scrollToHeading })
   close()
-  triggerRef.value?.buttonRef?.focus()
+  triggerRef.value?.focus()
 }
 
 function getIndex(id: string): number {
@@ -138,7 +138,7 @@ function handleKeydown(event: KeyboardEvent) {
     }
     case 'Escape':
       close()
-      triggerRef.value?.buttonRef?.focus()
+      triggerRef.value?.focus()
       break
   }
 }


### PR DESCRIPTION
Update the README toc button to use the new button components

<img width="813" height="347" alt="image" src="https://github.com/user-attachments/assets/576978b3-3c08-4739-acdf-277a19ec0cc7" />

<details>
<summary>(original description before pr change)</summary>

Add a button to copy raw readme markdown to the clipboard

**screen recording**

https://github.com/user-attachments/assets/2c558744-97f9-4804-8694-48b0850fa854

~~closes #1020~~

~~there is already a PR (https://github.com/npmx-dev/npmx.dev/pull/1058) addressing this iddue, I found that out just before creating this PR, I am opening this PR as there are some subtle design differences, not trying to compete or anything, just for a design consideration, I am okay even if my design is selected but implemented in the first PR.~~

</details>