### PR TITLE
fix: position of icon in readme callouts

### DIFF
--- a/app/components/Readme.vue
+++ b/app/components/Readme.vue
@@ -291,6 +291,7 @@ function handleClick(event: MouseEvent) {
   height: 1.25rem;
   position: absolute;
   top: 1rem;
+  left: 1rem;
 }
 
 .readme :deep(blockquote[data-callout] > p:first-child) {


### PR DESCRIPTION
Fixes https://github.com/npmx-dev/npmx.dev/issues/1415

After:

<img width="1064" height="779" alt="image" src="https://github.com/user-attachments/assets/18a2f8ca-66b6-4357-984d-3c09e7756114" />
