### PR TITLE
feat: link to releases

### DIFF
--- a/app/components/Package/Versions.vue
+++ b/app/components/Package/Versions.vue
@@ -494,7 +494,7 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
                     })
                   "
                   class="inline-flex items-center text-fg-muted hover:text-fg transition-colors shrink-0"
-                ></LinkBase>
+                />
               </div>
               <div v-if="row.tags.length" class="flex items-center gap-1 mt-0.5 flex-wrap">
                 <span
@@ -563,11 +563,9 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
                   v-if="getMatchedRelease(v.version, props.releases ?? [])"
                   :to="getMatchedRelease(v.version, props.releases ?? [])!.url"
                   :title="$t('package.releases.view_release_for_version', { version: v.version })"
+                  classicon="i-carbon-catalog size-3"
                   class="inline-flex items-center text-fg-muted hover:text-fg transition-colors shrink-0"
-                >
-                  <span class="i-carbon-catalog size-3" aria-hidden="true" />
-                  <span class="sr-only">{{ $t('package.releases.view_release') }}</span>
-                </LinkBase>
+                />
               </div>
               <div class="flex items-center gap-2 shrink-0">
                 <DateTime

--- a/app/components/Package/Versions.vue
+++ b/app/components/Package/Versions.vue
@@ -869,11 +869,9 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
                           version: group.versions[0]?.version,
                         })
                       "
+                      classicon="i-carbon-catalog size-3"
                       class="inline-flex items-center text-fg-muted hover:text-fg transition-colors shrink-0"
-                    >
-                      <span class="i-carbon-catalog size-3" aria-hidden="true" />
-                      <span class="sr-only">{{ $t('package.releases.view_release') }}</span>
-                    </LinkBase>
+                    />
                   </div>
                   <div class="flex items-center gap-2 shrink-0 pe-2">
                     <DateTime

--- a/app/components/Package/Versions.vue
+++ b/app/components/Package/Versions.vue
@@ -11,6 +11,8 @@ import {
   getVersionGroupLabel,
   isSameVersionGroup,
 } from '~/utils/versions'
