### PR TITLE
fix: type prehydrate settings as AppSettings

### DIFF
--- a/app/utils/prehydrate.ts
+++ b/app/utils/prehydrate.ts
@@ -16,7 +16,9 @@ export function initPreferencesOnPrehydrate() {
     const validPMs = new Set(['npm', 'pnpm', 'yarn', 'bun', 'deno', 'vlt'])
 
     // Read settings from localStorage
-    const settings = JSON.parse(localStorage.getItem('npmx-settings') || '{}')
+    const settings = JSON.parse(
+      localStorage.getItem('npmx-settings') || '{}',
+    ) as Partial<AppSettings>
 
     const accentColorId = settings.accentColorId
     if (accentColorId && accentColorIds.has(accentColorId)) {


### PR DESCRIPTION
This fixes an `any` type on the settings var that is getting read from the `localStorage`.
I fixed this by parsing the settings object as the `AppSettings` type from `/app/composables/useSettings.ts`