### PR TITLE
fix: do not run lunaria when making a merge commit

### DIFF
--- a/lunaria/lunaria.ts
+++ b/lunaria/lunaria.ts
@@ -1,8 +1,15 @@
 import { createLunaria } from '@lunariajs/core'
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { Page } from './components.ts'
 import { lunariaJSONFiles, prepareJsonFiles } from './prepare-json-files.ts'
 import type { I18nStatus } from '../shared/types/i18n-status.ts'
+
+// skip lunaria during git merges as git history may be in an inconsistent state.
+if (existsSync('.git/MERGE_HEAD')) {
+  // eslint-disable-next-line no-console
+  console.log('Skipping lunaria: git merge in progress')
+  process.exit(0)
+}
 
 await prepareJsonFiles()
 

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "node": "24"
   },
   "simple-git-hooks": {
-    "pre-commit": "[ -n \"$NO_VERIFY\" ] && exit 0\nnpx lint-staged"
+    "pre-commit": "npx lint-staged"
   },
   "lint-staged": {
     "i18n/locales/*": [


### PR DESCRIPTION
I noticed during a meeting that when resolving merge-conflicts with `--continue`, Lunaria crashes (_it often can't find the file combination for large changes_). But when using `--continue` - you can't use `--no-verify` to bypass it.

I've added an option to bypass it via an env variable (`NO_VERIFY=1`) until we figure it out better

`NO_VERIFY=1 git merge --continue` 

or something similar if passing variables is not supported in the system/terminal

`cross-env NO_VERIFY=1 git merge --continue`

@ghostdevv fyi 

<img width="783" height="111" alt="image" src="https://github.com/user-attachments/assets/be74a216-aa56-40eb-90f3-8c28e933b666" />
