### PR TITLE
feat(i18n): change default cache for `/lunaria/status.json`

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -158,6 +158,12 @@ export default defineNuxtConfig({
     '/_v/view': { proxy: 'https://npmx.dev/_vercel/insights/view' },
     '/_v/event': { proxy: 'https://npmx.dev/_vercel/insights/event' },
     '/_v/session': { proxy: 'https://npmx.dev/_vercel/insights/session' },
+    // lunaria status.json
+    '/lunaria/status.json': {
+      headers: {
+        'Cache-Control': 'public, max-age=0, must-revalidate',
+      },
+    },
   },
 
   experimental: {


### PR DESCRIPTION
We need to avoid default Vercel cache headers for json files: `public, max-age=86400, immutable`, this PR changes the cache control to `public, max-age=0, must-revalidate` to allow get a fresh `status.json` file on every i18n deployment change. 

Since Vercel will send `last-modified`, using `useFech` will receive a 200 when updated and a 304 (`not modified`) when not changed and once at browser cache.

_/lunaria/status.json not being updated without disabling cache at devtools_
<img width="606" height="374" alt="image" src="https://github.com/user-attachments/assets/7b903131-fba1-45fc-8e24-d015fdf8b762" />

_/lunaria/status.json with this PR and once in browser cache_
<img width="984" height="315" alt="image" src="https://github.com/user-attachments/assets/090affff-e0cd-49db-8b6d-b9b3c7b617de" />

