### PR TITLE
fix: convert anchor links in readme content to lowercase

### DIFF
--- a/server/utils/readme.ts
+++ b/server/utils/readme.ts
@@ -384,7 +384,9 @@ ${html}
       })
     }
 
-    return `<a href="${resolvedHref}"${titleAttr}${relAttr}${targetAttr}>${text}</a>`
+    const hrefValue = resolvedHref.startsWith('#') ? resolvedHref.toLowerCase() : resolvedHref
+
+    return `<a href="${hrefValue}"${titleAttr}${relAttr}${targetAttr}>${text}</a>`
   }
 
   // GitHub-style callouts: > [!NOTE], > [!TIP], etc.


### PR DESCRIPTION
This fixes #1008 for now, but later we should consider preserving text casing for anchor links for better compatibility.


* Generated TOC dropdown works
* Inline TOC works

Examples

* https://npmxdev-git-fork-thasmo-readme-lowercase-anchor-links-npmx.vercel.app/package/nuxt
* https://npmxdev-git-fork-thasmo-readme-lowercase-anchor-links-npmx.vercel.app/package/@wojtekmaj/opening-hours-utils

