### PR TITLE
fix: detect esm only pkg w/ main and module fields

### DIFF
--- a/shared/utils/package-analysis.ts
+++ b/shared/utils/package-analysis.ts
@@ -82,8 +82,10 @@ export function detectModuleFormat(pkg: ExtendedPackageJson): ModuleFormat {
 
   // Legacy detection without exports field
   if (hasModule && hasMain) {
-    // Has both module (ESM) and main (CJS) fields
-    return 'dual'
+    // Check for dual packages (has module field and main points to cjs)
+    const mainIsCJS = pkg.main?.endsWith('.cjs') || (pkg.main?.endsWith('.js') && !isTypeModule)
+
+    return mainIsCJS ? 'dual' : 'esm'
   }
 
   if (hasModule || isTypeModule) {

--- a/test/unit/shared/utils/package-analysis.spec.ts
+++ b/test/unit/shared/utils/package-analysis.spec.ts
@@ -26,6 +26,16 @@ describe('detectModuleFormat', () => {
     expect(detectModuleFormat({ module: 'index.mjs', main: 'index.js' })).toBe('dual')
   })
 
+  it('detects dual from type + module + main fields', () => {
+    expect(detectModuleFormat({ type: 'module', module: 'index.js', main: 'index.cjs' })).toBe(
+      'dual',
+    )
+  })
+
+  it('detects esm from type + module + main fields', () => {
+    expect(detectModuleFormat({ type: 'module', module: 'index.js', main: 'index.js' })).toBe('esm')
+  })
+
   it('detects ESM from module field without main', () => {
     expect(detectModuleFormat({ module: 'index.mjs' })).toBe('esm')
   })


### PR DESCRIPTION
# Problem
[In the Compare feature](https://npmx.dev/compare?packages=lodash-es,lodash&facets=moduleFormat,license,vulnerabilities), the heuristic for legacy fallback for dual vs esm only detection has a bug currently where it assumes `main` contains CJS when the package also has a `module` field.

That reports ESM only packages w/ both esm main and module fields like [lodash-es](https://github.com/lodash/lodash/blob/a89086873c551e413ed6159654e4da2a6af549d6/package.json#L10-L13) as dual packages.
```json
  "type": "module",
  "jsnext:main": "lodash.js",
  "main": "lodash.js",
  "module": "lodash.js",
```

**Above is an ESM only package description, but currently that will be reported as "ESM + CJS"**

# Solution

Infer if the main field should be CJS or ESM. If main is `.cjs` extension then we for sure know it's CJS. If we have a `.js` file and no `"type": "module"` then we have a CJS file.


### 📸
Before:
<img width="401" height="56" alt="image" src="https://github.com/user-attachments/assets/7a713cfa-ca66-484b-83d6-3c3a40ba9d3f" />


After:
<img width="401" height="56" alt="image" src="https://github.com/user-attachments/assets/c2d25eb9-d0ba-490f-8b89-b186cc90d6d6" />
