### PR TITLE
fix: cancel input blur when input is refocused

### DIFF
--- a/app/components/Compare/PackageSelector.vue
+++ b/app/components/Compare/PackageSelector.vue
@@ -92,10 +92,17 @@ function handleKeydown(e: KeyboardEvent) {
   }
 }
 
+const { start, stop } = useTimeoutFn(() => {
+  isInputFocused.value = false
+}, 200)
+
 function handleBlur() {
-  useTimeoutFn(() => {
-    isInputFocused.value = false
-  }, 200)
+  start()
+}
+
+function handleFocus() {
+  stop()
+  isInputFocused.value = true
 }
 </script>
 
@@ -151,7 +158,7 @@ function handleBlur() {
           size="medium"
           class="w-full min-w-25 ps-7"
           aria-autocomplete="list"
-          @focus="isInputFocused = true"
+          @focus="handleFocus"
           @blur="handleBlur"
           @keydown="handleKeydown"
         />


### PR DESCRIPTION
It was possible that the "stale" blur set `isInputFocused` to false, when refocused in under 200ms.

Before:


https://github.com/user-attachments/assets/1540a3bf-019f-4231-adad-c81b4c0c1c76


After:



https://github.com/user-attachments/assets/f5ebbab3-ced8-4c91-997d-c088e7bc24f8



cc @serhalp calling `useTimeoutFn` inside of `handleBlur` recreates the `isPending` ref on each call resulting in a small memory leak.