### PR TITLE
fix: do not show back button when there is no history

### DIFF
--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -53,6 +53,7 @@ const { data: contributors, status: contributorsStatus } = useFetch<GitHubContri
             type="button"
             class="inline-flex items-center gap-2 font-mono text-sm text-fg-muted hover:text-fg transition-colors duration-200 rounded focus-visible:outline-accent/70 shrink-0"
             @click="router.back()"
+            v-show="router.options.history.state.back !== null"
           >
             <span class="i-carbon:arrow-left rtl-flip w-4 h-4" aria-hidden="true" />
             <span class="hidden sm:inline">{{ $t('nav.back') }}</span>

--- a/app/pages/compare.vue
+++ b/app/pages/compare.vue
@@ -118,6 +118,7 @@ useSeoMeta({
             type="button"
             class="inline-flex items-center gap-2 font-mono text-sm text-fg-muted hover:text-fg transition-colors duration-200 rounded focus-visible:outline-accent/70 shrink-0"
             @click="router.back()"
+            v-show="router.options.history.state.back !== null"
           >
             <span class="i-carbon:arrow-left rtl-flip w-4 h-4" aria-hidden="true" />
             <span class="hidden sm:inline">{{ $t('nav.back') }}</span>

--- a/app/pages/privacy.vue
+++ b/app/pages/privacy.vue
@@ -30,6 +30,7 @@ const { locale } = useI18n()
             type="button"
             class="inline-flex items-center gap-2 font-mono text-sm text-fg-muted hover:text-fg transition-colors duration-200 rounded focus-visible:outline-accent/70 shrink-0"
             @click="router.back()"
+            v-show="router.options.history.state.back !== null"
           >
             <span class="i-carbon:arrow-left rtl-flip w-4 h-4" aria-hidden="true" />
             <span class="sr-only sm:not-sr-only">{{ $t('nav.back') }}</span>

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -52,6 +52,7 @@ const setLocale: typeof setNuxti18nLocale = locale => {
             type="button"
             class="inline-flex items-center gap-2 font-mono text-sm text-fg-muted hover:text-fg transition-colors duration-200 rounded focus-visible:outline-accent/70 shrink-0 p-1.5 -mx-1.5"
             @click="router.back()"
+            v-show="router.options.history.state.back !== null"
           >
             <span class="i-carbon:arrow-left rtl-flip w-4 h-4" aria-hidden="true" />
             <span class="sr-only sm:not-sr-only">{{ $t('nav.back') }}</span>


### PR DESCRIPTION
When users landed on non-home page, there is no router history so nothing happens when clicking the back button.

cf. https://npmx.dev/about vs https://npmxdev-git-fork-shuuji3-fix-hide-back-button-wit-2dbbf1-poetry.vercel.app/about

<img width="1422" height="486" alt="Screenshot of about page, cursor hovering on the back button" src="https://github.com/user-attachments/assets/f700e56f-0166-4fd7-a934-a1766955cb0a" />
