### PR TITLE
docs: add npmx-weekly to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ We welcome contributions &ndash; please do feel free to explore the project and 
 - [npkg.lorypelli.dev](https://npkg.lorypelli.dev/) &ndash; An alternative frontend to npm made with as little client-side JavaScript as possible
 - [vscode-npmx](https://github.com/npmx-dev/vscode-npmx) &ndash; VSCode extension for npmx
 - [nxjt](https://nxjt.netlify.app) &ndash; npmx Jump To: Quickly navigate to npmx common webpages.
-- [npmx-weekly](https://npmx-weekly.trueberryless.org/) &ndash; A weekly newsletter for the npmx ecosystem.
+- [npmx-weekly](https://npmx-weekly.trueberryless.org/) &ndash; A weekly newsletter for the npmx ecosystem. Add your own content via suggestions in the weekly PR on [GitHub](https://github.com/trueberryless-org/npmx-weekly/pulls?q=is%3Aopen+is%3Apr+label%3A%22%F0%9F%95%94+weekly+post%22).
 - [npmx-digest](https://npmx-digest.trueberryless.org/) &ndash; An automated news aggregation website that summarizes npmx activity from GitHub and Bluesky every 8 hours.
 
 If you're building something cool, let us know! 🙏


### PR DESCRIPTION
Yesterday, I published [npmx.weekly](https://npmx-weekly.trueberryless.org/) (extending the "recap" format of [npmx.digest](https://npmx-digest.trueberryless.org/)). The format is a little bit different (not 100% automated and people can submit their own content in the weekly PR), so I also added one additional sentence explaining the concept shortly. Feel free to leave comments and suggestions if this item should be added elsewhere, rephrased or however you like.

I'll also ping @whitep4nth3r here, as you are the expert regarding any kind of outreach 🙌 