### PR TITLE
fix(ui): hide text on mobile devices to prevent inconsistent display on small screens

### DIFF
--- a/app/components/ColumnPicker.vue
+++ b/app/components/ColumnPicker.vue
@@ -77,7 +77,7 @@ function handleReset() {
       @click.stop="isOpen = !isOpen"
       classicon="i-carbon-column"
     >
-      {{ $t('filters.columns.title') }}
+      <span class="sr-only sm:not-sr-only">{{ $t('filters.columns.title') }}</span>
     </ButtonBase>
 
     <Transition name="dropdown">


### PR DESCRIPTION
related: #1244 

Currently, the "Columns" button text in the table view toolbar may cause layout overflow on small screens, especially in languages ​​with longer translated text.

My proposed solution is to display it as an icon button while ensuring that screen readers can still access the corresponding content.

What are your thoughts on this? If everyone agrees with my suggestion, I will proceed with refining this PR.

<details>
<summary>before</summary>
<img width="563" height="1001" alt="ac465657-ed1b-4f3b-bb0d-7cc0abab0b64" src="https://github.com/user-attachments/assets/4383043a-92d3-4019-98dd-6e17c679320b" />
<img width="563" height="1001" alt="771c943b-9151-478b-ad24-08a32c364501" src="https://github.com/user-attachments/assets/ebfc2826-772f-4bb5-944a-283d2ff20225" />
<img width="563" height="1001" alt="6782fff9-990e-4208-9650-a927ba578d8b" src="https://github.com/user-attachments/assets/cf1bb3cb-f778-4857-b7fb-7c6d9afca4de" />
</details>

<details>
<summary>after</summary>
<img width="563" height="1001" alt="image" src="https://github.com/user-attachments/assets/5b886bda-815d-4ba4-a267-bf834a5ab004" />
</details>