### PR TITLE
test: cover frontmatter with pbt

### DIFF
--- a/test/unit/shared/utils/parse-basic-frontmatter.spec.ts
+++ b/test/unit/shared/utils/parse-basic-frontmatter.spec.ts
@@ -150,7 +150,7 @@ describe('parseBasicFrontmatter', () => {
   })
 
   it('should parse back every key-value pair from generated frontmatter', () => {
-    const keyArb = fc.stringMatching(/^[a-z][a-z0-9_]*$/i)
+    const keyArb = fc.stringMatching(/^[a-z]\w*$/i)
     const singleValueArbs = (inArray: boolean) =>
       // for arrays: all values get parsed as strings and there should not be any comma in the value even for quoted strings
       [


### PR DESCRIPTION
I'm continuing my work on extending the usage of property based testing via fast-check to other parts of the codebase. Lately I wanted to play with `parseBasicFrontmatter`. Given it was covered by classical tests I believed it was something useful to cover and make fully reliable.

To date, I started with a very first version of a property based test. But it found some behaviors I was not expecting to encountered so I filtered some. Before continuing and cleaning up this PBT test that is now more and more complex to handle some edge-cases that might be bug I want to know if these edge-cases are expected or not.

In this PR, all the tests added without PBT are responsible to capture on of the edge-cases. The tests using `it` are green, the ones with `it.fails` are red if we drop the `.fails`. Are these results expected?