### PR TITLE
feat: add blog menu item to mobile menu

### DIFF
--- a/app/components/Header/MobileMenu.client.vue
+++ b/app/components/Header/MobileMenu.client.vue
@@ -117,7 +117,7 @@ onUnmounted(deactivate)
                   class="flex items-center gap-3 px-3 py-3 rounded-md font-mono text-sm text-fg hover:bg-bg-subtle transition-colors duration-200"
                   @click="closeMenu"
                 >
-                  <span class="i-carbon:information w-5 h-5 text-fg-muted" aria-hidden="true" />
+                  <span class="i-carbon:blog w-5 h-5 text-fg-muted" aria-hidden="true" />
                   {{ $t('footer.blog') }}
                 </NuxtLink>
 


### PR DESCRIPTION
Added the blog link to the mobile menu, currently in draft in case @whitep4nth3r has some additions I can contribute as a follow-up

Closes #1140 

<img width="537" height="1128" alt="image" src="https://github.com/user-attachments/assets/603ec0a7-67e8-4a6f-ae5b-59b10f145382" />