+import { getMatchedRelease } from '~/utils/releases'
+import type { Release } from '~/composables/useRepoMeta'
 
 const props = defineProps<{
   packageName: string
@@ -18,6 +20,7 @@ const props = defineProps<{
   distTags: Record<string, string>
   time: Record<string, string>
   selectedVersion?: string
+  releases?: Release[]
 }>()
 
 const chartModal = useModal('chart-modal')
@@ -458,28 +461,41 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
           <!-- Version info -->
           <div class="flex-1 py-1.5 min-w-0 flex gap-2 justify-between items-center">
             <div class="overflow-hidden">
-              <LinkBase
-                :to="versionRoute(row.primaryVersion.version)"
-                block
-                class="text-sm"
-                :class="
-                  row.primaryVersion.deprecated
-                    ? 'text-red-800 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
-                    : undefined
-                "
-                :title="
-                  row.primaryVersion.deprecated
-                    ? $t('package.versions.deprecated_title', {
-                        version: row.primaryVersion.version,
-                      })
-                    : row.primaryVersion.version
-                "
-                :classicon="row.primaryVersion.deprecated ? 'i-carbon-warning-hex' : undefined"
-              >
-                <span dir="ltr" class="block truncate">
-                  {{ row.primaryVersion.version }}
-                </span>
-              </LinkBase>
+              <div class="flex items-center gap-1.5">
+                <LinkBase
+                  :to="versionRoute(row.primaryVersion.version)"
+                  block
+                  class="text-sm"
+                  :class="
+                    row.primaryVersion.deprecated
+                      ? 'text-red-800 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
+                      : undefined
+                  "
+                  :title="
+                    row.primaryVersion.deprecated
+                      ? $t('package.versions.deprecated_title', {
+                          version: row.primaryVersion.version,
+                        })
+                      : row.primaryVersion.version
+                  "
+                  :classicon="row.primaryVersion.deprecated ? 'i-carbon-warning-hex' : undefined"
+                >
+                  <span dir="ltr" class="block truncate">
+                    {{ row.primaryVersion.version }}
+                  </span>
+                </LinkBase>
+                <LinkBase
+                  v-if="getMatchedRelease(row.primaryVersion.version, props.releases ?? [])"
+                  :to="getMatchedRelease(row.primaryVersion.version, props.releases ?? [])!.url"
+                  classicon="i-carbon-catalog size-3.5"
+                  :title="
+                    $t('package.releases.view_release_for_version', {
+                      version: row.primaryVersion.version,
+                    })
+                  "
+                  class="inline-flex items-center text-fg-muted hover:text-fg transition-colors shrink-0"
+                ></LinkBase>
+              </div>
               <div v-if="row.tags.length" class="flex items-center gap-1 mt-0.5 flex-wrap">
                 <span
                   v-for="tag in row.tags"
@@ -522,26 +538,37 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
             :class="v.version === effectiveCurrentVersion ? 'rounded bg-bg-subtle px-2 -mx-2' : ''"
           >
             <div class="flex items-center justify-between gap-2">
-              <LinkBase
-                :to="versionRoute(v.version)"
-                block
-                class="text-xs"
-                :class="
-                  v.deprecated
-                    ? 'text-red-800 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
-                    : undefined
-                "
-                :title="
-                  v.deprecated
-                    ? $t('package.versions.deprecated_title', { version: v.version })
-                    : v.version
-                "
-                :classicon="v.deprecated ? 'i-carbon-warning-hex' : undefined"
-              >
-                <span dir="ltr" class="block truncate">
-                  {{ v.version }}
-                </span>
-              </LinkBase>
+              <div class="flex items-center gap-1.5 min-w-0">
+                <LinkBase
+                  :to="versionRoute(v.version)"
+                  block
+                  class="text-xs"
+                  :class="
+                    v.deprecated
+                      ? 'text-red-800 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
+                      : undefined
+                  "
+                  :title="
+                    v.deprecated
+                      ? $t('package.versions.deprecated_title', { version: v.version })
+                      : v.version
+                  "
+                  :classicon="v.deprecated ? 'i-carbon-warning-hex' : undefined"
+                >
+                  <span dir="ltr" class="block truncate">
+                    {{ v.version }}
+                  </span>
+                </LinkBase>
+                <LinkBase
+                  v-if="getMatchedRelease(v.version, props.releases ?? [])"
+                  :to="getMatchedRelease(v.version, props.releases ?? [])!.url"
+                  :title="$t('package.releases.view_release_for_version', { version: v.version })"
+                  class="inline-flex items-center text-fg-muted hover:text-fg transition-colors shrink-0"
+                >
+                  <span class="i-carbon-catalog size-3" aria-hidden="true" />
+                  <span class="sr-only">{{ $t('package.releases.view_release') }}</span>
+                </LinkBase>
+              </div>
               <div class="flex items-center gap-2 shrink-0">
                 <DateTime
                   v-if="v.time"
@@ -630,28 +657,43 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
             :class="hiddenRowContainsCurrent(row) ? 'rounded bg-bg-subtle px-2 -mx-2' : ''"
           >
             <div class="flex items-center justify-between gap-2">
-              <LinkBase
-                :to="versionRoute(row.primaryVersion.version)"
-                block
-                class="text-xs"
-                :class="
-                  row.primaryVersion.deprecated
-                    ? 'text-red-800 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
-                    : undefined
-                "
-                :title="
-                  row.primaryVersion.deprecated
-                    ? $t('package.versions.deprecated_title', {
-                        version: row.primaryVersion.version,
-                      })
-                    : row.primaryVersion.version
-                "
-                :classicon="row.primaryVersion.deprecated ? 'i-carbon-warning-hex' : undefined"
-              >
-                <span dir="ltr" class="block truncate">
-                  {{ row.primaryVersion.version }}
-                </span>
-              </LinkBase>
+              <div class="flex items-center gap-1.5 min-w-0">
+                <LinkBase
+                  :to="versionRoute(row.primaryVersion.version)"
+                  block
+                  class="text-xs"
+                  :class="
+                    row.primaryVersion.deprecated
+                      ? 'text-red-800 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
+                      : undefined
+                  "
+                  :title="
+                    row.primaryVersion.deprecated
+                      ? $t('package.versions.deprecated_title', {
+                          version: row.primaryVersion.version,
+                        })
+                      : row.primaryVersion.version
+                  "
+                  :classicon="row.primaryVersion.deprecated ? 'i-carbon-warning-hex' : undefined"
+                >
+                  <span dir="ltr" class="block truncate">
+                    {{ row.primaryVersion.version }}
+                  </span>
+                </LinkBase>
+                <LinkBase
+                  v-if="getMatchedRelease(row.primaryVersion.version, props.releases ?? [])"
+                  :to="getMatchedRelease(row.primaryVersion.version, props.releases ?? [])!.url"
+                  :title="
+                    $t('package.releases.view_release_for_version', {
+                      version: row.primaryVersion.version,
+                    })
+                  "
+                  class="inline-flex items-center text-fg-muted hover:text-fg transition-colors shrink-0"
+                >
+                  <span class="i-carbon-catalog size-3" aria-hidden="true" />
+                  <span class="sr-only">{{ $t('package.releases.view_release') }}</span>
+                </LinkBase>
+              </div>
               <div class="flex items-center gap-2 shrink-0 pe-2">
                 <DateTime
                   v-if="row.primaryVersion.time"
@@ -708,31 +750,51 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
                         aria-hidden="true"
                       />
                     </button>
-                    <LinkBase
-                      v-if="group.versions[0]?.version"
-                      :to="versionRoute(group.versions[0]?.version)"
-                      block
-                      class="text-xs"
-                      :class="
-                        group.versions[0]?.deprecated
-                          ? 'text-red-800 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
-                          : undefined
-                      "
-                      :title="
-                        group.versions[0]?.deprecated
-                          ? $t('package.versions.deprecated_title', {
-                              version: group.versions[0]?.version,
-                            })
-                          : group.versions[0]?.version
-                      "
-                      :classicon="
-                        group.versions[0]?.deprecated ? 'i-carbon-warning-hex' : undefined
-                      "
-                    >
-                      <span dir="ltr" class="block truncate">
-                        {{ group.versions[0]?.version }}
-                      </span>
-                    </LinkBase>
+                    <div class="flex items-center gap-1.5 min-w-0">
+                      <LinkBase
+                        v-if="group.versions[0]?.version"
+                        :to="versionRoute(group.versions[0]?.version)"
+                        block
+                        class="text-xs"
+                        :class="
+                          group.versions[0]?.deprecated
+                            ? 'text-red-800 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
+                            : undefined
+                        "
+                        :title="
+                          group.versions[0]?.deprecated
+                            ? $t('package.versions.deprecated_title', {
+                                version: group.versions[0]?.version,
+                              })
+                            : group.versions[0]?.version
+                        "
+                        :classicon="
+                          group.versions[0]?.deprecated ? 'i-carbon-warning-hex' : undefined
+                        "
+                      >
+                        <span dir="ltr" class="block truncate">
+                          {{ group.versions[0]?.version }}
+                        </span>
+                      </LinkBase>
+                      <LinkBase
+                        v-if="
+                          group.versions[0]?.version &&
+                          getMatchedRelease(group.versions[0]?.version, props.releases ?? [])
+                        "
+                        :to="
+                          getMatchedRelease(group.versions[0]?.version, props.releases ?? [])!.url
+                        "
+                        :title="
+                          $t('package.releases.view_release_for_version', {
+                            version: group.versions[0]?.version,
+                          })
+                        "
+                        class="inline-flex items-center text-fg-muted hover:text-fg transition-colors shrink-0"
+                      >
+                        <span class="i-carbon-catalog size-3" aria-hidden="true" />
+                        <span class="sr-only">{{ $t('package.releases.view_release') }}</span>
+                      </LinkBase>
+                    </div>
                   </div>
                   <div class="flex items-center gap-2 shrink-0 pe-2">
                     <DateTime
@@ -772,12 +834,12 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
                 :class="majorGroupContainsCurrent(group) ? 'rounded bg-bg-subtle px-2 -mx-2' : ''"
               >
                 <div class="flex items-center justify-between gap-2">
-                  <div class="flex items-center gap-2 min-w-0">
+                  <div class="flex items-center gap-1.5 min-w-0 ms-6">
                     <LinkBase
                       v-if="group.versions[0]?.version"
                       :to="versionRoute(group.versions[0]?.version)"
                       block
-                      class="text-xs ms-6"
+                      class="text-xs"
                       :class="
                         group.versions[0]?.deprecated
                           ? 'text-red-800 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
@@ -797,6 +859,22 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
                       <span dir="ltr" class="block truncate">
                         {{ group.versions[0]?.version }}
                       </span>
+                    </LinkBase>
+                    <LinkBase
+                      v-if="
+                        group.versions[0]?.version &&
+                        getMatchedRelease(group.versions[0]?.version, props.releases ?? [])
+                      "
+                      :to="getMatchedRelease(group.versions[0]?.version, props.releases ?? [])!.url"
+                      :title="
+                        $t('package.releases.view_release_for_version', {
+                          version: group.versions[0]?.version,
+                        })
+                      "
+                      class="inline-flex items-center text-fg-muted hover:text-fg transition-colors shrink-0"
+                    >
+                      <span class="i-carbon-catalog size-3" aria-hidden="true" />
+                      <span class="sr-only">{{ $t('package.releases.view_release') }}</span>
                     </LinkBase>
                   </div>
                   <div class="flex items-center gap-2 shrink-0 pe-2">
@@ -841,26 +919,39 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
                   "
                 >
                   <div class="flex items-center justify-between gap-2">
-                    <LinkBase
-                      :to="versionRoute(v.version)"
-                      block
-                      class="text-xs"
-                      :class="
-                        v.deprecated
-                          ? 'text-red-800 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
-                          : undefined
-                      "
-                      :title="
-                        v.deprecated
-                          ? $t('package.versions.deprecated_title', { version: v.version })
-                          : v.version
-                      "
-                      :classicon="v.deprecated ? 'i-carbon-warning-hex' : undefined"
-                    >
-                      <span dir="ltr" class="block truncate">
-                        {{ v.version }}
-                      </span>
-                    </LinkBase>
+                    <div class="flex items-center gap-1.5 min-w-0">
+                      <LinkBase
+                        :to="versionRoute(v.version)"
+                        block
+                        class="text-xs"
+                        :class="
+                          v.deprecated
+                            ? 'text-red-800 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
+                            : undefined
+                        "
+                        :title="
+                          v.deprecated
+                            ? $t('package.versions.deprecated_title', { version: v.version })
+                            : v.version
+                        "
+                        :classicon="v.deprecated ? 'i-carbon-warning-hex' : undefined"
+                      >
+                        <span dir="ltr" class="block truncate">
+                          {{ v.version }}
+                        </span>
+                      </LinkBase>
+                      <LinkBase
+                        v-if="getMatchedRelease(v.version, props.releases ?? [])"
+                        :to="getMatchedRelease(v.version, props.releases ?? [])!.url"
+                        :title="
+                          $t('package.releases.view_release_for_version', { version: v.version })
+                        "
+                        class="inline-flex items-center text-fg-muted hover:text-fg transition-colors shrink-0"
+                      >
+                        <span class="i-carbon-catalog size-3" aria-hidden="true" />
+                        <span class="sr-only">{{ $t('package.releases.view_release') }}</span>
+                      </LinkBase>
+                    </div>
                     <div class="flex items-center gap-2 shrink-0 pe-2">
                       <DateTime
                         v-if="v.time"

--- a/app/components/Package/Versions.vue
+++ b/app/components/Package/Versions.vue
@@ -686,11 +686,9 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
                       version: row.primaryVersion.version,
                     })
                   "
