### PR TITLE
fix(ui): add padding for dependencies + peerDeps

### DIFF
--- a/app/components/Package/Dependencies.vue
+++ b/app/components/Package/Dependencies.vue
@@ -85,7 +85,7 @@ const numberFormatter = useNumberFormatter()
         )
       "
     >
-      <ul class="space-y-1 list-none m-0" :aria-label="$t('package.dependencies.list_label')">
+      <ul class="px-1 space-y-1 list-none m-0" :aria-label="$t('package.dependencies.list_label')">
         <li
           v-for="[dep, version] in sortedDependencies.slice(0, depsExpanded ? undefined : 10)"
           :key="dep"
@@ -168,7 +168,10 @@ const numberFormatter = useNumberFormatter()
         })
       "
     >
-      <ul class="space-y-1 list-none m-0" :aria-label="$t('package.peer_dependencies.list_label')">
+      <ul
+        class="px-1 space-y-1 list-none m-0"
+        :aria-label="$t('package.peer_dependencies.list_label')"
+      >
         <li
           v-for="peer in sortedPeerDependencies.slice(0, peerDepsExpanded ? undefined : 10)"
           :key="peer.name"
@@ -225,7 +228,7 @@ const numberFormatter = useNumberFormatter()
       "
     >
       <ul
-        class="space-y-1 list-none m-0"
+        class="px-1 space-y-1 list-none m-0"
         :aria-label="$t('package.optional_dependencies.list_label')"
       >
         <li


### PR DESCRIPTION
On the right-hand side, several collapsible sections are displayed. Among these, the simpler ones (containing only a list of strings or links) show inconsistent left-alignment between the `Dependencies.vue` component and the corresponding "Maintainers" rendering.

<img width="194" height="637" alt="Screenshot 2026-02-09 at 20 14 19" src="https://github.com/user-attachments/assets/a5b988cd-7f04-4218-8749-5b11398412ac" />

This also reveals another issue affecting the rendering of the dependencies lists (regular, optional, and peer) when navigating with the keyboard: the focus styles appear clipped.

<img width="355" height="120" alt="Screenshot 2026-02-09 at 20 27 19" src="https://github.com/user-attachments/assets/e7251d96-685e-445b-81b6-0f75cd876f75" />
<img width="341" height="105" alt="Screenshot 2026-02-09 at 20 27 21" src="https://github.com/user-attachments/assets/4f1483fa-e5fe-4983-938a-f2a5bfe45b12" />

Since the `CollapsibleSection` component uses `.overflow-hidden`, a simple fix may be to apply the same `.px-1` padding used in the "Maintainers" list rendering.
