### PR TITLE
feat: sort contributors list by role

### DIFF
--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { Role } from '#server/api/contributors.get'
+
 const router = useRouter()
 const canGoBack = useCanGoBack()
 
@@ -27,6 +29,22 @@ const pmLinks = {
 }
 
 const { data: contributors, status: contributorsStatus } = useLazyFetch('/api/contributors')
+
+const governanceMembers = computed(
+  () => contributors.value?.filter(c => c.role !== 'contributor') ?? [],
+)
+
+const communityContributors = computed(
+  () => contributors.value?.filter(c => c.role === 'contributor') ?? [],
+)
+
+const roleLabels = computed(
+  () =>
+    ({
+      steward: $t('about.team.role_steward'),
+      maintainer: $t('about.team.role_maintainer'),
+    }) as Partial<Record<Role, string>>,
+)
 </script>
 
 <template>
@@ -138,99 +156,135 @@ const { data: contributors, status: contributorsStatus } = useLazyFetch('/api/co
         </div>
 
         <div>
-          <h2 class="text-lg text-fg-subtle uppercase tracking-wider mb-4">Team</h2>
+          <h2 class="text-lg text-fg-subtle uppercase tracking-wider mb-4">
+            {{ $t('about.team.title') }}
+          </h2>
           <p class="text-fg-muted leading-relaxed mb-6">
             {{ $t('about.contributors.description') }}
           </p>
 
-          <!-- TODO: update string and maintainers list -->
-          <div v-if="contributors?.some(c => c.role !== 'contributor')" class="mb-12">
-            <h3 class="text-sm text-fg-subtle uppercase tracking-wider mb-4">Governance</h3>
-            <p class="text-fg-muted leading-relaxed mb-6">
-              TODO: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-              incididunt ut labore et dolore magna aliqua.
-            </p>
+          <!-- Governance: stewards + maintainers -->
+          <section
+            v-if="governanceMembers.length"
+            class="mb-12"
+            aria-labelledby="governance-heading"
+          >
+            <h3
+              id="governance-heading"
+              class="text-sm text-fg-subtle uppercase tracking-wider mb-4"
+            >
+              {{ $t('about.team.governance') }}
+            </h3>
 
-            <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
-              <a
-                v-for="person in contributors
-                  .filter(c => c.role !== 'contributor')
-                  .concat(contributors.filter(c => c.role !== 'contributor'))
-                  .concat(contributors.filter(c => c.role !== 'contributor'))
-                  .concat(contributors.filter(c => c.role !== 'contributor'))
-                  .concat(contributors.filter(c => c.role !== 'contributor'))"
+            <ul class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 list-none p-0">
+              <li
+                v-for="person in governanceMembers"
                 :key="person.id"
-                :href="person.html_url"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="flex items-center gap-3 p-2 border border-border rounded-lg hover:bg-fg/5 transition-colors group"
+                class="relative flex items-center gap-3 p-3 border border-border rounded-lg hover:border-border-hover hover:bg-bg-muted transition-[border-color,background-color] duration-200 cursor-pointer focus-within:ring-2 focus-within:ring-offset-bg focus-within:ring-offset-2 focus-within:ring-fg/50"
               >
                 <img
-                  :src="`${person.avatar_url}&s=64`"
-                  alt=""
-                  class="w-10 h-10 rounded-md ring-1 ring-border group-hover:ring-accent"
-                />
-                <div class="min-w-0">
-                  <div class="font-mono text-sm text-fg truncate">@{{ person.login }}</div>
-                  <div class="text-sm text-fg-muted tracking-tight">{{ person.role }}</div>
-                </div>
-              </a>
-              TODO: add other maintainers
-            </div>
-          </div>
-
-          <h3 class="text-sm text-fg-subtle uppercase tracking-wider mb-4">
-            {{
-              $t(
-                'about.contributors.title',
-                { count: $n(contributors?.length ?? 0) },
-                contributors?.length ?? 0,
-              )
-            }}
-          </h3>
-          <p class="text-fg-muted leading-relaxed mb-6">
-            TODO: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-            incididunt ut labore et dolore magna aliqua.
-          </p>
-
-          <!-- Contributors cloud -->
-          <div v-if="contributorsStatus === 'pending'" class="text-fg-subtle text-sm">
-            {{ $t('about.contributors.loading') }}
-          </div>
-          <div v-else-if="contributorsStatus === 'error'" class="text-fg-subtle text-sm">
-            {{ $t('about.contributors.error') }}
-          </div>
-          <div
-            v-else-if="contributors?.length"
-            class="grid grid-cols-[repeat(auto-fill,48px)] justify-center gap-2"
-          >
-            <a
-              v-for="contributor in contributors"
-              :key="contributor.id"
-              :href="contributor.html_url"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="group relative"
-              :aria-label="$t('about.contributors.view_profile', { name: contributor.login })"
-            >
-              <div class="relative flex items-center">
-                <img
-                  :src="`${contributor.avatar_url}&s=64`"
-                  :alt="contributor.login"
-                  width="32"
-                  height="32"
-                  class="w-12 h-12 rounded-lg ring-2 ring-transparent group-hover:ring-accent transition-all duration-200 ease-out hover:scale-125 will-change-transform"
+                  :src="`${person.avatar_url}&s=80`"
+                  :alt="`${person.login}'s avatar`"
+                  class="w-12 h-12 rounded-md ring-1 ring-border shrink-0"
                   loading="lazy"
                 />
+                <div class="min-w-0 flex-1">
+                  <div class="font-mono text-sm text-fg truncate">
+                    <NuxtLink
+                      :to="person.html_url"
+                      target="_blank"
+                      class="decoration-none after:content-[''] after:absolute after:inset-0"
+                      :aria-label="$t('about.contributors.view_profile', { name: person.login })"
+                    >
+                      @{{ person.login }}
+                    </NuxtLink>
+                  </div>
+                  <div class="text-xs text-fg-muted tracking-tight">
+                    {{ roleLabels[person.role] ?? person.role }}
+                  </div>
+                  <LinkBase
+                    v-if="person.sponsors_url"
+                    :to="person.sponsors_url"
+                    no-underline
+                    no-external-icon
+                    classicon="i-carbon:favorite"
+                    class="relative z-10 text-xs text-fg-muted hover:text-pink-400 mt-0.5"
+                    :aria-label="$t('about.team.sponsor_aria', { name: person.login })"
+                  >
+                    {{ $t('about.team.sponsor') }}
+                  </LinkBase>
+                </div>
                 <span
-                  class="pointer-events-none absolute -top-9 inset-is-1/2 -translate-x-1/2 whitespace-nowrap rounded-md bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900 text-xs px-2 py-1 shadow-lg opacity-0 scale-95 transition-all duration-150 group-hover:opacity-100 group-hover:scale-100"
-                  dir="ltr"
+                  class="i-carbon:launch rtl-flip w-3.5 h-3.5 text-fg-muted opacity-50 shrink-0 self-start mt-0.5"
+                  aria-hidden="true"
+                />
+              </li>
+            </ul>
+          </section>
+
+          <!-- Contributors cloud -->
+          <section aria-labelledby="contributors-heading">
+            <h3
+              id="contributors-heading"
+              class="text-sm text-fg-subtle uppercase tracking-wider mb-4"
+            >
+              {{
+                $t(
+                  'about.contributors.title',
+                  { count: $n(communityContributors.length) },
+                  communityContributors.length,
+                )
+              }}
+            </h3>
+
+            <div
+              v-if="contributorsStatus === 'pending'"
+              class="text-fg-subtle text-sm"
+              role="status"
+            >
+              {{ $t('about.contributors.loading') }}
+            </div>
+            <div
+              v-else-if="contributorsStatus === 'error'"
+              class="text-fg-subtle text-sm"
+              role="alert"
+            >
+              {{ $t('about.contributors.error') }}
+            </div>
+            <ul
+              v-else-if="communityContributors.length"
+              class="grid grid-cols-[repeat(auto-fill,48px)] justify-center gap-2 list-none p-0"
+            >
+              <li
+                v-for="contributor in communityContributors"
+                :key="contributor.id"
+                class="group relative"
+              >
+                <LinkBase
+                  :to="contributor.html_url"
+                  no-underline
+                  no-external-icon
+                  :aria-label="$t('about.contributors.view_profile', { name: contributor.login })"
                 >
-                  @{{ contributor.login }}
-                </span>
-              </div>
-            </a>
-          </div>
+                  <img
+                    :src="`${contributor.avatar_url}&s=64`"
+                    :alt="`${contributor.login}'s avatar`"
+                    width="48"
+                    height="48"
+                    class="w-12 h-12 rounded-lg ring-2 ring-transparent group-hover:ring-accent transition-all duration-200 ease-out hover:scale-125 will-change-transform"
+                    loading="lazy"
+                  />
+                  <span
+                    class="pointer-events-none absolute -top-9 inset-is-1/2 -translate-x-1/2 whitespace-nowrap rounded-md bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900 text-xs px-2 py-1 shadow-lg opacity-0 scale-95 transition-all duration-150 group-hover:opacity-100 group-hover:scale-100"
+                    dir="ltr"
+                    role="tooltip"
+                  >
+                    @{{ contributor.login }}
+                  </span>
+                </LinkBase>
+              </li>
+            </ul>
+          </section>
         </div>
 
         <CallToAction />

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -810,8 +810,16 @@
         "managers": "package managers"
       }
     },
