### PR TITLE
fix: show correct install size for native packages

### DIFF
--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -495,7 +495,7 @@ const likeAction = async () => {
   }
 }
 
-const dependencyCount = getDependencyCount(displayVersion.value)
+const dependencyCount = computed(() => getDependencyCount(displayVersion.value))
 
 const numberFormatter = useNumberFormatter()
 const compactNumberFormatter = useCompactNumberFormatter()
@@ -918,7 +918,7 @@ onKeyStroke(
               </span>
 
               <!-- Separator and install size -->
-              <template v-if="displayVersion?.dist.unpackedSize !== installSize?.totalSize">
+              <template v-if="displayVersion?.dist?.unpackedSize !== installSize?.totalSize">
                 <span class="text-fg-subtle mx-1">/</span>
 
                 <span


### PR DESCRIPTION
## Before

<img width="585" height="215" alt="image" src="https://github.com/user-attachments/assets/c77a2854-2196-4dd7-a072-e60b42517309" />

<img width="590" height="230" alt="image" src="https://github.com/user-attachments/assets/262a9361-3644-44f6-9ad4-bf551b07c2ad" />


## After

<img width="595" height="225" alt="image" src="https://github.com/user-attachments/assets/ced8e5b4-6430-4034-a873-c18ac04d4cd6" />

<img width="585" height="225" alt="image" src="https://github.com/user-attachments/assets/7cd270e7-0d26-45e4-b9ad-b7353cb95e14" />


