### PR TITLE
feat: remove space and `@` from user input atproto handle

### DIFF
--- a/app/components/Header/AuthModal.client.vue
+++ b/app/components/Header/AuthModal.client.vue
@@ -22,9 +22,22 @@ async function handleCreateAccount() {
 
 async function handleLogin() {
   if (handleInput.value) {
-    await authRedirect(handleInput.value.trim().replace('@', ''))
+    await authRedirect(handleInput.value)
   }
 }
+
+watch(handleInput, newHandleInput => {
+  if (!newHandleInput) return
+
+  const normalized = newHandleInput
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9.-]/g, '')
+
+  if (normalized !== newHandleInput) {
+    handleInput.value = normalized
+  }
+})
 </script>
 
 <template>


### PR DESCRIPTION
This change prevents common mistakes for atproto handle input. Many apps includes `@`-prefix so users can easily copy their handle with a extra character `@` and sometimes spaces in their UI.

Currenctly, I have to strictly input my handle `shuuji3.xyz`, now I can input ` @shuuji3.xyz `.

<img width="770" height="557" alt="Screenshot of auth modal input is ' @shuuji3.xyz '" src="https://github.com/user-attachments/assets/250e67ec-efca-4aff-b9ba-2b64e675d0f5" />

For reference, this is Bluesky app for `@npmx.dev` profile:

<img width="859" height="350" alt="Screenshot of bluesky profile @npmx.dev including '@' char" src="https://github.com/user-attachments/assets/1a309097-005c-45f0-a67e-ba8eb5a06dc5" />