### PR TITLE
chore: add "v" before version number on badges

### DIFF
--- a/server/api/registry/badge/[type]/[...pkg].get.ts
+++ b/server/api/registry/badge/[type]/[...pkg].get.ts
@@ -123,8 +123,12 @@ async function fetchInstallSize(packageName: string, version: string): Promise<n
 
 const badgeStrategies = {
   'version': async (pkgData: globalThis.Packument, requestedVersion?: string) => {
-    const value = requestedVersion ?? getLatestVersion(pkgData) ?? 'unknown'
-    return { label: 'version', value, color: COLORS.blue }
+    const version = requestedVersion ?? getLatestVersion(pkgData) ?? 'unknown'
+    return {
+      label: 'version',
+      value: version === 'unknown' ? version : `v${version}`,
+      color: COLORS.blue,
+    }
   },
 
   'license': async (pkgData: globalThis.Packument) => {

--- a/test/e2e/badge.spec.ts
+++ b/test/e2e/badge.spec.ts
@@ -61,7 +61,7 @@ test.describe('badge API', () => {
 
         expect(response.status()).toBe(200)
         if (type === 'version') {
-          expect(body).toContain('3.12.0')
+          expect(body).toContain('v3.12.0')
         }
       })
 


### PR DESCRIPTION
In other places, we show package version number with "v" prefix, which also helps recognizing what number we're actually looking at if we override label:

![nuxt](https://github.com/user-attachments/assets/4b406fdf-2334-43a1-9037-ecd0acaeeea3)

It's also in line with shields.io style:

![](https://img.shields.io/npm/v/nuxt.svg)