+                  classicon="i-carbon-catalog size-3"
                   class="inline-flex items-center text-fg-muted hover:text-fg transition-colors shrink-0"
-                >
-                  <span class="i-carbon-catalog size-3" aria-hidden="true" />
-                  <span class="sr-only">{{ $t('package.releases.view_release') }}</span>
-                </LinkBase>
+                />
               </div>
               <div class="flex items-center gap-2 shrink-0 pe-2">
                 <DateTime
@@ -787,11 +785,9 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
                             version: group.versions[0]?.version,
                           })
                         "
+                        classicon="i-carbon-catalog size-3"
                         class="inline-flex items-center text-fg-muted hover:text-fg transition-colors shrink-0"
-                      >
-                        <span class="i-carbon-catalog size-3" aria-hidden="true" />
-                        <span class="sr-only">{{ $t('package.releases.view_release') }}</span>
-                      </LinkBase>
+                      />
                     </div>
                   </div>
                   <div class="flex items-center gap-2 shrink-0 pe-2">
@@ -942,11 +938,9 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
                         :title="
                           $t('package.releases.view_release_for_version', { version: v.version })
                         "
+                        classicon="i-carbon-catalog size-3"
                         class="inline-flex items-center text-fg-muted hover:text-fg transition-colors shrink-0"
