### PR TITLE
fix: add missing padding

### DIFF
--- a/app/components/Package/Versions.vue
+++ b/app/components/Package/Versions.vue
@@ -486,7 +486,7 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
     <div class="space-y-0.5 min-w-0">
       <!-- Semver range filter -->
       <div class="px-1 pb-1">
-        <div class="flex items-center gap-1.5">
+        <div class="flex items-center gap-1.5 py-1">
           <InputBase
             v-model="semverFilter"
             type="text"

--- a/app/components/Package/WeeklyDownloadStats.vue
+++ b/app/components/Package/WeeklyDownloadStats.vue
@@ -310,7 +310,7 @@ const config = computed(() => {
             </template>
           </ClientOnly>
 
-          <div v-if="hasWeeklyDownloads" class="hidden motion-safe:flex justify-end">
+          <div v-if="hasWeeklyDownloads" class="hidden motion-safe:flex justify-end p-1">
             <ButtonBase size="small" @click="toggleSparklineAnimation">
               {{
                 hasSparklineAnimation


### PR DESCRIPTION
Minor polishing, adds padding on 2 elements of the side panel to fix the cropping of the focus rings:

- sparkline animation toggle button
- versions filter input