+    "team": {
+      "title": "Team",
+      "governance": "Governance",
+      "role_steward": "steward",
+      "role_maintainer": "maintainer",
+      "sponsor": "sponsor",
+      "sponsor_aria": "Sponsor {name} on GitHub"
+    },
     "contributors": {
-      "title": "{count} Contributor | {count} Contributors",
+      "title": "... and {count} more contributor | ... and {count} more contributors",
       "description": "npmx is fully open source, built by an amazing community of contributors. Join us and let's build the npm browsing experience we always wanted, together.",
       "loading": "Loading contributors...",
       "error": "Failed to load contributors",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -2434,6 +2434,30 @@
           },
           "additionalProperties": false
         },
+        "team": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "governance": {
+              "type": "string"
+            },
+            "role_steward": {
+              "type": "string"
+            },
+            "role_maintainer": {
+              "type": "string"
+            },
+            "sponsor": {
+              "type": "string"
+            },
+            "sponsor_aria": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "contributors": {
           "type": "object",
           "properties": {

--- a/lunaria/files/en-GB.json
+++ b/lunaria/files/en-GB.json
@@ -809,8 +809,16 @@
         "managers": "package managers"
       }
     },
+    "team": {
+      "title": "Team",
+      "governance": "Governance",
+      "role_steward": "steward",
+      "role_maintainer": "maintainer",
+      "sponsor": "sponsor",
+      "sponsor_aria": "Sponsor {name} on GitHub"
+    },
     "contributors": {
-      "title": "{count} Contributor | {count} Contributors",
+      "title": "... and {count} more contributor | ... and {count} more contributors",
       "description": "npmx is fully open source, built by an amazing community of contributors. Join us and let's build the npm browsing experience we always wanted, together.",
       "loading": "Loading contributors...",
       "error": "Failed to load contributors",

--- a/lunaria/files/en-US.json
+++ b/lunaria/files/en-US.json
@@ -809,8 +809,16 @@
         "managers": "package managers"
       }
     },
