### PR TITLE
fix(ui): noPrefetch and prefetch warnings

### DIFF
--- a/app/components/Link/Base.vue
+++ b/app/components/Link/Base.vue
@@ -3,41 +3,39 @@ import type { NuxtLinkProps } from '#app'
 import type { IconClass } from '~/types'
 
 const props = withDefaults(
-  defineProps<
-    {
-      /** Disabled links will be displayed as plain text */
-      disabled?: boolean
-      /**
-       * `type` should never be used, because this will always be a link.
-       * */
-      type?: never
-      variant?: 'button-primary' | 'button-secondary' | 'link'
-      size?: 'small' | 'medium'
-      block?: boolean
+  defineProps<{
+    /** Disabled links will be displayed as plain text */
+    disabled?: boolean
+    /**
+     * `type` should never be used, because this will always be a link.
+     * */
+    type?: never
+    variant?: 'button-primary' | 'button-secondary' | 'link'
+    size?: 'small' | 'medium'
+    block?: boolean
 
-      ariaKeyshortcuts?: string
+    ariaKeyshortcuts?: string
 
-      /**
-       * Don't use this directly. This will automatically be set to `_blank` for external links passed via `to`.
-       */
-      target?: never
+    /**
+     * Don't use this directly. This will automatically be set to `_blank` for external links passed via `to`.
+     */
+    target?: never
 
-      /**
-       * Don't use this directly. This will automatically be set for external links passed via `to`.
-       */
-      rel?: never
+    /**
+     * Don't use this directly. This will automatically be set for external links passed via `to`.
+     */
+    rel?: never
 
-      classicon?: IconClass
+    classicon?: IconClass
 
-      to?: NuxtLinkProps['to']
+    to?: NuxtLinkProps['to']
 
-      /** always use `to` instead of `href` */
-      href?: never
+    /** always use `to` instead of `href` */
+    href?: never
 
-      /** should only be used for links where the context makes it very clear they are clickable. Don't just use this, because you don't like underlines. */
-      noUnderline?: boolean
-    } & NuxtLinkProps
-  >(),
+    /** should only be used for links where the context makes it very clear they are clickable. Don't just use this, because you don't like underlines. */
+    noUnderline?: boolean
+  }>(),
   { variant: 'link', size: 'medium' },
 )
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1585

### 🧭 Context

<!-- Brief background and why this change is needed -->
Anywhere LinkBase is used, the console is flooded with warnings about noPrefetch and prefetch conflicting in NuxtLink.

<!-- High-level summary of what changed -->
This PR removes `& NuxtLinkProps` from defineProps and declares only the props LinkBase actually needs.


### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
The warning is triggered because spreading & NuxtLinkProps into defineProps causes Vue to register all NuxtLink props with their defaults. When v-bind="props" is used to forward them to NuxtLink, both prefetch and noPrefetch are passed simultaneously, even when neither was explicitly provided by the consumer, triggering NuxtLink's conflict check on every render.