### PR TITLE
fix(ui): escape special characters in description

### DIFF
--- a/app/components/Compare/PackageSelector.vue
+++ b/app/components/Compare/PackageSelector.vue
@@ -306,8 +306,9 @@ function handleFocus() {
             <span
               v-if="result.description"
               class="text-xs text-fg-muted truncate mt-0.5 w-full block"
-              v-html="result.description"
-            />
+            >
+              {{ decodeHtmlEntities(result.description) }}
+            </span>
           </ButtonBase>
         </div>
       </Transition>

--- a/app/components/Package/TableRow.vue
+++ b/app/components/Package/TableRow.vue
@@ -68,8 +68,9 @@ const allMaintainersText = computed(() => {
     <td
       v-if="isColumnVisible('description')"
       class="py-2 px-3 text-sm text-fg-muted max-w-xs truncate"
-      v-html="pkg.description || '-'"
-    />
+    >
+      {{ decodeHtmlEntities(pkg.description || '-') }}
+    </td>
 
     <!-- Downloads -->
     <td


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: https://github.com/npmx-dev/npmx.dev/issues/1572

### 🧭 Context

I'm using the `decodeHtmlEntities` to decode the HTML entities and render them

### 📚 Description

This is the one that fixes the issue in Compare packages
<img width="1288" height="465" alt="image" src="https://github.com/user-attachments/assets/b278b9bc-f988-4fc7-b331-d9554a98f001" />

and I also found another instance in the Search table row

<img width="1380" height="408" alt="image" src="https://github.com/user-attachments/assets/8cc65700-cd43-40ac-a0e0-c54499c828e4" />
