### PR TITLE
fix(a11y): add tabindex to main content

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -127,7 +127,7 @@ if (import.meta.client) {
 
     <AppHeader :show-logo="!isHomepage" />
 
-    <div id="main-content" class="flex-1 flex flex-col">
+    <div id="main-content" class="flex-1 flex flex-col" tabindex="-1">
       <NuxtPage />
     </div>
 


### PR DESCRIPTION
Add tabindex="-1" to the #main-content container so it can receive focus when using the skip-link feature.

Before tabbing and clicking the skip link, it would simply scroll to the main content, but tabbing would still start from the first element on the page (the logo).

https://github.com/user-attachments/assets/75cba5ac-eccd-457c-ad10-73f3e0fb1a71

After adding tabindex="-1", clicking the skip link focuses on the main, and the next tab goes to the first element of the main content.

https://github.com/user-attachments/assets/909e98e8-3766-46fd-ba6d-49f024069205

