### PR TITLE
fix: use e18e docs for replacements

### DIFF
--- a/app/components/Compare/ReplacementSuggestion.vue
+++ b/app/components/Compare/ReplacementSuggestion.vue
@@ -16,8 +16,7 @@ const emit = defineEmits<{
 
 const docUrl = computed(() => {
   if (props.replacement.type !== 'documented' || !props.replacement.docPath) return null
-  // TODO(serhalp): Once the e18e docs site is complete, link there instead
-  return `https://github.com/es-tooling/module-replacements/blob/main/docs/modules/${props.replacement.docPath}.md`
+  return `https://e18e.dev/docs/replacements/${props.replacement.docPath}.html`
 })
 </script>
 

--- a/app/components/Package/Replacement.vue
+++ b/app/components/Package/Replacement.vue
@@ -12,7 +12,7 @@ const mdnUrl = computed(() => {
 
 const docPath = computed(() => {
   if (props.replacement.type !== 'documented' || !props.replacement.docPath) return null
-  return `https://e18e.dev/docs/replacements/${props.replacement.docPath}`
+  return `https://e18e.dev/docs/replacements/${props.replacement.docPath}.html`
 })
 </script>
 


### PR DESCRIPTION
We recently changed the replacement notice to link to e18e, this is just
one we missed.
