### PR TITLE
fix: fix fallback not triggered for 0 measuredWidth

### DIFF
--- a/server/api/registry/badge/[type]/[...pkg].get.ts
+++ b/server/api/registry/badge/[type]/[...pkg].get.ts
@@ -69,7 +69,7 @@ function measureTextWidth(text: string, font: string): number | null {
 
     const measuredWidth = context.measureText(text).width
 
-    if (!Number.isNaN(measuredWidth)) {
+    if (Number.isFinite(measuredWidth) && measuredWidth > 0) {
       return Math.ceil(measuredWidth)
     }
   }


### PR DESCRIPTION
Currently fallback does not work: https://npmx.dev/api/registry/badge/version/nuxt?label=thisisatest

with this PR, fallback still sucks but at least does not appear very broken:

https://npmxdev-git-improved-fallback-npmx.vercel.app/api/registry/badge/version/nuxt?label=thisisatest