### PR TITLE
fix(a11y): use semantic html for keyword list

### DIFF
--- a/app/components/Package/Card.vue
+++ b/app/components/Package/Card.vue
@@ -161,7 +161,7 @@ const numberFormatter = useNumberFormatter()
     </div>
 
     <ul
-        role="list"  
+      role="list"
       v-if="result.package.keywords?.length"
       :aria-label="$t('package.card.keywords')"
       class="relative z-10 flex flex-wrap gap-1.5 mt-3 pt-3 border-t border-border list-none m-0 p-0 pointer-events-none items-center"


### PR DESCRIPTION
The `aria-label` is invalid on a `<div>` element. I seized the opportunity and used semantic html (ul + li) to describe the keyword list better, which also permits the `aria-label` attribute.