### PR TITLE
fix: missed input parts on quick search

### DIFF
--- a/app/components/Header/SearchBox.vue
+++ b/app/components/Header/SearchBox.vue
@@ -28,8 +28,7 @@ const showSearchBar = computed(() => {
   return route.name !== 'index'
 })
 
-// Local input value (updates immediately as user types)
-const searchQuery = shallowRef(normalizeSearchParam(route.query.q))
+const searchQuery = useGlobalSearchQuery()
 
 // Pages that have their own local filter using ?q
 const pagesWithLocalFilter = new Set(['~username', 'org'])
@@ -74,21 +73,6 @@ const updateUrlQuery = Object.assign(
 watch(searchQuery, value => {
   updateUrlQuery(value)
 })
-
-// Sync input with URL when navigating (e.g., back button)
-watch(
-  () => route.query.q,
-  urlQuery => {
-    // Don't sync from pages that use ?q for local filtering
-    if (pagesWithLocalFilter.has(route.name as string)) {
-      return
-    }
-    const value = normalizeSearchParam(urlQuery)
-    if (searchQuery.value !== value) {
-      searchQuery.value = value
-    }
-  },
-)
 
 function handleSubmit() {
   if (pagesWithLocalFilter.has(route.name as string)) {

--- a/app/composables/useGlobalSearchQuery.ts
+++ b/app/composables/useGlobalSearchQuery.ts
@@ -1,0 +1,16 @@
+import { normalizeSearchParam } from '#shared/utils/url'
+
+export function useGlobalSearchQuery() {
+  const route = useRoute()
+  const searchQuery = useState<string>('search-query', () => normalizeSearchParam(route.query.q))
+
+  // clean search input when navigating away from search page
+  watch(
+    () => route.query.q,
+    urlQuery => {
+      const value = normalizeSearchParam(urlQuery)
+      if (!value) searchQuery.value = ''
+    },
+  )
+  return searchQuery
+}

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -4,7 +4,7 @@ import { SHOWCASED_FRAMEWORKS } from '~/utils/frameworks'
 
 const { searchProvider } = useSearchProvider()
 
-const searchQuery = shallowRef('')
+const searchQuery = useGlobalSearchQuery()
 const isSearchFocused = shallowRef(false)
 
 async function search() {

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -38,8 +38,8 @@ const updateUrlPage = debounce((page: number) => {
   })
 }, 500)
 
-// The actual search query (from URL, used for API calls)
-const query = computed(() => normalizeSearchParam(route.query.q))
+const searchQuery = useGlobalSearchQuery()
+const query = computed(() => searchQuery.value)
 
 // Track if page just loaded (for hiding "Searching..." during view transition)
 const hasInteracted = shallowRef(false)


### PR DESCRIPTION
## What

The user would type in one place, and several navigations would launch for each input. Then the route from the first navigation would change, and the user would continue typing—but navigation from the first page would still continue. They rewrote the route and the query listener updated the field value

## How

I created a global storage for search fields, and both fields write to it. The field doesn't actually listen to query now, but only uses it for default value and as the factor that `q` has been cleared (_when exiting the search_)

So now there's a single source of truth - the search store. And query parameter is simply synchronized with it for page reloads and for the server

resolves #1211 resolves #764