### PR TITLE
chore: exclude prereleases from outdated packages

### DIFF
--- a/app/composables/npm/useOutdatedDependencies.ts
+++ b/app/composables/npm/useOutdatedDependencies.ts
@@ -102,7 +102,8 @@ export function useOutdatedDependencies(
       let latestStable = data.distTags.latest
       if (!latestStable) continue
 
-      // If latest tag is a prerelease, find the latest stable version instead
+      // If latest tag is a prerelease, find the latest stable version instead. Take note that this
+      // overrides the latest distTag.
       if (prerelease(latestStable)) {
         const stableVersions = data.versions.filter(v => !prerelease(v))
         if (stableVersions.length > 0) {


### PR DESCRIPTION
Fixes #1456. However, this might need some discussion because the problematic behaviour can be interpreted in two ways:

1. A developer intentionally chose to tag a version as `latest`, and we should honour this decision
2. A developer mistakenly tagged the version as `latest`, and we decided that `*-alpha` or `*-beta` should overrule the distTag

What are your thoughts on this?