### PR TITLE
feat: improve readme loading and error handling

### DIFF
--- a/app/components/Package/Readme.vue
+++ b/app/components/Package/Readme.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import Readme from '../Readme.vue'
+
+const props = defineProps<{
+  packageName: string
+  requestedVersion: string | null
+  repositoryUrl: string | null
+}>()
+
+// Fetch README for specific version if requested, otherwise latest
+const { data } = useLazyFetch<ReadmeResponse>(
+  () => {
+    const base = `/api/registry/readme/${props.packageName}`
+    const version = props.requestedVersion
+    return version ? `${base}/v/${version}` : base
+  },
+  { default: () => ({ html: '', md: '', playgroundLinks: [], toc: [] }) },
+)
+
+// Track active TOC item based on scroll position
+const tocItems = computed(() => data.value?.toc ?? [])
+const { activeId: activeTocId } = useActiveTocItem(tocItems)
+
+//copy README file as Markdown
+const { copied: copiedReadme, copy: copyReadme } = useClipboard({
+  source: () => data.value?.md ?? '',
+  copiedDuring: 2000,
+})
+</script>
+
+<template>
+  <div class="flex flex-wrap items-center justify-between mb-3 px-1">
+    <h2 id="readme-heading" class="group text-xs text-fg-subtle uppercase tracking-wider">
+      <LinkBase to="#readme">
+        {{ $t('package.readme.title') }}
+      </LinkBase>
+    </h2>
+    <div class="flex gap-2">
+      <!-- Copy readme as Markdown button -->
+      <TooltipApp v-if="data?.md" :text="$t('package.readme.copy_as_markdown')" position="bottom">
+        <ButtonBase
+          @click="copyReadme()"
+          :aria-pressed="copiedReadme"
+          :aria-label="copiedReadme ? $t('common.copied') : $t('package.readme.copy_as_markdown')"
+          :classicon="copiedReadme ? 'i-carbon:checkmark' : 'i-simple-icons:markdown'"
+        >
+          {{ copiedReadme ? $t('common.copied') : $t('common.copy') }}
+        </ButtonBase>
+      </TooltipApp>
+      <ReadmeTocDropdown
+        v-if="data?.toc && data.toc.length > 1"
+        :toc="data.toc"
+        :active-id="activeTocId"
+      />
+    </div>
+  </div>
+
+  <!-- eslint-disable vue/no-v-html -- HTML is sanitized server-side -->
+  <Readme v-if="data?.html" :html="data.html" />
+  <p v-else class="text-fg-muted italic">
+    {{ $t('package.readme.no_readme') }}
+    <a
+      v-if="repositoryUrl"
+      :href="repositoryUrl"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="link text-fg underline underline-offset-4 decoration-fg-subtle hover:(decoration-fg text-fg) transition-colors duration-200"
+      >{{ $t('package.readme.view_on_github') }}</a
+    >
+  </p>
+</template>
+
+<style module>
+.areaReadme {
+  grid-area: readme;
+}
+
+.areaReadme > :global(.readme) {
+  overflow-x: hidden;
+}
+</style>

