### PR TITLE
chore: rearrange footer items

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -23,22 +23,9 @@ const showModal = () => modalRef.value?.showModal?.()
           <LinkBase :to="{ name: 'privacy' }">
             {{ $t('privacy_policy.title') }}
           </LinkBase>
-          <LinkBase to="https://docs.npmx.dev">
-            {{ $t('footer.docs') }}
-          </LinkBase>
-          <LinkBase to="https://repo.npmx.dev">
-            {{ $t('footer.source') }}
-          </LinkBase>
-          <LinkBase to="https://social.npmx.dev">
-            {{ $t('footer.social') }}
-          </LinkBase>
-          <LinkBase to="https://chat.npmx.dev">
-            {{ $t('footer.chat') }}
-          </LinkBase>
-
           <button
             type="button"
-            class="group inline-flex gap-x-1 items-center justify-center underline-offset-[0.2rem] underline decoration-1 decoration-fg/30 font-mono text-fg hover:(decoration-accent text-accent) focus-visible:(decoration-accent text-accent) transition-colors duration-200"
+            class="cursor-pointer group inline-flex gap-x-1 items-center justify-center underline-offset-[0.2rem] underline decoration-1 decoration-fg/30 font-mono text-fg hover:(decoration-accent text-accent) focus-visible:(decoration-accent text-accent) transition-colors duration-200"
             @click.prevent="showModal"
             aria-haspopup="dialog"
           >
@@ -102,6 +89,18 @@ const showModal = () => modalRef.value?.showModal?.()
               </li>
             </ul>
           </Modal>
+          <LinkBase to="https://docs.npmx.dev">
+            {{ $t('footer.docs') }}
+          </LinkBase>
+          <LinkBase to="https://repo.npmx.dev">
+            {{ $t('footer.source') }}
+          </LinkBase>
+          <LinkBase to="https://social.npmx.dev">
+            {{ $t('footer.social') }}
+          </LinkBase>
+          <LinkBase to="https://chat.npmx.dev">
+            {{ $t('footer.chat') }}
+          </LinkBase>
         </div>
       </div>
       <BuildEnvironment v-if="!isHome" footer />


### PR DESCRIPTION
There is one thing I want to say. We've added keyboard shortcuts in footer recently. Now in footer some items are related to within our app like about, privacy policy. Some footer items are external links which open in a new tab like docs.npmx.dev, chat.npmx.dev etc. And external links have also icon in the footer so that we can understand it is external. I think keyboard shortcuts is not external things. So I think we can group it together with the internal footer items like about and privacy policy. But currently keyboard shortcuts is with external links. So I think maybe it looks better if we rearrange this. 

 Before:
<img width="1146" height="323" alt="before" src="https://github.com/user-attachments/assets/6f35a7b0-46a4-48cc-9290-61f3e4d9abeb" />

After:
<img width="1146" height="323" alt="now" src="https://github.com/user-attachments/assets/1337fde3-c15c-4c9f-b841-d6acb5cbbbe4" />
