### PR TITLE
feat: ctrl+k to focus search

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -47,22 +47,36 @@ if (import.meta.server) {
   setJsonLd(createWebSiteSchema())
 }
 
+function focusSearchOrNavigate() {
+  const searchInput = document.querySelector<HTMLInputElement>(
+    'input[type="search"], input[name="q"]',
+  )
+
+  if (searchInput) {
+    searchInput.focus()
+    return
+  }
+
+  router.push({ name: 'search' })
+}
+
 onKeyDown(
   '/',
   e => {
     if (isEditableElement(e.target)) return
     e.preventDefault()
+    focusSearchOrNavigate()
+  },
+  { dedupe: true },
+)
 
-    const searchInput = document.querySelector<HTMLInputElement>(
-      'input[type="search"], input[name="q"]',
-    )
-
-    if (searchInput) {
-      searchInput.focus()
-      return
-    }
-
-    router.push({ name: 'search' })
+onKeyDown(
+  // Explicitly check Ctrl+K for broader compatibility (especially Firefox)
+  e => e.ctrlKey && e.key === 'k',
+  e => {
+    if (isEditableElement(e.target)) return
+    e.preventDefault()
+    focusSearchOrNavigate()
   },
   { dedupe: true },
 )

--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -49,6 +49,10 @@ const showModal = () => modalRef.value?.showModal?.()
                 <span>{{ $t('shortcuts.focus_search') }}</span>
               </li>
               <li class="flex gap-2 items-center">
+                <kbd class="kbd">Ctrl</kbd>+<kbd class="kbd">K</kbd>
+                <span>{{ $t('shortcuts.focus_search') }}</span>
+              </li>
+              <li class="flex gap-2 items-center">
                 <kbd class="kbd">?</kbd>
                 <span>{{ $t('shortcuts.show_kbd_hints') }}</span>
               </li>


### PR DESCRIPTION
Make `ctrl`+`k` focus the search.
Show new keyboard shortcut in keyboard shortcuts modal:

<img width="244" height="207" alt="ctrl+k keyboard shortcut in keyboard shortcuts modal" src="https://github.com/user-attachments/assets/5d72d155-c0c2-43d3-9397-77fedf0edeff" />
