### PR TITLE
fix(ui): avoid README actions to be cropped with visible focus

### DIFF
--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -1292,6 +1292,9 @@ onKeyStroke(
 
 .area-readme {
   grid-area: readme;
+}
+
+.area-readme > .readme {
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
Go to https://npmx.dev/package/nuxt, and focus README actions with your keyboard. You’ll observe that the focus ring is cropped:

<img width="768" height="67" alt="Screenshot 2026-02-07 at 12 13 47" src="https://github.com/user-attachments/assets/c0c3b458-c673-4d9f-a839-4926f762672c" />
<img width="764" height="99" alt="Screenshot 2026-02-07 at 12 13 39" src="https://github.com/user-attachments/assets/39cea899-cc4b-4338-9230-b270e6b13d69" />

This is due to the entire README area having an `overflow-x: hidden`. I suppose this is there to avoid README content to overflow in the page, so I’ve isolated this CSS rule to target only the real README content of this `<div>`, letting the overflow possible for the README actions bar, which gives the following rendering.

<img width="775" height="73" alt="Screenshot 2026-02-07 at 12 13 21" src="https://github.com/user-attachments/assets/cbff0a68-43e9-4afe-82e0-d033d12db942" />
<img width="762" height="95" alt="Screenshot 2026-02-07 at 12 13 15" src="https://github.com/user-attachments/assets/11c83d44-2d86-4bfa-9427-c63c0c5c1551" />
