### PR TITLE
docs: add `vscode-open-in-npmx` to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ We welcome contributions &ndash; please do feel free to explore the project and 
 - [npm-userscript](https://github.com/bluwy/npm-userscript) &ndash; Browser userscript with various improvements and fixes for npmjs.com
 - [npm-alt](https://npm.willow.sh/) &ndash; An alternative npm package browser
 - [npkg.lorypelli.dev](https://npkg.lorypelli.dev/) &ndash; An alternative frontend to npm made with as little client-side JavaScript as possible
-- [vscode-npmx](https://github.com/npmx-dev/vscode-npmx) &ndash; VSCode extension for npmx
+- [vscode-npmx](https://github.com/npmx-dev/vscode-npmx) &ndash; Official VSCode extension for npmx
+- [vscode-open-in-npmx](https://github.com/sybers/vscode-open-in-npmx) &ndash; VSCode shortcut to open packages on npmx
 - [nxjt](https://nxjt.netlify.app) &ndash; npmx Jump To: Quickly navigate to npmx common webpages.
 - [npmx-weekly](https://npmx-weekly.trueberryless.org/) &ndash; A weekly newsletter for the npmx ecosystem. Add your own content via suggestions in the weekly PR on [GitHub](https://github.com/trueberryless-org/npmx-weekly/pulls?q=is%3Aopen+is%3Apr+label%3A%22%F0%9F%95%94+weekly+post%22).
 - [npmx-digest](https://npmx-digest.trueberryless.org/) &ndash; An automated news aggregation website that summarizes npmx activity from GitHub and Bluesky every 8 hours.


### PR DESCRIPTION
Hey!

I quickly made [this extension](https://github.com/sybers/vscode-open-in-npmx) to have a command to open currently selected text or current package on npmx.dev.

I know there's already a VSCode extension, but I wanted something dead simple just to have a shortcut and I think some other folks might also just need this.

I'd understand if you'd prefer to keep only the official extension in the Readme :)