### PR TITLE
fix: keep package name visible

### DIFF
--- a/app/components/Compare/FacetCard.vue
+++ b/app/components/Compare/FacetCard.vue
@@ -101,14 +101,14 @@ function getShortName(header: string): string {
 
         <!-- Package name -->
         <span
-          class="relative font-mono text-xs text-fg-muted truncate flex-shrink min-w-0"
+          class="relative font-mono text-xs text-fg-muted truncate flex-shrink-0"
           :title="headers[index]"
         >
           {{ getShortName(headers[index] ?? '') }}
         </span>
 
         <!-- Value -->
-        <span class="relative flex-shrink-0">
+        <span class="relative min-w-0 text-end">
           <!-- Loading state -->
           <template v-if="isCellLoading(index)">
             <span


### PR DESCRIPTION
Look, our engines in vitest is really long. For that reason the package name is not visible in mobile version due to long values. I think we can improve it.

Before:
<img width="592" height="371" alt="wrong" src="https://github.com/user-attachments/assets/bef757ce-3cf9-4a40-a459-ac96b7ec8066" />

After:
<img width="592" height="371" alt="correct" src="https://github.com/user-attachments/assets/194801dc-da8d-4658-8d59-3668f335e105" />

