### PR TITLE
fix: update npm username regex to support underscores and dots

### DIFF
--- a/shared/schemas/user.ts
+++ b/shared/schemas/user.ts
@@ -1,6 +1,6 @@
 import * as v from 'valibot'
 
-const NPM_USERNAME_RE = /^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$/i
+const NPM_USERNAME_RE = /^[a-z0-9]([\w.-]*[a-z0-9])?$/i
 const NPM_USERNAME_MAX_LENGTH = 50
 
 /**


### PR DESCRIPTION
### Description

Current regex for npm usernames was restrictive. It was preventing avatars from loading for valid users that contain underscores or dots in their handles, such as rich_harris. I've updated the regex to correctly support these characters.