### PR TITLE
fix: add Luau icons

### DIFF
--- a/app/utils/file-icons.ts
+++ b/app/utils/file-icons.ts
@@ -78,6 +78,7 @@ export const EXTENSION_ICONS: Record<string, string> = {
   'cs': 'vscode-icons-file-type-csharp',
   'php': 'vscode-icons-file-type-php',
   'lua': 'vscode-icons-file-type-lua',
+  'luau': 'vscode-icons-file-type-luau',
   'r': 'vscode-icons-file-type-r',
   'sql': 'vscode-icons-file-type-sql',
   'pl': 'vscode-icons-file-type-perl',


### PR DESCRIPTION
[Luau](https://luau-lang.org/) icons are missing from the source file viewer.

This is commonly a problem for orgs like [`@rbxts`](https://npmx.dev/org/rbxts), which has hundreds of packages with luau source files.

This PR adds the luau icon, using the [vscode-icons](https://icon-sets.iconify.design/vscode-icons/?icon-filter=luau&keyword=vscode) pack.

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/bbb68d8d-7194-44a6-bf63-fa2ad7ab6330" alt="Before: generic file icons for .luau files" width="100%" /> | <img src="https://github.com/user-attachments/assets/d9bb5f02-927e-46c4-a41d-2a2b853c2e44" alt="After: Luau-specific icons in source file viewer" width="100%" /> |