### PR TITLE
fix: make the `/` in the logo not selectable

### DIFF
--- a/app/components/AppLogo.vue
+++ b/app/components/AppLogo.vue
@@ -24,6 +24,7 @@ defineProps<{
       font-size="420"
       font-weight="500"
       text-anchor="middle"
+      style="user-select: none"
     >
       <tspan>/</tspan>
     </text>


### PR DESCRIPTION
Fixes https://github.com/npmx-dev/npmx.dev/issues/1341

This makes the `./` in the logo fully behave like an image, rather than it being half-selectable.