### PR TITLE
fix: update replacement "Learn more" link to e18e docs

### DIFF
--- a/app/components/Package/Replacement.vue
+++ b/app/components/Package/Replacement.vue
@@ -12,7 +12,7 @@ const mdnUrl = computed(() => {
 
 const docPath = computed(() => {
   if (props.replacement.type !== 'documented' || !props.replacement.docPath) return null
-  return `https://github.com/es-tooling/module-replacements/blob/main/docs/modules/${props.replacement.docPath}.md`
+  return `https://e18e.dev/docs/replacements/${props.replacement.docPath}`
 })
 </script>
 


### PR DESCRIPTION
This replaces the docs link from the source GitHub Markdown page to the e18e docs page. The later renders the diff highlight properly.

Example package: https://npmxdev-git-fork-shuuji3-fix-user-e18e-docs-link-npmx.vercel.app/package/path-exists

The "Learn more" link target:
- Before: https://github.com/es-tooling/module-replacements/blob/main/docs/modules/path-exists.md
- After: https://e18e.dev/docs/replacements/path-exists