### PR TITLE
fix: align shell prompt `$`  for multiple lines command

### DIFF
--- a/app/components/Terminal/Install.vue
+++ b/app/components/Terminal/Install.vue
@@ -112,7 +112,7 @@ const copyCreateCommand = () => copyCreate(getFullCreateCommand())
           :data-pm-cmd="pm.id"
           class="flex items-center gap-2 group/installcmd min-w-0"
         >
-          <span class="text-fg-subtle font-mono text-sm select-none shrink-0">$</span>
+          <span class="self-start text-fg-subtle font-mono text-sm select-none shrink-0">$</span>
           <code class="font-mono text-sm min-w-0"
             ><span
               v-for="(part, i) in getInstallPartsForPM(pm.id)"
@@ -139,7 +139,7 @@ const copyCreateCommand = () => copyCreate(getFullCreateCommand())
             :data-pm-cmd="pm.id"
             class="flex items-center gap-2 min-w-0"
           >
-            <span class="text-fg-subtle font-mono text-sm select-none shrink-0">$</span>
+            <span class="self-start text-fg-subtle font-mono text-sm select-none shrink-0">$</span>
             <code class="font-mono text-sm min-w-0"
               ><span
                 v-for="(part, i) in getTypesInstallPartsForPM(pm.id)"
@@ -174,7 +174,7 @@ const copyCreateCommand = () => copyCreate(getFullCreateCommand())
             :data-pm-cmd="pm.id"
             class="flex items-center gap-2 group/runcmd"
           >
-            <span class="text-fg-subtle font-mono text-sm select-none">$</span>
+            <span class="self-start text-fg-subtle font-mono text-sm select-none">$</span>
             <code class="font-mono text-sm"
               ><span
                 v-for="(part, i) in getRunPartsForPM(pm.id, executableInfo?.primaryCommand)"
@@ -219,7 +219,7 @@ const copyCreateCommand = () => copyCreate(getFullCreateCommand())
             :data-pm-cmd="pm.id"
             class="flex items-center gap-2 group/createcmd"
           >
-            <span class="text-fg-subtle font-mono text-sm select-none">$</span>
+            <span class="self-start text-fg-subtle font-mono text-sm select-none">$</span>
             <code class="font-mono text-sm"
               ><span
                 v-for="(part, i) in getCreatePartsForPM(pm.id)"


### PR DESCRIPTION
fix #1311

### Before
<img width="1441" height="509" alt="screenshot of install command, the prompt $ is aligned to the center vertially" src="https://github.com/user-attachments/assets/67cc1cb7-c9f4-48ba-a151-8f822685b219" />


### After

<img width="1441" height="509" alt="screenshot of install command, the prompt $ is aligned to the top vertially" src="https://github.com/user-attachments/assets/1ea4f37f-acaf-41d0-8425-39e4d8c31b8e" />
