### PR TITLE
feat: add pnpm and yarn engine icons

### DIFF
--- a/app/components/Package/Compatibility.vue
+++ b/app/components/Package/Compatibility.vue
@@ -14,6 +14,8 @@ const engineIcons: Record<string, string> = {
   bun: 'i-simple-icons:bun',
   node: 'i-simple-icons:nodedotjs',
   npm: 'i-simple-icons:npm',
+  pnpm: 'i-simple-icons:pnpm',
+  yarn: 'i-simple-icons:yarn',
 }
 
 function getName(engine: string): string {


### PR DESCRIPTION
I noticed there's no engine icon for pnpm in the astro page, so I added it here. And I added yarn too because why not.

https://npmx.dev/package/astro

<img width="342" height="167" alt="image" src="https://github.com/user-attachments/assets/fdfab5fd-4633-4395-b17b-304d0418c884" />
