### PR TITLE
fix: surfacing 429s as not found to users

### DIFF
--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -72,6 +72,7 @@ const {
   isLoadingMore,
   hasMore,
   fetchMore,
+  isRateLimited,
 } = useNpmSearch(query, () => ({
   size: requestedSize.value,
   incremental: true,
@@ -706,8 +707,15 @@ defineOgImageComponent('Default', {
             </button>
           </div>
 
+          <!-- Rate limited by npm - check FIRST before showing any results -->
+          <div v-if="isRateLimited" role="status" class="py-12">
+            <p class="text-fg-muted font-mono mb-6 text-center">
+              {{ $t('search.rate_limited') }}
+            </p>
+          </div>
+
           <!-- Enhanced toolbar -->
-          <div v-if="visibleResults.total > 0" class="mb-6">
+          <div v-else-if="visibleResults.total > 0" class="mb-6">
             <PackageListToolbar
               :filters="filters"
               v-model:sort-option="sortOption"
@@ -805,7 +813,7 @@ defineOgImageComponent('Default', {
           </div>
 
           <PackageList
-            v-if="displayResults.length > 0"
+            v-if="displayResults.length > 0 && !isRateLimited"
             :results="displayResults"
             :search-query="query"
             :filters="filters"
@@ -828,7 +836,7 @@ defineOgImageComponent('Default', {
 
           <!-- Pagination controls -->
           <PaginationControls
-            v-if="displayResults.length > 0"
+            v-if="displayResults.length > 0 && !isRateLimited"
             v-model:mode="paginationMode"
             v-model:page-size="preferredPageSize"
             v-model:current-page="currentPage"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -25,6 +25,7 @@
     "found_packages": "No packages found | Found 1 package | Found {count} packages",
     "updating": "(updating...)",
     "no_results": "No packages found for \"{query}\"",
+    "rate_limited": "Hit npm rate limit, try again in a moment",
     "title": "search",
     "title_search": "search: {search}",
     "title_packages": "search packages",

--- a/lunaria/files/en-GB.json
+++ b/lunaria/files/en-GB.json
@@ -25,6 +25,7 @@
     "found_packages": "No packages found | Found 1 package | Found {count} packages",
     "updating": "(updating...)",
     "no_results": "No packages found for \"{query}\"",
+    "rate_limited": "Hit npm rate limit, try again in a moment",
     "title": "search",
     "title_search": "search: {search}",
     "title_packages": "search packages",

--- a/lunaria/files/en-US.json
+++ b/lunaria/files/en-US.json
@@ -25,6 +25,7 @@
     "found_packages": "No packages found | Found 1 package | Found {count} packages",
     "updating": "(updating...)",
     "no_results": "No packages found for \"{query}\"",
+    "rate_limited": "Hit npm rate limit, try again in a moment",
     "title": "search",
     "title_search": "search: {search}",
     "title_packages": "search packages",


### PR DESCRIPTION
Resolves: #1174 

This is a speculative PR which changes the approach to surface an explicit "Hit npm rate limit, try again in a moment" message when 429s happen. I wondered if this would be useful?

<img width="1849" height="822" alt="image" src="https://github.com/user-attachments/assets/60aa1ddd-4841-440c-9aac-73fb1b243116" />

No worries if it's not - but I thought I'd share the idea! This doesn't contain all i18n locales. If the approach is helpful I think with AIs help I can probably provide that.

PS first time doing any Vue / Nuxt - please bear with my mistakes!