### PR TITLE
feat: add TanStack Start to framework list

### DIFF
--- a/app/utils/frameworks.ts
+++ b/app/utils/frameworks.ts
@@ -61,6 +61,11 @@ export const SHOWCASED_FRAMEWORKS = [
     package: 'solid-js',
     color: 'oklch(0.4237 0.0857 255.45)',
   },
+  {
+    name: 'tanstack start',
+    package: '@tanstack/start',
+    color: 'oklch(60.9% .126 221.723)',
+  },
 ]
 
 export type FrameworkPackageName = (typeof SHOWCASED_FRAMEWORKS)[number]['package']


### PR DESCRIPTION
## Context

[TanStack Start](https://tanstack.com/start/latest) as a framework has been gaining popularity (13.5K GH Stars). Based on that, it makes sense to add it to the homepage framework list.

I've picked the `oklch` color based on the `--color-cyan-600` used on the TanStack Start page of the TanStack website.

<img width="1710" height="985" alt="Screenshot 2026-02-15 at 23 23 32" src="https://github.com/user-attachments/assets/d3f47aa7-7e75-4cdf-9b68-f45755f60303" />


## Screenshots

### Desktop
<img width="1710" height="940" alt="Screenshot 2026-02-15 at 23 27 09" src="https://github.com/user-attachments/assets/6e579abd-bf8d-4243-8998-8ff858426082" />

### Mobile
<img width="388" height="793" alt="Screenshot 2026-02-15 at 23 26 56" src="https://github.com/user-attachments/assets/c45f6687-74e3-4b6b-9366-43976066e391" />

CC: @tannerlinsley, @tkdodo, @schiller-manuel