### PR TITLE
fix: correct mobile bottom navigation in RTL language

### DIFF
--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -645,7 +645,7 @@ onKeyStroke(
             v-if="resolvedVersion"
             as="nav"
             :aria-label="$t('package.navigation')"
-            class="hidden sm:flex max-sm:flex max-sm:fixed max-sm:z-40 max-sm:inset-is-50% max-sm:-translate-x-50% max-sm:bg-[--bg]/90 max-sm:backdrop-blur-md max-sm:border max-sm:border-border max-sm:rounded-md max-sm:shadow-md"
+            class="hidden sm:flex max-sm:flex max-sm:fixed max-sm:z-40 max-sm:inset-is-1/2 max-sm:-translate-x-1/2 max-sm:rtl:translate-x-1/2 max-sm:bg-[--bg]/90 max-sm:backdrop-blur-md max-sm:border max-sm:border-border max-sm:rounded-md max-sm:shadow-md"
             :class="$style.packageNav"
           >
             <LinkBase


### PR DESCRIPTION
fix #1315

- The `rtl:` prefix can be used to apply unocss class only to RTL locales.
- I also replced `50%` with `1/2` to be consistent with other usages.

### Before
<img height="600" alt="screenshot of package page on mobile. only a small edge of nav is shown at the bottom left screen" src="https://github.com/user-attachments/assets/112813df-90cc-4f0e-a930-a9ebb8f7b1ed" />

### After
<img height="600" alt="screenshot of package page on mobile. bottom nav is fully shown at the bottom center of the screen" src="https://github.com/user-attachments/assets/17a8dd22-d905-4bc3-a4c6-9eb0cfa2a80e" />
