### PR TITLE
fix: apply narrower max width to featured frameworks

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -109,7 +109,7 @@ defineOgImageComponent('Default', {
 
       <nav
         :aria-label="$t('nav.popular_packages')"
-        class="pt-4 pb-36 sm:pb-40 text-center motion-safe:animate-fade-in motion-safe:animate-fill-both"
+        class="pt-4 pb-36 sm:pb-40 text-center motion-safe:animate-fade-in motion-safe:animate-fill-both max-w-xl mx-auto"
         style="animation-delay: 0.3s"
       >
         <ul class="flex flex-wrap items-center justify-center gap-x-6 gap-y-3 list-none m-0 p-0">


### PR DESCRIPTION
<img width="1333" height="851" alt="image" src="https://github.com/user-attachments/assets/4e76af42-f42b-40b3-a434-37aa2e222200" />
