### PR TITLE
fix: improve collapsible section state detection

### DIFF
--- a/app/components/CollapsibleSection.vue
+++ b/app/components/CollapsibleSection.vue
@@ -26,7 +26,7 @@ onPrehydrate(() => {
   const settings = JSON.parse(localStorage.getItem('npmx-settings') || '{}')
   const collapsed: string[] = settings?.sidebar?.collapsed || []
   for (const id of collapsed) {
-    if (!document.documentElement.dataset.collapsed?.includes(id)) {
+    if (!document.documentElement.dataset.collapsed?.split(' ').includes(id)) {
       document.documentElement.dataset.collapsed = (
         document.documentElement.dataset.collapsed +
         ' ' +
@@ -38,7 +38,9 @@ onPrehydrate(() => {
 
 onMounted(() => {
   if (document?.documentElement) {
-    isOpen.value = !(document.documentElement.dataset.collapsed?.includes(props.id) ?? false)
+    isOpen.value = !(
+      document.documentElement.dataset.collapsed?.split(' ').includes(props.id) ?? false
+    )
   }
 })
 


### PR DESCRIPTION
Collapsible sections (_in the sidebar of package pages_) sometimes showed content that weren't clickable.

The problem was that the logic simply checked for the presence of the current section's id in the dataset. For example - if `optional-dependencies` were collapsed, this check also worked for `dependencies` section, marking the wrong section as !isOpen.

At the same time, the content was visible, since the required style for hiding was not added (it is added by passing through exact ids)