### PR TITLE
feat: rewrite npmjs.org links

### DIFF
--- a/server/utils/readme.ts
+++ b/server/utils/readme.ts
@@ -220,8 +220,10 @@ const reservedPathsNpmJs = [
   'policies',
 ]
 
+const npmJsHosts = new Set(['www.npmjs.com', 'npmjs.com', 'www.npmjs.org', 'npmjs.org'])
+
 const isNpmJsUrlThatCanBeRedirected = (url: URL) => {
-  if (url.host !== 'www.npmjs.com' && url.host !== 'npmjs.com') {
+  if (!npmJsHosts.has(url.host)) {
     return false
   }
 

--- a/test/unit/server/utils/readme.spec.ts
+++ b/test/unit/server/utils/readme.spec.ts
@@ -341,6 +341,20 @@ describe('Markdown File URL Resolution', () => {
 
       expect(result.html).toContain('href="https://www.npmjs.com/products"')
     })
+
+    it('redirects npmjs.org urls to local', async () => {
+      const markdown = `[Some npmjs.org link](https://www.npmjs.org/package/test-pkg)`
+      const result = await renderReadmeHtml(markdown, 'test-pkg')
+
+      expect(result.html).toContain('href="/package/test-pkg"')
+    })
+
+    it('redirects npmjs.org urls to local (no www and http)', async () => {
+      const markdown = `[Some npmjs.org link](http://npmjs.org/package/test-pkg)`
+      const result = await renderReadmeHtml(markdown, 'test-pkg')
+
+      expect(result.html).toContain('href="/package/test-pkg"')
+    })
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

fixes: #1521 


### 📚 Description

Rewrite to npmjs.org url to npmx relative path. currently we only have npmjs.com links handled

(Before and After)

https://github.com/user-attachments/assets/75fcf5e3-dd65-45f6-b92b-b98b5149ebc3