-                      >
-                        <span class="i-carbon-catalog size-3" aria-hidden="true" />
-                        <span class="sr-only">{{ $t('package.releases.view_release') }}</span>
-                      </LinkBase>
+                      />
                     </div>
                     <div class="flex items-center gap-2 shrink-0 pe-2">
                       <DateTime

--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -611,7 +611,7 @@ onKeyStroke(
   e => {
     if (!currentVersionRelease.value) return
     e.preventDefault()
-    navigateTo(currentVersionRelease.value.url)
+    navigateTo(currentVersionRelease.value.url, { external: true })
   },
   { dedupe: true },
 )
@@ -764,7 +764,7 @@ const showSkeleton = shallowRef(false)
               variant="button-secondary"
               :to="currentVersionRelease.url"
               aria-keyshortcuts="r"
-              classicon="i-carbon-catalog"
+              classicon="i-carbon:catalog"
             >
               {{ $t('package.links.release') }}
             </LinkBase>

--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -367,8 +367,6 @@ const {
   forks,
   forksLink,
   releases,
-  releasesLink,
-  releasesPending,
 } = useRepoMeta(repositoryUrl)
 
 const currentVersionRelease = computed(() => {

--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -17,6 +17,7 @@ import { detectPublishSecurityDowngradeForVersion } from '~/utils/publish-securi
 import { useModal } from '~/composables/useModal'
 import { useAtproto } from '~/composables/atproto/useAtproto'
 import { togglePackageLike } from '~/utils/atproto/likes'
+import { getMatchedRelease } from '~/utils/releases'
 
 defineOgImageComponent('Package', {
   name: () => packageName.value,
@@ -358,7 +359,23 @@ const repositoryUrl = computed(() => {
   return url
 })
 
-const { meta: repoMeta, repoRef, stars, starsLink, forks, forksLink } = useRepoMeta(repositoryUrl)
+const {
+  meta: repoMeta,
+  repoRef,
+  stars,
+  starsLink,
+  forks,
+  forksLink,
+  releases,
+  releasesLink,
+  releasesPending,
+} = useRepoMeta(repositoryUrl)
+
+const currentVersionRelease = computed(() => {
+  const version = resolvedVersion.value ?? displayVersion.value?.version
+  if (!version || !releases.value.length) return null
+  return getMatchedRelease(version, releases.value)
+})
 
 const PROVIDER_ICONS: Record<string, string> = {
   github: 'i-carbon:logo-github',
@@ -591,6 +608,16 @@ onKeyStroke(
   },
 )
 
+onKeyStroke(
+  e => isKeyWithoutModifiers(e, 'r') && !isEditableElement(e.target),
+  e => {
+    if (!currentVersionRelease.value) return
+    e.preventDefault()
+    navigateTo(currentVersionRelease.value.url)
+  },
+  { dedupe: true },
+)
+
 const showSkeleton = shallowRef(false)
 </script>
 
@@ -733,6 +760,15 @@ const showSkeleton = shallowRef(false)
               classicon="i-carbon:compare"
             >
               {{ $t('package.links.compare') }}
+            </LinkBase>
+            <LinkBase
+              v-if="currentVersionRelease"
+              variant="button-secondary"
+              :to="currentVersionRelease.url"
+              aria-keyshortcuts="r"
+              classicon="i-carbon-catalog"
+            >
+              {{ $t('package.links.release') }}
             </LinkBase>
           </ButtonGroup>
 
@@ -1334,6 +1370,7 @@ const showSkeleton = shallowRef(false)
             :dist-tags="pkg['dist-tags'] ?? {}"
             :time="pkg.time"
             :selected-version="resolvedVersion ?? pkg['dist-tags']?.['latest']"
+            :releases="releases"
           />
 
           <!-- Install Scripts Warning -->

--- a/app/utils/releases.ts
+++ b/app/utils/releases.ts
@@ -1,0 +1,38 @@
+import type { Release } from '~/composables/useRepoMeta'
+
+/**
+ * Match an npm version string to a repository release.
+ * Handles various tag formats: "v1.0.0", "1.0.0", "release-1.0.0", etc.
+ *
+ * @param version - npm version string (e.g., "1.2.3", "0.9.0-beta.1")
+ * @param releases - Array of releases from repository
+ * @returns Matched release or null
+ */
+export function getMatchedRelease(version: string, releases: Release[]): Release | null {
+  if (!version || !releases.length) return null
+
+  // Normalize version for comparison (remove any existing 'v' prefix)
+  const normalizedVersion = version.replace(/^v/, '').toLowerCase()
+
+  // Try exact matches with common tag formats
+  const tagVariants = [
+    `v${normalizedVersion}`, // Most common: v1.0.0
+    normalizedVersion, // Without prefix: 1.0.0
+    `release-${normalizedVersion}`, // Some projects: release-1.0.0
+    `${normalizedVersion}-release`, // Alternative: 1.0.0-release
+  ]
+
+  for (const release of releases) {
+    if (!release.url) continue
+    const releaseTag = release.tag.toLowerCase()
+
+    // Check each variant (case-insensitive)
+    for (const variant of tagVariants) {
+      if (releaseTag === variant) {
+        return release
+      }
+    }
+  }
+
+  return null
+}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -210,9 +210,6 @@
       "release": "release"
     },
     "releases": {
-      "title": "Releases",
-      "view_all": "View all {count} releases",
-      "view_release": "View release",
       "view_release_for_version": "View release for {version}"
     },
     "likes": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -206,7 +206,14 @@
       "code": "code",
       "docs": "docs",
       "fund": "fund",
-      "compare": "compare"
+      "compare": "compare",
+      "release": "release"
+    },
+    "releases": {
+      "title": "Releases",
+      "view_all": "View all {count} releases",
+      "view_release": "View release",
+      "view_release_for_version": "View release for {version}"
     },
     "likes": {
       "like": "Like this package",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -634,15 +634,6 @@
         "releases": {
           "type": "object",
           "properties": {
-            "title": {
-              "type": "string"
-            },
-            "view_all": {
-              "type": "string"
-            },
-            "view_release": {
-              "type": "string"
-            },
             "view_release_for_version": {
               "type": "string"
             }

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -624,6 +624,27 @@
             },
             "compare": {
               "type": "string"
+            },
+            "release": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "releases": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "view_all": {
+              "type": "string"
+            },
+            "view_release": {
+              "type": "string"
+            },
+            "view_release_for_version": {
+              "type": "string"
             }
           },
           "additionalProperties": false

--- a/lunaria/files/en-GB.json
+++ b/lunaria/files/en-GB.json
@@ -209,9 +209,6 @@
       "release": "release"
     },
     "releases": {
-      "title": "Releases",
-      "view_all": "View all {count} releases",
-      "view_release": "View release",
       "view_release_for_version": "View release for {version}"
     },
     "likes": {

--- a/lunaria/files/en-GB.json
+++ b/lunaria/files/en-GB.json
@@ -209,6 +209,9 @@
       "release": "release"
     },
     "releases": {
+      "title": "Releases",
+      "view_all": "View all {count} releases",
+      "view_release": "View release",
       "view_release_for_version": "View release for {version}"
     },
     "likes": {

--- a/lunaria/files/en-GB.json
+++ b/lunaria/files/en-GB.json
@@ -205,7 +205,14 @@
       "code": "code",
       "docs": "docs",
       "fund": "fund",
-      "compare": "compare"
+      "compare": "compare",
+      "release": "release"
+    },
+    "releases": {
+      "title": "Releases",
+      "view_all": "View all {count} releases",
+      "view_release": "View release",
+      "view_release_for_version": "View release for {version}"
     },
     "likes": {
       "like": "Like this package",

--- a/lunaria/files/en-US.json
+++ b/lunaria/files/en-US.json
@@ -209,9 +209,6 @@
       "release": "release"
     },
     "releases": {
-      "title": "Releases",
-      "view_all": "View all {count} releases",
-      "view_release": "View release",
       "view_release_for_version": "View release for {version}"
     },
     "likes": {

--- a/lunaria/files/en-US.json
+++ b/lunaria/files/en-US.json
@@ -209,6 +209,9 @@
       "release": "release"
     },
     "releases": {
+      "title": "Releases",
+      "view_all": "View all {count} releases",
+      "view_release": "View release",
       "view_release_for_version": "View release for {version}"
     },
     "likes": {

--- a/lunaria/files/en-US.json
+++ b/lunaria/files/en-US.json
@@ -205,7 +205,14 @@
       "code": "code",
       "docs": "docs",
       "fund": "fund",
-      "compare": "compare"
+      "compare": "compare",
+      "release": "release"
+    },
+    "releases": {
+      "title": "Releases",
+      "view_all": "View all {count} releases",
+      "view_release": "View release",
+      "view_release_for_version": "View release for {version}"
     },
     "likes": {
       "like": "Like this package",


### PR DESCRIPTION
I don't know how common the case is for everyone, but I found that one of the most played actions for me to visit a package's npm page is when I found a new major version released, and I wanted to know what has changed. So my flow would be 

> `search for the package` -> `npm` -> `repo` -> `release page`

As many release notes are hosted in GitHub, I think it would be very useful for npmx to offer an easy entry for accessing the release notes.

<img width="2294" height="964" alt="CleanShot 2026-02-11 at 14 13 14@2x" src="https://github.com/user-attachments/assets/411ab0f8-c5fa-4996-9b82-500fa6c3094a" />

---

A few open questions:

- [ ] Apparently, I use Claude Code to generate the `fetchReleases` for providers other than GitHub, I didn't test them, and actually don't really know how. Should we keep them as-is for future contribution to improve, or should we remove them entirely and add back one by one later?
- [ ] For improve the above experience for developers, maybe we should have a list of package example that we can go through (that are configured with different source hosting, that contributors can check them one-by-one). And also maybe a dev-time only page (debug page) for linking them easily (out of scope of this PR)
- [ ] At least for GitHub, we actually have the markdown and html content of the release note, should we render them in our app instead of linking them? (for future PR)
- [ ] As we have more and more items, the UI is getting a bit crowded, to keep things scoped, I plan to tweak the UI in another PR later.

--- 

Edit: I just notice it has some conflicts to the existing work #1233 (issue #501), linking for ack