### PR TITLE
fix(i18n): update Japanese translations

### DIFF
--- a/i18n/locales/ja-JP.json
+++ b/i18n/locales/ja-JP.json
@@ -355,7 +355,8 @@
       "facet": "指標",
       "title": "トレンド",
       "items": {
-        "downloads": "ダウンロード数"
+        "downloads": "ダウンロード数",
+        "likes": "いいね数"
       }
     },
     "downloads": {

--- a/lunaria/files/ja-JP.json
+++ b/lunaria/files/ja-JP.json
@@ -354,7 +354,8 @@
       "facet": "指標",
       "title": "トレンド",
       "items": {
-        "downloads": "ダウンロード数"
+        "downloads": "ダウンロード数",
+        "likes": "いいね数"
       }
     },
     "downloads": {


### PR DESCRIPTION
- adjust existing translations
- improved the a11y page to more clearly express our thoughts and efforts on a11y
- add missing keys, including vacation strings