### PR TITLE
docs: update 2.keyboard-shortcuts.md to match implementation

### DIFF
--- a/docs/content/2.guide/2.keyboard-shortcuts.md
+++ b/docs/content/2.guide/2.keyboard-shortcuts.md
@@ -7,30 +7,30 @@ navigation:
 
 npmx.dev supports keyboard navigation for faster browsing.
 
-## Use global shortcuts
+## Global shortcuts
 
-| Key | Action           |
-| --- | ---------------- |
-| `/` | Focus search bar |
-| `.` | Open code viewer |
+| Key | Action                   |
+| --- | ------------------------ |
+| `/` | Focus search bar         |
+| `?` | Highlight keyboard hints |
+| `,` | Open settings            |
+| `c` | Open compare             |
 
-## Navigate search results
+::tip
+These shortcuts work anywhere on the site. Press `/` from any page to quickly search for a package.
+::
+
+## Search results
 
 | Key                       | Action                |
 | ------------------------- | --------------------- |
 | `Arrow Up` / `Arrow Down` | Move through results  |
 | `Enter`                   | Open selected package |
 
-## Browse code
+## Package page
 
-When in the code viewer:
-
-| Key                       | Action             |
-| ------------------------- | ------------------ |
-| `Arrow Up` / `Arrow Down` | Navigate file tree |
-| `Enter`                   | Open selected file |
-| `Escape`                  | Close code viewer  |
-
-::tip
-These shortcuts work anywhere on the site. Press `/` from any page to quickly search for a package.
-::
+| Key | Action           |
+| --- | ---------------- |
+| `.` | Open code viewer |
+| `d` | Open docs        |
+| `c` | Compare package  |


### PR DESCRIPTION
- Add `?`, `,`, `c` to global shortcuts section and move `.` to package page section                                        
- Remove unimplemented browse code section (file tree arrow keys, enter, escape)                                            
- Add package page section with `.`, `d`, `c` shortcuts                                                                     
- Move tip to global shortcuts section where it belongs