### PR TITLE
fix: adjust badge api caching strategy

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -88,6 +88,13 @@ export default defineNuxtConfig({
   routeRules: {
     // API routes
     '/api/**': { isr: 60 },
+    '/api/registry/badge/**': {
+      isr: {
+        expiration: 60 * 60 /* one hour */,
+        passQuery: true,
+        allowQuery: ['color', 'labelColor', 'label', 'name'],
+      },
+    },
     '/api/registry/docs/**': { isr: true, cache: { maxAge: 365 * 24 * 60 * 60 } },
     '/api/registry/file/**': { isr: true, cache: { maxAge: 365 * 24 * 60 * 60 } },
     '/api/registry/provenance/**': { isr: true, cache: { maxAge: 365 * 24 * 60 * 60 } },


### PR DESCRIPTION
Currently, modifying the query parameters in the badge API will not update the returned content.