### PR TITLE
feat(i18n): add missing German translation

### DIFF
--- a/i18n/locales/de-DE.json
+++ b/i18n/locales/de-DE.json
@@ -624,6 +624,7 @@
       "invalid_name": "Ungültiger Paketname:",
       "available": "Dieser Name ist verfügbar!",
       "taken": "Dieser Name ist bereits vergeben.",
+      "missing_permission": "Du hast keine Berechtigung, ein Paket zum Scope {'@'}{scope} hinzuzufügen.",
       "similar_warning": "Ähnliche Pakete existieren - npm könnte diesen Namen ablehnen:",
       "related": "Verwandte Pakete:",
       "scope_warning_title": "Erwäge stattdessen ein Scoped-Paket",

--- a/lunaria/files/de-DE.json
+++ b/lunaria/files/de-DE.json
@@ -623,6 +623,7 @@
       "invalid_name": "Ungültiger Paketname:",
       "available": "Dieser Name ist verfügbar!",
       "taken": "Dieser Name ist bereits vergeben.",
+      "missing_permission": "Du hast keine Berechtigung, ein Paket zum Scope {'@'}{scope} hinzuzufügen.",
       "similar_warning": "Ähnliche Pakete existieren - npm könnte diesen Namen ablehnen:",
       "related": "Verwandte Pakete:",
       "scope_warning_title": "Erwäge stattdessen ein Scoped-Paket",


### PR DESCRIPTION
### 🧭 Context

Adds missing German translation for `claim.modal.missing_permission`
