### PR TITLE
fix: only show error in claim package modal if checkResult is null

### DIFF
--- a/app/components/Package/ClaimPackageModal.vue
+++ b/app/components/Package/ClaimPackageModal.vue
@@ -36,7 +36,7 @@ const isChecking = computed(() => {
 })
 
 const mergedError = computed(() => {
-  return checkResult !== null
+  return checkResult.value !== null
     ? null
     : (publishError.value ??
         (checkError.value instanceof Error


### PR DESCRIPTION
The claim package modal has a default error message that persists even after the package name is validated.

<img width="479" height="461" alt="Screenshot 2026-02-07 at 17 39 51" src="https://github.com/user-attachments/assets/d6e9e6c4-ad76-4e23-9e13-70f1624612db" />

This pull checks if the checkResult variable is null before presenting the mergedError message
