### PR TITLE
fix: correct unexpected navigation behavior of Comma shortcut

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -180,7 +180,7 @@ onKeyStroke(
     for (const link of desktopLinks.value) {
       if (link.to && link.keyshortcut && isKeyWithoutModifiers(e, link.keyshortcut)) {
         e.preventDefault()
-        navigateTo(link.to.name)
+        navigateTo(link.to)
         break
       }
     }


### PR DESCRIPTION
On the Package page, pressing the Comma shortcut navigates to the settings package(https://npmx.dev/package/settings) instead of the Settings configuration page.