### PR TITLE
chore: remove shadow and border accent

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -100,7 +100,7 @@ defineOgImageComponent('Default', {
                 <ButtonBase
                   type="submit"
                   variant="primary"
-                  class="absolute inset-ie-2"
+                  class="absolute inset-ie-2 border-transparent"
                   classicon="i-carbon:search"
                 >
                   <span class="sr-only sm:not-sr-only">


### PR DESCRIPTION
Look, the search button has some shadow and border accent. I think we can improve it. 

Before:
<img width="765" height="301" alt="wrong" src="https://github.com/user-attachments/assets/d57812ce-788c-4ae3-829b-60afbe013118" />

After:
<img width="786" height="336" alt="right" src="https://github.com/user-attachments/assets/37426b2d-ee36-4cc4-b297-715ee8693d43" />