--- a/app/components/ReadmeTocDropdown.vue
+++ b/app/components/ReadmeTocDropdown.vue
@@ -152,7 +152,6 @@ function handleKeydown(event: KeyboardEvent) {
     @click="toggle"
     @keydown="handleKeydown"
     classicon="i-carbon:list"
-    class="px-2.5"
     block
   >
     <span

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -236,6 +236,7 @@
       "no_readme": "No README available.",
       "view_on_github": "View on GitHub",
       "toc_title": "Outline",
+      "load_error": "Failed to load README",
       "callout": {
         "note": "Note",
         "tip": "Tip",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -712,6 +712,9 @@
             "toc_title": {
               "type": "string"
             },
+            "load_error": {
+              "type": "string"
+            },
             "callout": {
               "type": "object",
               "properties": {

--- a/lunaria/files/en-GB.json
+++ b/lunaria/files/en-GB.json
@@ -235,6 +235,7 @@
       "no_readme": "No README available.",
       "view_on_github": "View on GitHub",
       "toc_title": "Outline",
+      "load_error": "Failed to load README",
       "callout": {
         "note": "Note",
         "tip": "Tip",

--- a/lunaria/files/en-US.json
+++ b/lunaria/files/en-US.json
@@ -235,6 +235,7 @@
       "no_readme": "No README available.",
       "view_on_github": "View on GitHub",
       "toc_title": "Outline",
+      "load_error": "Failed to load README",
       "callout": {
         "note": "Note",
         "tip": "Tip",

--- a/server/api/registry/file/[...pkg].get.ts
+++ b/server/api/registry/file/[...pkg].get.ts
@@ -94,7 +94,7 @@ async function fetchFileContent(
  * - /api/registry/file/@scope/packageName/v/1.2.3/path/to/file.ts
  */
 export default defineCachedEventHandler(
-  async event => {
+  async (event): Promise<PackageFileContentResponse> => {
     // Parse: [pkg, 'v', version, ...filePath] or [@scope, pkg, 'v', version, ...filePath]
     const pkgParamSegments = getRouterParam(event, 'pkg')?.split('/') ?? []
 

--- a/server/api/registry/readme/[...pkg].get.ts
+++ b/server/api/registry/readme/[...pkg].get.ts
@@ -56,7 +56,7 @@ async function fetchReadmeFromJsdelivr(
  * - /api/registry/readme/@scope/packageName/v/1.2.3 - scoped package, specific version
  */
 export default defineCachedEventHandler(
-  async event => {
+  async (event): Promise<ReadmeResponse> => {
     // Parse package name and optional version from URL segments
     // Patterns: [pkg] or [pkg, 'v', version] or [@scope, pkg] or [@scope, pkg, 'v', version]
     const pkgParamSegments = getRouterParam(event, 'pkg')?.split('/') ?? []

--- a/server/api/registry/readme/[...pkg].get.ts
+++ b/server/api/registry/readme/[...pkg].get.ts
@@ -107,7 +107,7 @@ export default defineCachedEventHandler(
       }
 
       if (!readmeContent || readmeContent === NPM_MISSING_README_SENTINEL) {
-        return { html: '', playgroundLinks: [], toc: [] }
+        return { html: '', playgroundLinks: [], toc: [], md: '' }
       }
 
       // Parse repository info for resolving relative URLs to GitHub


### PR DESCRIPTION
For now a little experimental, what to do some exploration and see if this could be a direction we can/should be going.

1. **Extract Readme component from package page**
    This has the benefit of better separation of concerns. The data loading is also moved into the component. Since the Playground component needs the same data, both now do a fetch, but that gets deduplicated.
2. **Add explicit loading and error state for Readme**
    This mainly fixes the issue of "There is no Readme appearing" when something goes wrong

As it is currently implemented I am not sure in which cases the loading state for the Readme would appear. We could load it non-blocking which would render the rest of the page faster so it can load in the background. I am not sure exactly though what the best way to do this in Nuxt is.

I think ideally the whole page should be rendered via SSR, if all the fetches have cached results. Otherwise a component like the readme component could be client side rendered to have faster time to interaction.

This pattern would also allow us to control the loading skeletons on a per component basis, while making it easier to already show headings etc.

If we would follow through with this the whole page could be small components, each fetching their own data, with Nuxt deduplication making sure we fetch the same thing twice. I have worked with a similar pattern in Next and I really liked it from a DX as well as from a UX perspective (because it makes it easier to show each thing as early as possible, without being blocked by other data that might be needed elsewhere).

### Open questions
- SWR. Currently you might see an outdated version of the readme, but it looks ready and then might change after a moment to the current version. Is that what we want? Shouldn't there at least be some indication that it's still refreshing?
- I think someone mentioned that caching happens only for explicit version, but most package views will come from non-explicit version, so they will always have to get the correct version first?
- There might also be some problem with the current setup and changes to be made, because I am not sure, if this way the Readme will start to fetch it's data before the main package page is ready.