### PR TITLE
chore: don't warn for unmocked `data:` URLs

### DIFF
--- a/modules/runtime/server/cache.ts
+++ b/modules/runtime/server/cache.ts
@@ -710,12 +710,17 @@ export default defineNitroPlugin(nitroApp => {
   const originalFetch = globalThis.fetch
   const original$fetch = globalThis.$fetch
 
-  // Override native fetch for esm.sh requests
+  // Override native fetch for esm.sh requests and to inject test fixture responses
   globalThis.fetch = async (input: URL | RequestInfo, init?: RequestInit): Promise<Response> => {
     const urlStr =
       typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
 
-    if (urlStr.startsWith('/') || urlStr.includes('woff') || urlStr.includes('fonts')) {
+    if (
+      urlStr.startsWith('/') ||
+      urlStr.startsWith('data:') ||
+      urlStr.includes('woff') ||
+      urlStr.includes('fonts')
+    ) {
       return await originalFetch(input, init)
     }
 


### PR DESCRIPTION
I noticed this in test logs:

```
[WebServer] [test-fixtures] NO FIXTURE PATTERN
[WebServer] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
[WebServer] URL does not match any known fixture pattern
[WebServer] URL: data:application/octet-stream;base64,AGFzbQEAAAABugM3YAF/AGACf38AYAF/AX9gA39/fwBgAn98AGACf38Bf2ADf39/AX9gBH9/[...snip...]
````

This isn't an actual network request, so we should ignore it.