### PR TITLE
fix: remove html comments from package description and deprecation notices

### DIFF
--- a/app/composables/useMarkdown.ts
+++ b/app/composables/useMarkdown.ts
@@ -37,8 +37,8 @@ function stripAndEscapeHtml(text: string, packageName?: string): string {
   // Only match tags that start with a letter or / (to avoid matching things like "a < b > c")
   stripped = stripped.replace(/<\/?[a-z][^>]*>/gi, '')
 
-  // Strip HTML comments: <!-- ... -->
-  stripped = stripped.replace(/<!--[\s\S]*?-->/g, '')
+  // Strip HTML comments: <!-- ... --> (including unclosed comments from truncation)
+  stripped = stripped.replace(/<!--[\s\S]*?(-->|$)/g, '')
 
   if (packageName) {
     // Trim first to handle leading/trailing whitespace from stripped HTML

--- a/test/nuxt/composables/use-markdown.spec.ts
+++ b/test/nuxt/composables/use-markdown.spec.ts
@@ -344,5 +344,10 @@ describe('useMarkdown', () => {
       const processed = useMarkdown({ text: '<!-- automd:badges color=yellow -->' })
       expect(processed.value).toBe('')
     })
+
+    it('strips unclosed HTML comments (truncated)', () => {
+      const processed = useMarkdown({ text: 'A library <!-- automd:badges color=yel' })
+      expect(processed.value).toBe('A library ')
+    })
   })
 })


### PR DESCRIPTION
Resolves https://github.com/npmx-dev/npmx.dev/issues/1354

Not ideal as packages might have *no description* then but given that the description is fetched directly from NPM, we could only parse the README and take the first non-comment line.
This could be done in another iteration if worth it