+    "team": {
+      "title": "Team",
+      "governance": "Governance",
+      "role_steward": "steward",
+      "role_maintainer": "maintainer",
+      "sponsor": "sponsor",
+      "sponsor_aria": "Sponsor {name} on GitHub"
+    },
     "contributors": {
-      "title": "{count} Contributor | {count} Contributors",
+      "title": "... and {count} more contributor | ... and {count} more contributors",
       "description": "npmx is fully open source, built by an amazing community of contributors. Join us and let's build the npm browsing experience we always wanted, together.",
       "loading": "Loading contributors...",
       "error": "Failed to load contributors",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -34,6 +34,9 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     sessionPassword: '',
+    github: {
+      orgToken: '',
+    },
     // Upstash Redis for distributed OAuth token refresh locking in production
     upstash: {
       redisRestUrl: process.env.UPSTASH_KV_REST_API_URL || process.env.KV_REST_API_URL || '',

--- a/server/api/contributors.get.ts
+++ b/server/api/contributors.get.ts
@@ -1,3 +1,5 @@
+export type Role = 'steward' | 'maintainer' | 'contributor'
+
 export interface GitHubContributor {
   login: string
   id: number
@@ -5,26 +7,127 @@ export interface GitHubContributor {
   html_url: string
   contributions: number
   role: Role
+  sponsors_url: string | null
 }
 
-// TODO: stub - need to fetch list of role members from somewhere to avoid hardcoding (
-type Role = 'stewards' | 'core' | 'maintainers' | 'contributor'
-const roleMembers: Record<Exclude<Role, 'contributor'>, Set<GitHubContributor['login']>> = {
-  stewards: new Set(['danielroe', 'patak-dev']),
-  core: new Set([]),
-  maintainers: new Set([]),
+type GitHubAPIContributor = Omit<GitHubContributor, 'role' | 'sponsors_url'>
+
+// Fallback when no GitHub token is available (e.g. preview environments).
+// Only stewards are shown as maintainers; everyone else is a contributor.
+const FALLBACK_STEWARDS = new Set(['danielroe', 'patak-dev'])
+
+interface TeamMembers {
+  steward: Set<string>
+  maintainer: Set<string>
 }
 
-function getRoleInfo(login: string): { role: Role; order: number } {
-  if (roleMembers.stewards.has(login)) return { role: 'stewards', order: 0 }
-  if (roleMembers.core.has(login)) return { role: 'core', order: 1 }
-  if (roleMembers.maintainers.has(login)) return { role: 'maintainers', order: 2 }
-  return { role: 'contributor', order: 3 }
+async function fetchTeamMembers(token: string): Promise<TeamMembers | null> {
+  const teams: Record<keyof TeamMembers, string> = {
+    steward: 'stewards',
+    maintainer: 'maintainers',
+  }
+
+  try {
+    const result: TeamMembers = { steward: new Set(), maintainer: new Set() }
+
+    for (const [role, slug] of Object.entries(teams) as [keyof TeamMembers, string][]) {
+      const response = await fetch(
+        `https://api.github.com/orgs/npmx-dev/teams/${slug}/members?per_page=100`,
+        {
+          headers: {
+            'Accept': 'application/vnd.github.v3+json',
+            'Authorization': `Bearer ${token}`,
+            'User-Agent': 'npmx',
+          },
+        },
+      )
+
+      if (!response.ok) {
+        console.warn(`Failed to fetch ${slug} team members: ${response.status}`)
+        return null
+      }
+
+      const members = (await response.json()) as { login: string }[]
+      for (const member of members) {
+        result[role].add(member.login)
+      }
+    }
+
+    return result
+  } catch (error) {
+    console.warn('Failed to fetch team members from GitHub:', error)
+    return null
+  }
+}
+
+/**
+ * Batch-query GitHub GraphQL API to check which users have sponsors enabled.
+ * Returns a Set of logins that have a sponsors listing.
+ */
+async function fetchSponsorable(token: string, logins: string[]): Promise<Set<string>> {
+  if (logins.length === 0) return new Set()
+
+  // Build aliased GraphQL query: user0: user(login: "x") { hasSponsorsListing login }
+  const fragments = logins.map(
+    (login, i) => `user${i}: user(login: "${login}") { hasSponsorsListing login }`,
+  )
+  const query = `{ ${fragments.join('\n')} }`
+
+  try {
+    const response = await fetch('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'npmx',
+      },
+      body: JSON.stringify({ query }),
+    })
+
+    if (!response.ok) {
+      console.warn(`Failed to fetch sponsors info: ${response.status}`)
+      return new Set()
+    }
+
+    const json = (await response.json()) as {
+      data?: Record<string, { login: string; hasSponsorsListing: boolean } | null>
+    }
+
+    const sponsorable = new Set<string>()
+    if (json.data) {
+      for (const user of Object.values(json.data)) {
+        if (user?.hasSponsorsListing) {
+          sponsorable.add(user.login)
+        }
+      }
+    }
+    return sponsorable
+  } catch (error) {
+    console.warn('Failed to fetch sponsors info:', error)
+    return new Set()
+  }
+}
+
+function getRoleInfo(login: string, teams: TeamMembers): { role: Role; order: number } {
+  if (teams.steward.has(login)) return { role: 'steward', order: 0 }
+  if (teams.maintainer.has(login)) return { role: 'maintainer', order: 1 }
+  return { role: 'contributor', order: 2 }
 }
 
 export default defineCachedEventHandler(
   async (): Promise<GitHubContributor[]> => {
-    const allContributors: GitHubContributor[] = []
+    const githubToken = useRuntimeConfig().github.orgToken
+
+    // Fetch team members dynamically if token is available, otherwise use fallback
+    const teams: TeamMembers = await (async () => {
+      if (githubToken) {
+        const fetched = await fetchTeamMembers(githubToken)
+        if (fetched) return fetched
+      }
+      return { steward: FALLBACK_STEWARDS, maintainer: new Set<string>() }
+    })()
+
+    const allContributors: GitHubAPIContributor[] = []
     let page = 1
     const perPage = 100
 
@@ -35,6 +138,7 @@ export default defineCachedEventHandler(
           headers: {
             'Accept': 'application/vnd.github.v3+json',
             'User-Agent': 'npmx',
+            ...(githubToken && { Authorization: `Bearer ${githubToken}` }),
           },
         },
       )
@@ -46,7 +150,7 @@ export default defineCachedEventHandler(
         })
       }
 
-      const contributors = (await response.json()) as GitHubContributor[]
+      const contributors = (await response.json()) as GitHubAPIContributor[]
 
       if (contributors.length === 0) {
         break
@@ -54,7 +158,6 @@ export default defineCachedEventHandler(
 
       allContributors.push(...contributors)
 
-      // If we got fewer than perPage results, we've reached the end
       if (contributors.length < perPage) {
         break
       }
@@ -62,19 +165,28 @@ export default defineCachedEventHandler(
       page++
     }
 
-    return (
-      allContributors
-        // Filter out bots
-        .filter(c => !c.login.includes('[bot]'))
-        // Assign role
-        .map(c => {
-          const { role, order } = getRoleInfo(c.login)
-          return Object.assign(c, { role, order })
-        })
-        // Sort by role (steward > core > maintainer > contributor)
-        .sort((a, b) => a.order - b.order)
-        .map(({ order: _, ...rest }) => rest)
-    )
+    const filtered = allContributors.filter(c => !c.login.includes('[bot]'))
+
+    // Identify maintainers (stewards + maintainers) and check their sponsors status
+    const maintainerLogins = filtered
+      .filter(c => teams.steward.has(c.login) || teams.maintainer.has(c.login))
+      .map(c => c.login)
+
+    const sponsorable = githubToken
+      ? await fetchSponsorable(githubToken, maintainerLogins)
+      : new Set<string>()
+
+    return filtered
+      .map(c => {
+        const { role, order } = getRoleInfo(c.login, teams)
+        const sponsors_url = sponsorable.has(c.login)
+          ? `https://github.com/sponsors/${c.login}`
+          : null
+        Object.assign(c, { role, order, sponsors_url })
+        return c as GitHubContributor & { order: number; sponsors_url: string | null; role: Role }
+      })
+      .sort((a, b) => a.order - b.order || b.contributions - a.contributions)
+      .map(({ order: _, ...rest }) => rest)
   },
   {
     maxAge: 3600, // Cache for 1 hour


### PR DESCRIPTION
An attempt to sort contributors list by the governance role (steward > core > maintainer > contributor).

<img width="1049" height="558" alt="screenshot of contributor list in about page, daniel and patak is first two icons" src="https://github.com/user-attachments/assets/cfa1fe53-5ff1-4371-a036-09e7402e3efe" />


I cannot find a public member list of the maintainers so kept it empty for now.

One option to avoid hardcoding is to create GitHub Team for each governance role, and create members list in GitHub Actions with command like `gh api /orgs/npmx-dev/teams/steward/members --jq 'map(.login)`.

/cc @patak-dev @userquin

(ref. original chat: https://bsky.app/profile/patak.dev/post/3mek245m7as26)