### PR TITLE
fix: compare page package desc truncate invalid

### DIFF
--- a/app/components/Compare/PackageSelector.vue
+++ b/app/components/Compare/PackageSelector.vue
@@ -204,7 +204,10 @@ function handleFocus() {
             @click="addPackage(result.name)"
           >
             <span class="font-mono text-sm text-fg block">{{ result.name }}</span>
-            <span v-if="result.description" class="text-xs text-fg-muted truncate mt-0.5">
+            <span
+              v-if="result.description"
+              class="text-xs text-fg-muted truncate mt-0.5 w-full block"
+            >
               {{ result.description }}
             </span>
           </ButtonBase>


### PR DESCRIPTION
|current|after|
|---|---|
|<img width="1087" height="539" alt="image" src="https://github.com/user-attachments/assets/991c7be3-1fc4-4347-bc27-1b13f253359e" />|<img width="1101" height="541" alt="image" src="https://github.com/user-attachments/assets/4c87f0a6-5854-4c78-8498-8f0a36daa643" />|