### PR TITLE
fix: navigating to org page from search leads to 404 page

### DIFF
--- a/app/composables/npm/useOrgPackages.ts
+++ b/app/composables/npm/useOrgPackages.ts
@@ -92,11 +92,11 @@ export function useOrgPackages(orgName: MaybeRefOrGetter<string>) {
       // Get all package names in the org
       let packageNames: string[]
       try {
-        const { data } = await $npmRegistry<Record<string, string>>(
-          `/-/org/${encodeURIComponent(org)}/package`,
+        const { packages } = await $fetch<{ packages: string[]; count: number }>(
+          `/api/registry/org/${encodeURIComponent(org)}/packages`,
           { signal },
         )
-        packageNames = Object.keys(data)
+        packageNames = packages
       } catch (err) {
         // Check if this is a 404 (org not found)
         if (err && typeof err === 'object' && 'statusCode' in err && err.statusCode === 404) {


### PR DESCRIPTION
## Bug

See #1190.

## Fix

Org packages are fetched from the npm registry api (`/-/org/{org}/package`) in two places:

1. Server route `/api/registry/org/[org]/packages.get.ts`: calls `$fetch('https://registry.npmjs.org/-/org/{org}/package')`
2. Client composable `useOrgPackages()`: calls `$npmRegistry('/-/org/{org}/package')`

The composable bypasses the server route, duplicating the registry call, org name encoding, and error handling, and bypassing the important server-side caching. But most importantly, calls to the registry from the client fail with a CORS error, since the registry doesn't allow cross-origin requests from browsers.

Fixes #1190.

## QA

Note: if you try this fix, please note that if you use an org that has many packages you'll likely run into a separate issue that prints a ton of 429s (with CORS errors) in your browser console. This is a separate latent issue. Let's fix that in a separate PR 😅.