### PR TITLE
fix: restore rows truncates in package page

### DIFF
--- a/app/components/Link/Base.vue
+++ b/app/components/Link/Base.vue
@@ -12,6 +12,7 @@ const props = withDefaults(
       'type'?: never
       'variant'?: 'button-primary' | 'button-secondary' | 'link'
       'size'?: 'small' | 'medium'
+      'iconSize'?: 'sm' | 'md' | 'lg'
 
       'keyshortcut'?: string
 
@@ -51,11 +52,21 @@ const isLinkAnchor = computed(
   () => !!props.to && typeof props.to === 'string' && props.to.startsWith('#'),
 )
 
+const ICON_SIZE_MAP = {
+  sm: 'size-3 min-w-3',
+  md: 'size-4 min-w-4',
+  lg: 'size-5 min-w-5',
+}
+
 /** size is only applicable for button like links */
 const isLink = computed(() => props.variant === 'link')
 const isButton = computed(() => props.variant !== 'link')
 const isButtonSmall = computed(() => props.size === 'small' && props.variant !== 'link')
 const isButtonMedium = computed(() => props.size === 'medium' && props.variant !== 'link')
+
+const iconSizeClass = computed(
+  () => ICON_SIZE_MAP[props.iconSize || (isButtonSmall.value && 'sm') || 'md'],
+)
 </script>
 
 <template>
@@ -89,11 +100,7 @@ const isButtonMedium = computed(() => props.size === 'medium' && props.variant !
     :aria-keyshortcuts="keyshortcut"
     :target="isLinkExternal ? '_blank' : undefined"
   >
-    <span
-      v-if="classicon"
-      :class="[isButtonSmall ? 'size-3' : 'size-4', classicon]"
-      aria-hidden="true"
-    />
+    <span v-if="classicon" class="me-1" :class="[iconSizeClass, classicon]" aria-hidden="true" />
     <slot />
     <!-- automatically show icon indicating external link -->
     <span

--- a/app/components/Package/Dependencies.vue
+++ b/app/components/Package/Dependencies.vue
@@ -91,7 +91,7 @@ const numberFormatter = useNumberFormatter()
           :key="dep"
           class="flex items-center justify-between py-1 text-sm gap-2"
         >
-          <LinkBase :to="packageRoute(dep)" dir="ltr">
+          <LinkBase :to="packageRoute(dep)" class="block truncate" dir="ltr">
             {{ dep }}
           </LinkBase>
           <span class="flex items-center gap-1 max-w-[40%]" dir="ltr">
@@ -125,7 +125,7 @@ const numberFormatter = useNumberFormatter()
             </LinkBase>
             <LinkBase
               :to="packageRoute(dep, version)"
-              class="truncate"
+              class="block truncate"
               :class="getVersionClass(outdatedDeps[dep])"
               :title="outdatedDeps[dep] ? getOutdatedTooltip(outdatedDeps[dep], $t) : version"
             >
@@ -175,7 +175,7 @@ const numberFormatter = useNumberFormatter()
           class="flex items-center justify-between py-1 text-sm gap-1 min-w-0"
         >
           <div class="flex items-center gap-1 min-w-0 flex-1">
-            <LinkBase :to="packageRoute(peer.name)" class="truncate" dir="ltr">
+            <LinkBase :to="packageRoute(peer.name)" class="block truncate" dir="ltr">
               {{ peer.name }}
             </LinkBase>
             <TagStatic v-if="peer.optional" :title="$t('package.dependencies.optional')">
@@ -184,7 +184,7 @@ const numberFormatter = useNumberFormatter()
           </div>
           <LinkBase
             :to="packageRoute(peer.name, peer.version)"
-            class="truncate"
+            class="block truncate max-w-[40%]"
             :title="peer.version"
             dir="ltr"
           >
@@ -236,10 +236,15 @@ const numberFormatter = useNumberFormatter()
           :key="dep"
           class="flex items-center justify-between py-1 text-sm gap-2"
         >
-          <LinkBase :to="packageRoute(dep)" class="truncate" dir="ltr">
+          <LinkBase :to="packageRoute(dep)" class="block truncate" dir="ltr">
             {{ dep }}
           </LinkBase>
-          <LinkBase :to="packageRoute(dep, version)" class="truncate" :title="version" dir="ltr">
+          <LinkBase
+            :to="packageRoute(dep, version)"
+            class="block truncate"
+            :title="version"
+            dir="ltr"
+          >
             {{ version }}
           </LinkBase>
         </li>

--- a/app/components/Package/Versions.vue
+++ b/app/components/Package/Versions.vue
@@ -357,7 +357,7 @@ function getTagVersions(tag: string): VersionDisplay[] {
               <div>
                 <LinkBase
                   :to="versionRoute(row.primaryVersion.version)"
-                  class="text-sm"
+                  class="text-sm block truncate"
                   :class="
                     row.primaryVersion.deprecated ? 'text-red-400 hover:text-red-300' : undefined
                   "
@@ -369,6 +369,7 @@ function getTagVersions(tag: string): VersionDisplay[] {
                       : row.primaryVersion.version
                   "
                   :classicon="row.primaryVersion.deprecated ? 'i-carbon-warning-hex' : undefined"
+                  icon-size="sm"
                 >
                   <span dir="ltr">
                     {{ row.primaryVersion.version }}
@@ -414,7 +415,7 @@ function getTagVersions(tag: string): VersionDisplay[] {
             <div class="flex items-center justify-between gap-2">
               <LinkBase
                 :to="versionRoute(v.version)"
-                class="text-xs truncate"
+                class="text-xs block truncate"
                 :class="v.deprecated ? 'text-red-400 hover:text-red-300' : undefined"
                 :title="
                   v.deprecated
@@ -422,6 +423,7 @@ function getTagVersions(tag: string): VersionDisplay[] {
                     : v.version
                 "
                 :classicon="v.deprecated ? 'i-carbon-warning-hex' : undefined"
+                icon-size="sm"
               >
                 <span dir="ltr">
                   {{ v.version }}
@@ -511,7 +513,7 @@ function getTagVersions(tag: string): VersionDisplay[] {
             <div class="flex items-center justify-between gap-2">
               <LinkBase
                 :to="versionRoute(row.primaryVersion.version)"
-                class="text-xs truncate"
+                class="text-xs block truncate"
                 :class="
                   row.primaryVersion.deprecated ? 'text-red-400 hover:text-red-300' : undefined
                 "
@@ -523,6 +525,7 @@ function getTagVersions(tag: string): VersionDisplay[] {
                     : row.primaryVersion.version
                 "
                 :classicon="row.primaryVersion.deprecated ? 'i-carbon-warning-hex' : undefined"
+                icon-size="sm"
               >
                 <span dir="ltr">
                   {{ row.primaryVersion.version }}
@@ -583,7 +586,7 @@ function getTagVersions(tag: string): VersionDisplay[] {
                     <LinkBase
                       v-if="group.versions[0]?.version"
                       :to="versionRoute(group.versions[0]?.version)"
-                      class="text-xs truncate"
+                      class="text-xs block truncate"
                       :class="
                         group.versions[0]?.deprecated
                           ? 'text-red-400 hover:text-red-300'
@@ -599,6 +602,7 @@ function getTagVersions(tag: string): VersionDisplay[] {
                       :classicon="
                         group.versions[0]?.deprecated ? 'i-carbon-warning-hex' : undefined
                       "
+                      icon-size="sm"
                     >
                       <span dir="ltr">
                         {{ group.versions[0]?.version }}
@@ -644,7 +648,7 @@ function getTagVersions(tag: string): VersionDisplay[] {
                     <LinkBase
                       v-if="group.versions[0]?.version"
                       :to="versionRoute(group.versions[0]?.version)"
-                      class="text-xs truncate"
+                      class="text-xs block truncate"
                       :class="
                         group.versions[0]?.deprecated
                           ? 'text-red-400 hover:text-red-300'
@@ -660,6 +664,7 @@ function getTagVersions(tag: string): VersionDisplay[] {
                       :classicon="
                         group.versions[0]?.deprecated ? 'i-carbon-warning-hex' : undefined
                       "
+                      icon-size="sm"
                     >
                       <span dir="ltr">
                         {{ group.versions[0]?.version }}
@@ -703,7 +708,7 @@ function getTagVersions(tag: string): VersionDisplay[] {
                   <div class="flex items-center justify-between gap-2">
                     <LinkBase
                       :to="versionRoute(v.version)"
-                      class="text-xs truncate"
+                      class="text-xs block truncate"
                       :class="v.deprecated ? 'text-red-400 hover:text-red-300' : undefined"
                       :title="
                         v.deprecated


### PR DESCRIPTION
There's a degradation on the packages page, causing some truncates to be lost.

Mostly, we simply forgot during the changes queue that it's necessary to specify "block" for truncate to work correctly. Some places got lost in the change. I checked that PRs and did a little searching - I think I've found all cases

There's also a slight downgrade in the icon - it's gotten too big and lost its indentation in the dependencies section. Fixed this too - it slightly messed up the component patterns, but I think we'll come back to work on the UI and update it there