### PR TITLE
ci: only run mirror to tangled on npmx repo

### DIFF
--- a/.github/workflows/mirror-tangled.yml
+++ b/.github/workflows/mirror-tangled.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   mirror:
     name: 🕸️ Mirror to Tangled
+    if: ${{ github.repository == 'npmx-dev/npmx.dev' }}
     runs-on: ubuntu-24.04-arm
 
     steps:


### PR DESCRIPTION
This will skip running this github action on forks which will always fail ([example](https://github.com/jonathanyeong/npmx.dev/actions/runs/21879526080/job/63157784276)).

I think it's okay to limit to github repository since the tangled remote is also hardcoded to `npmx`:

```
          git remote add tangled git@tangled.org:npmx.dev/npmx.dev
```

Github actions doc: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-jobs-with-conditions