### PR TITLE
fix: remove block from flex elements

### DIFF
--- a/app/components/Compare/PackageSelector.vue
+++ b/app/components/Compare/PackageSelector.vue
@@ -185,7 +185,7 @@ function handleFocus() {
             :aria-label="$t('compare.no_dependency.add_column')"
             @click="addPackage(NO_DEPENDENCY_ID)"
           >
-            <span class="text-sm text-accent italic flex items-center gap-2 block">
+            <span class="text-sm text-accent italic flex items-center gap-2">
               <span class="i-carbon:clean w-4 h-4" aria-hidden="true" />
               {{ $t('compare.no_dependency.typeahead_title') }}
             </span>

--- a/app/components/Package/DeprecatedTree.vue
+++ b/app/components/Package/DeprecatedTree.vue
@@ -53,7 +53,7 @@ function getDepthStyle(depth: DependencyDepth) {
         aria-controls="deprecated-tree-details"
         @click="isExpanded = !isExpanded"
       >
-        <span class="flex items-center gap-2 min-w-0 block">
+        <span class="flex items-center gap-2 min-w-0">
           <span class="i-carbon-warning-hex w-4 h-4 shrink-0" aria-hidden="true" />
           <span class="font-mono text-sm font-medium truncate">
             {{ $t('package.deprecated.tree_found', analysisData!.deprecatedPackages.length) }}

--- a/app/components/Package/VulnerabilityTree.vue
+++ b/app/components/Package/VulnerabilityTree.vue
@@ -83,7 +83,7 @@ function getDepthStyle(depth: string | undefined) {
         aria-controls="vuln-tree-details"
         @click="isExpanded = !isExpanded"
       >
-        <span class="flex items-center gap-2 min-w-0 block">
+        <span class="flex items-center gap-2 min-w-0">
           <span class="i-carbon:warning-alt w-4 h-4 shrink-0" aria-hidden="true" />
           <span class="font-mono text-sm font-medium truncate">
             {{


### PR DESCRIPTION
#1274 added the block class to flex elements, which cause the UI to look like this

<img width="130" height="114" alt="image" src="https://github.com/user-attachments/assets/0d153d7e-97e0-4fb3-a65c-cf4709b300c2" />

This PR removes the block as flex is enough.