### PR TITLE
fix(i18n): german translation for "hit" in a11y section + missing keys

### DIFF
--- a/i18n/locales/de-DE.json
+++ b/i18n/locales/de-DE.json
@@ -362,9 +362,11 @@
       "y_axis_label": "{granularity} {facet}",
       "facet": "Facette",
       "title": "Trends",
+      "contributors_skip": "Nicht angezeigt bei Mitwirkende (hat kein GitHub-Repository): | Nicht angezeigt bei Mitwirkende (haben kein GitHub-Repository):",
       "items": {
         "downloads": "Downloads",
-        "likes": "Likes"
+        "likes": "Likes",
+        "contributors": "Mitwirkende"
       }
     },
     "downloads": {

--- a/lunaria/files/de-DE.json
+++ b/lunaria/files/de-DE.json
@@ -361,9 +361,11 @@
       "y_axis_label": "{granularity} {facet}",
       "facet": "Facette",
       "title": "Trends",
+      "contributors_skip": "Nicht angezeigt bei Mitwirkende (hat kein GitHub-Repository): | Nicht angezeigt bei Mitwirkende (haben kein GitHub-Repository):",
       "items": {
         "downloads": "Downloads",
-        "likes": "Likes"
+        "likes": "Likes",
+        "contributors": "Mitwirkende"
       }
     },
     "downloads": {


### PR DESCRIPTION
stößt was missing an ö.

Also added missing German translation keys for the trends section (untranslated version below):

<img width="976" height="587" alt="image" src="https://github.com/user-attachments/assets/0ba5d875-18fd-4362-a53d-92a9a503ea22" />
