### PR TITLE
fix: make social cards clickable and remove z-index trickery

### DIFF
--- a/app/components/CallToAction.vue
+++ b/app/components/CallToAction.vue
@@ -27,7 +27,7 @@ const socialLinks = computed(() => [
 ])
 
 function handleCardClick(event: MouseEvent) {
-  if ((event.target as HTMLElement).closest('a')) return
+  if ((event.target as HTMLElement).closest(':any-link')) return
   if (event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) return
 
   const selection = window.getSelection()


### PR DESCRIPTION
## Description
This PR addresses the usability issue where **clicking on text** within social cards did not trigger navigation.

Previously, the text elements were positioned above the link overlay (using `z-index`) to allow for text selection, but this created "dead zones" where clicks were not registered.

## Changes
- **Removed CSS Tricks:** Deleted the `absolute inset-0` link overlay and `z-1` classes, simplifying the DOM structure as suggested by @knowler.
- **Added Click Handler:** Implemented a `handleCardClick` function that programmatically clicks the CTA link when the card is clicked.
- **Preserved Native Behavior:** The handler checks for:
  - Nested links/icons (using `.closest('a')`)
  - Text selection (using `window.getSelection()`)
  - Modifier keys (Ctrl/Cmd/Shift/Alt)

## Demo

| Before | After |
| :---: | :---: |
| ![npmx_card_before](https://github.com/user-attachments/assets/5b3d3810-dcb7-4e72-9dbc-c3caf4870e1a) | ![npmx_card_after](https://github.com/user-attachments/assets/a06b2332-bc55-4cd2-b90e-2bbfdeb6167a) |



Fixes #1517