### PR TITLE
fix: opening package docs in a new tab doesn't work

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -115,8 +115,7 @@ export default defineNuxtConfig({
     '/package/:org/:name/v/:version': { isr: getISRConfig(60, true) },
     // infinite cache (versioned - doesn't change)
     '/package-code/**': { isr: true, cache: { maxAge: 365 * 24 * 60 * 60 } },
-    '/package-docs/:name/v/**': { isr: true, cache: { maxAge: 365 * 24 * 60 * 60 } },
-    '/package-docs/:org/:name/v/**': { isr: true, cache: { maxAge: 365 * 24 * 60 * 60 } },
+    '/package-docs/**': { isr: true, cache: { maxAge: 365 * 24 * 60 * 60 } },
     // static pages
     '/': { prerender: true },
     '/200.html': { prerender: true },


### PR DESCRIPTION
closes #1101 

### Description

simplified the `package-docs` route rules in `nuxt.config` to use a global glob pattern. This fixes an issue where Vercel ISR would incorrectly map path parameters, causing 404s and malformed URLs ([...]) when opening documentation in a new tab.