### PR TITLE
chore: reduce uncaught errors in prod

### DIFF
--- a/server/utils/atproto/oauth.ts
+++ b/server/utils/atproto/oauth.ts
@@ -67,7 +67,10 @@ async function getOAuthSession(
     })
 
     const currentSession = serverSession.data
-    if (!currentSession) return { oauthSession: undefined, serverSession }
+    // TODO (jg): why can a session be `{}`?
+    if (!currentSession || !currentSession.public?.did) {
+      return { oauthSession: undefined, serverSession }
+    }
 
     const oauthSession = await client.restore(currentSession.public.did)
     return { oauthSession, serverSession }

--- a/server/utils/docs/client.ts
+++ b/server/utils/docs/client.ts
@@ -9,6 +9,7 @@
 
 import { doc, type DocNode } from '@deno/doc'
 import type { DenoDocNode, DenoDocResult } from '#shared/types/deno-doc'
+import { isBuiltin } from 'node:module'
 
 // =============================================================================
 // Configuration
@@ -81,12 +82,9 @@ function createLoader(): (
     _cacheSetting?: string,
     _checksum?: string,
   ) => {
-    let url: URL
-    try {
-      url = new URL(specifier)
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.error(e)
+    const url = URL.parse(specifier)
+
+    if (url === null) {
       return undefined
     }
 
@@ -139,7 +137,11 @@ function createResolver(): (specifier: string, referrer: string) => string {
     }
 
     // Handle bare specifiers - resolve through esm.sh
-    if (!specifier.startsWith('http://') && !specifier.startsWith('https://')) {
+    if (
+      !specifier.startsWith('http://') &&
+      !specifier.startsWith('https://') &&
+      !isBuiltin(specifier)
+    ) {
       // Try to resolve bare specifier relative to esm.sh base
       const baseUrl = new URL(referrer)
       if (baseUrl.hostname === 'esm.sh') {

--- a/shared/types/userSession.ts
+++ b/shared/types/userSession.ts
@@ -1,15 +1,17 @@
 import type { NodeSavedSession, NodeSavedState } from '@atproto/oauth-client-node'
 
 export interface UserServerSession {
-  public: {
-    did: string
-    handle: string
-    pds: string
-    avatar?: string
-  }
+  public?:
+    | {
+        did: string
+        handle: string
+        pds: string
+        avatar?: string
+      }
+    | undefined
   // Only to be used in the atproto session and state stores
   // Will need to change to Record<string, T> and add a current logged in user if we ever want to support
   // multiple did logins per server session
-  oauthSession: NodeSavedSession | undefined
-  oauthState: NodeSavedState | undefined
+  oauthSession?: NodeSavedSession | undefined
+  oauthState?: NodeSavedState | undefined
 }


### PR DESCRIPTION
This adds a couple of minor fixes for reducing errors we're seeing in
production:

- Sessions can be `{}`, in which case, our types are incorrect
- When a module imports a built-in, the docs resolver tries to load it
  from `esm.sh`
- Use `URL.parse` instead of a try/catch
