### PR TITLE
fix: improve versions modal input alignment

### DIFF
--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -1729,10 +1729,10 @@ watch(selectedMetric, value => {
           v-if="showResetButton"
           type="button"
           aria-label="Reset date range"
-          class="self-end flex items-center justify-center px-2.5 py-1.75 border border-transparent rounded-md text-fg-subtle hover:text-fg transition-colors hover:border-border focus-visible:outline-accent/70 sm:mb-0"
+          class="self-end flex items-center justify-center px-2.5 py-2.25 border border-transparent rounded-md text-fg-subtle hover:text-fg transition-colors hover:border-border focus-visible:outline-accent/70 sm:mb-0"
           @click="resetDateRange"
         >
-          <span class="i-lucide:undo-2 w-5 h-5" aria-hidden="true" />
+          <span class="block i-lucide:undo-2 w-5 h-5" aria-hidden="true" />
         </button>
       </div>
 


### PR DESCRIPTION
Before:
<img width="971" height="180" alt="before" src="https://github.com/user-attachments/assets/29e9f9f4-d29b-46f5-a0c3-06b0adafacc2" />

After:
<img width="1038" height="875" alt="after" src="https://github.com/user-attachments/assets/27d3632d-981a-4371-bae0-8245b089f774" />


