### PR TITLE
fix: set `org` to empty string to make sure its route param is omitted

### DIFF
--- a/app/utils/router.ts
+++ b/app/utils/router.ts
@@ -1,9 +1,7 @@
 import type { RouteLocationRaw } from 'vue-router'
 
 export function packageRoute(packageName: string, version?: string | null): RouteLocationRaw {
-  const [org, name] = packageName.startsWith('@')
-    ? (packageName.split('/') as [string, string])
-    : ['', packageName]
+  const [org, name = ''] = packageName.startsWith('@') ? packageName.split('/') : ['', packageName]
 
   if (version) {
     return {


### PR DESCRIPTION
fix #1121