### PR TITLE
chore: remove `.oxfmtignore`

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -4,9 +4,5 @@
   "singleQuote": true,
   "arrowParens": "avoid",
   "quoteProps": "consistent",
-  "experimentalSortPackageJson": false,
-  "ignorePatterns": [
-    // Docus MDC content - formatter breaks component syntax
-    "docs/content/**/*.md"
-  ]
+  "experimentalSortPackageJson": false
 }


### PR DESCRIPTION
oxfmt doens't read `.oxfmtignore` so it's not really working or used and can be removed.

oxfmt recommends putting the ignores in [`ignorePatterns`](https://oxc.rs/docs/guide/usage/formatter/ignore-files.html#ignorepatterns) instead, but given the ignore `docs/*` files were actually being formatted all this time and have the `prettier-ignore` comments already in place, I think we can keep formatting them without ignoring completely.