### PR TITLE
chore: remove `vacations` from lunaria and compare logic

### DIFF
--- a/lunaria/files/en-GB.json
+++ b/lunaria/files/en-GB.json
@@ -1109,40 +1109,5 @@
       "p1": "If you encounter an accessibility barrier on {app}, please let us know by opening an issue on our {link}. We take these reports seriously and will do our best to address them.",
       "link": "GitHub repository"
     }
-  },
-  "vacations": {
-    "title": "on vacation",
-    "meta_description": "The npmx team is recharging. Discord reopens in a week.",
-    "heading": "recharging",
-    "subtitle": "we've been building npmx at a pace that has cost {some} of us sleep. we don't want that to be the norm! so we are taking a week off. together.",
-    "illustration_alt": "a single row of cosy icons",
-    "poke_log": "Poke the campfire",
-    "what": {
-      "title": "what's happening",
-      "p1": "discord is closed {dates}.",
-      "dates": "February 14 – 21",
-      "p2": "all invite links are gone and channels are locked – except {garden}, which stays open for folks who want to keep hanging out.",
-      "garden": "#garden"
-    },
-    "meantime": {
-      "title": "in the meantime",
-      "p1": "{site} and {repo} stay open – dig in, file issues, open PRs. we'll get to everything when we're back. just don't expect a fast review. we'll be somewhere near a cosy fireplace.",
-      "repo_link": "the repo"
-    },
-    "return": {
-      "title": "see you soon",
-      "p1": "we'll come back recharged and ready for the final push to March 3rd. {social} for updates.",
-      "social_link": "follow us on Bluesky",
-      "add_to_calendar": "remind me when Discord reopens"
-    },
-    "stats": {
-      "contributors": "Contributors",
-      "commits": "Commits",
-      "pr": "PRs Merged",
-      "subtitle": {
-        "some": "some",
-        "all": "all"
-      }
-    }
   }
 }

--- a/lunaria/files/en-US.json
+++ b/lunaria/files/en-US.json
@@ -1109,40 +1109,5 @@
       "p1": "If you encounter an accessibility barrier on {app}, please let us know by opening an issue on our {link}. We take these reports seriously and will do our best to address them.",
       "link": "GitHub repository"
     }
-  },
-  "vacations": {
-    "title": "on vacation",
-    "meta_description": "The npmx team is recharging. Discord reopens in a week.",
-    "heading": "recharging",
-    "subtitle": "we've been building npmx at a pace that has cost {some} of us sleep. we don't want that to be the norm! so we are taking a week off. together.",
-    "illustration_alt": "a single row of cosy icons",
-    "poke_log": "Poke the campfire",
-    "what": {
-      "title": "what's happening",
-      "p1": "discord is closed {dates}.",
-      "dates": "February 14 – 21",
-      "p2": "all invite links are gone and channels are locked – except {garden}, which stays open for folks who want to keep hanging out.",
-      "garden": "#garden"
-    },
-    "meantime": {
-      "title": "in the meantime",
-      "p1": "{site} and {repo} stay open – dig in, file issues, open PRs. we'll get to everything when we're back. just don't expect a fast review. we'll be somewhere near a cosy fireplace.",
-      "repo_link": "the repo"
-    },
-    "return": {
-      "title": "see you soon",
-      "p1": "we'll come back recharged and ready for the final push to March 3rd. {social} for updates.",
-      "social_link": "follow us on Bluesky",
-      "add_to_calendar": "remind me when Discord reopens"
-    },
-    "stats": {
-      "contributors": "Contributors",
-      "commits": "Commits",
-      "pr": "PRs Merged",
-      "subtitle": {
-        "some": "some",
-        "all": "all"
-      }
-    }
   }
 }

--- a/lunaria/prepare-json-files.ts
+++ b/lunaria/prepare-json-files.ts
@@ -66,9 +66,11 @@ export async function mergeLocaleObject(locale: LocaleObject): Promise<NestedObj
 
 async function loadLocaleSourceJson<T = unknown>(name: string): Promise<T> {
   const rawJson = JSON.parse(await fs.readFile(path.resolve(`${localesFolder}/${name}`), 'utf8'))
-  // Exclude $schema since it isn't useful in generated files and the relative path
+  // Exclude $schema since it isn't useful in generated files and the relative
+
+  // TODO: removing vacations entry key for temporal recharging page
   // would be wrong anyway
-  const { $schema: _, ...rest } = rawJson
+  const { $schema: _, vacations: __, ...rest } = rawJson
   return rest
 }
 

--- a/scripts/compare-translations.ts
+++ b/scripts/compare-translations.ts
@@ -385,6 +385,9 @@ const run = async (): Promise<void> => {
     lang: 'en',
   })
 
+  // TODO: removing vacations entry key for temporal recharging page
+  delete referenceContent.vacations
+
   // $schema is a JSON Schema reference, not a translation key
   delete referenceContent.$schema
 


### PR DESCRIPTION
This PR just removes `vacations` included at #1363 when running:
- `build:lunaria` script: preparing lunaria files
- `i18n:check` and `i18n:check:fix` scripts: check and fix translation files

This will keep translation statuses ok: without this PR we'll have missing entries for `vacations.*`, `app/pages/recharging.vue` is a temporal page that will be removed once we're back).