### PR TITLE
fix: allow modifier keys for import links in package code

### DIFF
--- a/app/components/Code/Viewer.vue
+++ b/app/components/Code/Viewer.vue
@@ -62,10 +62,11 @@ watch(
 function handleImportLinkNavigate() {
   if (!codeRef.value) return
 
-  const anchors = codeRef.value.querySelectorAll('a.import-link')
+  const anchors = codeRef.value.querySelectorAll<HTMLAnchorElement>('a.import-link')
   anchors.forEach(anchor => {
     // NOTE: We do not need to remove previous listeners because we re-create the entire HTML content on each html update
     anchor.addEventListener('click', event => {
+      if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) return
       const href = anchor.getAttribute('href')
       if (href) {
         event.preventDefault()


### PR DESCRIPTION
follow-up to https://github.com/npmx-dev/npmx.dev/pull/1307#discussion_r2785362803

I copied the conditions from vue-router: https://github.com/vuejs/router/blob/49b925d2042d2b9e8a75dc8eeb2578045a07d6c7/packages/router/src/RouterLink.ts#L414

I dont think we need to copy its other guards for now 🤔 