### PR TITLE
fix: search restore

### DIFF
--- a/app/composables/useGlobalSearch.ts
+++ b/app/composables/useGlobalSearch.ts
@@ -26,6 +26,7 @@ export function useGlobalSearch() {
     urlQuery => {
       const value = normalizeSearchParam(urlQuery)
       if (!value) searchQuery.value = ''
+      if (!searchQuery.value) searchQuery.value = value
     },
   )
   const updateUrlQueryImpl = (value: string, provider: 'npm' | 'algolia') => {


### PR DESCRIPTION
When navigating through elements other than our own, there's a chance that the search won't be restored. Since we always use replace within the search function, the only chance for this to happen is before switching from non-search to search (for example, via browser navigation buttons).

I most likely lost this during the initial improvements. Restoring it with a micro-fix

This does not affect all improvements, since the field will always be filled in during internal navigation (_filling first, then navigation_)