### PR TITLE
chore: add proper types to OgImage `Package.d.vue.ts` workaround

### DIFF
--- a/app/components/OgImage/Package.d.vue.ts
+++ b/app/components/OgImage/Package.d.vue.ts
@@ -1,3 +1,16 @@
-declare const _default: any
+// This type declaration file is required to break a circular type resolution in vue-tsc.
+//
+// nuxt-og-image generates a type declaration (.nuxt/module/nuxt-og-image.d.ts) that imports
+// this component's type. This creates a cycle: nuxt.d.ts → nuxt-og-image.d.ts → Package.vue →
+// needs auto-import globals from nuxt.d.ts. Without this file, vue-tsc resolves the component
+// before the globals are available, so all auto-imports (computed, toRefs, useFetch, etc.) fail.
+
+import type { DefineComponent } from 'vue'
+
+declare const _default: DefineComponent<{
+  name: string
+  version: string
+  primaryColor?: string
+}>
 
 export default _default


### PR DESCRIPTION
It appears this file was here to break a circular type resolution. `nuxt-og-image` generates a type declaration that imports `Package.vue type`, which needs auto-import globals from `nuxt.d.ts`, which needs the `nuxt-og-image` type declaration, creating a cycle.

The old file used `any` which was a band-aid. I couldn't come up with a way to remove this file entirely, but this at least types the component props so consumers still get real type-checking.