### PR TITLE
docs: [WIP] add npmx deployment instructions for self hosting

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,26 @@
+# Deploy your own npmx
+
+The npmx community operates a public instance at [npmx.dev](https://npmx.dev), but is designed to be open and self-hostable by anyone [on any platform that supports Nuxt](https://nuxt.com/deploy).
+
+To deploy your own instance, follow the steps below for your deployment target.
+
+> [!TIP]
+> This page is under construction. More deployment targets are coming soon.
+
+<!-- NOTE: Please list targets alphabetically to remain neutral. -->
+
+## Netlify
+
+1. [Follow the Netlify instructions to import an existing GitHub project](https://docs.netlify.com/start/quickstarts/deploy-from-repository/), selecting https://github.com/npmx-dev/npmx.dev/ when prompted.
+2. Generate a long, random key and set it as an environment variable in your new project called `SESSION_PASSWORD`.
+3. TODO something something Upstash creds?
+4. Run `pnpm remove @vercel/kv && pnpm add @netlify/blobs`
+5. Commit and push this change. This will trigger a successful deploy.
+6. TODO anything else?
+
+## Vercel
+
+1. [Follow the Vercel instructions to import an existing GitHub project](https://vercel.com/docs/getting-started-with-vercel/import), selecting https://github.com/npmx-dev/npmx.dev/ when prompted.
+2. Generate a long, random key and set it as an environment variable in your new project called `SESSION_PASSWORD`.
+3. TODO something something Upstash creds?
+4. TODO anything else?

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ npmx.dev also supports shorter, cleaner URLs:
 - [nuxt-og-image](https://github.com/nuxt-modules/og-image)
 - [npm Registry API](https://github.com/npm/registry/blob/main/docs/REGISTRY-API.md)
 
+## Deploy your own npmx instance
+
+The npmx community operates a public instance at [npmx.dev](https://npmx.dev), but is designed to be open and self-hostable by anyone [on any platform that supports Nuxt](https://nuxt.com/deploy).
+
+To deploy your own instance, follow the instructions in [DEPLOY.md](./DEPLOY.md).
+
 ## Contributing
 
 We welcome contributions &ndash; please do feel free to explore the project and improve things. See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on how to get up and running!


### PR DESCRIPTION
WIP — opening this to track remaining blockers and start drafting docs

## Blockers

- [x] https://github.com/npmx-dev/npmx.dev/pull/1146
- [x] https://github.com/npmx-dev/npmx.dev/pull/1148
- [x] can we avoid needing `pnpm remove @vercel/kv && pnpm add @netlify/blobs`? <br>https://github.com/npmx-dev/npmx.dev/pull/1169
- [x] hardcoded vercel-kv (uses fallback to filesystem caching, but that doesn't work in serverless/short-lived/diskless environments) <br>https://github.com/npmx-dev/npmx.dev/pull/1169
- [ ] deal with hardcoded vercel-runtime-cache (uses fallback to filesystem caching, but that doesn't work in serverless/short-lived/diskless environments)
- [ ] what to do about `modules/isr-fallback.ts`?
- [ ] what to do about redirects in `vercel.json`
- [ ] what to do about Vercel analytics stuff?