### PR TITLE
chore: remove unnecessary @public annotations and guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,18 +289,6 @@ import { hasProtocol } from 'ufo'
 | Constants        | SCREAMING_SNAKE_CASE     | `NPM_REGISTRY`, `ALLOWED_TAGS` |
 | Types/Interfaces | PascalCase               | `NpmSearchResponse`            |
 
-> [!TIP]
-> Exports in `app/composables/`, `app/utils/`, and `server/utils/` are auto-imported by Nuxt. To prevent [knip](https://knip.dev/) from flagging them as unused, add a `@public` JSDoc annotation:
->
-> ```typescript
-> /**
->  * @public
->  */
-> export function myAutoImportedFunction() {
->   // ...
-> }
-> ```
-
 ### Vue components
 
 - Use Composition API with `<script setup lang="ts">`

--- a/app/composables/useActiveTocItem.ts
+++ b/app/composables/useActiveTocItem.ts
@@ -7,7 +7,6 @@ import type { Ref } from 'vue'
  *
  * @param toc - Reactive array of TOC items
  * @returns Object containing activeId
- * @public
  */
 export function useActiveTocItem(toc: Ref<TocItem[]>) {
   const activeId = shallowRef<string | null>(null)

--- a/app/composables/useMarkdown.ts
+++ b/app/composables/useMarkdown.ts
@@ -8,7 +8,6 @@ interface UseMarkdownOptions {
   packageName?: string
 }
 
-/** @public */
 export function useMarkdown(options: MaybeRefOrGetter<UseMarkdownOptions>) {
   return computed(() => parseMarkdown(toValue(options)))
 }

--- a/server/utils/provenance.ts
+++ b/server/utils/provenance.ts
@@ -90,7 +90,6 @@ function repoUrlToBlobUrl(repository: string, path: string, ref = 'main'): strin
 /**
  * Parse npm attestations API response into ProvenanceDetails.
  * Prefers SLSA provenance v1; falls back to v0.2 for provider label and ledger only (no source commit/build file from v0.2).
- * @public
  */
 export function parseAttestationToProvenanceDetails(response: unknown): ProvenanceDetails | null {
   const body = response as NpmAttestationsResponse

--- a/server/utils/skills.ts
+++ b/server/utils/skills.ts
@@ -73,7 +73,6 @@ export interface SkillDirInfo {
 /**
  * Find skill directories in a package file tree.
  * Returns skill names and their children for file counting.
- * @public
  */
 export function findSkillDirs(tree: PackageFileTree[]): SkillDirInfo[] {
   const skillsDir = tree.find(node => node.type === 'directory' && node.name === 'skills')
@@ -176,7 +175,6 @@ export function validateSkill(frontmatter: SkillFrontmatter): SkillWarning[] {
 
 /**
  * Fetch skill list with frontmatter for discovery endpoint.
- * @public
  */
 export async function fetchSkillsList(
   packageName: string,
@@ -215,7 +213,6 @@ export interface WellKnownSkillItem {
 
 /**
  * Fetch skill list for well-known index.json format (CLI compatibility).
- * @public
  */
 export async function fetchSkillsListForWellKnown(
   packageName: string,

--- a/shared/schemas/blog.ts
+++ b/shared/schemas/blog.ts
@@ -34,5 +34,4 @@ export interface ResolvedAuthor extends Author {
 /**
  * Inferred type for blog post frontmatter
  */
-/** @public */
 export type BlogPostFrontmatter = InferOutput<typeof BlogPostSchema>

--- a/shared/schemas/user.ts
+++ b/shared/schemas/user.ts
@@ -21,7 +21,5 @@ export const GravatarQuerySchema = v.object({
   username: NpmUsernameSchema,
 })
 
-/** @public */
 export type NpmUsername = v.InferOutput<typeof NpmUsernameSchema>
-/** @public */
 export type GravatarQuery = v.InferOutput<typeof GravatarQuerySchema>

--- a/shared/types/npm-registry.ts
+++ b/shared/types/npm-registry.ts
@@ -233,7 +233,6 @@ export interface NpmVersionDist {
 /**
  * Parsed provenance details for display (from attestation bundle SLSA predicate).
  * Used by the provenance API and PackageProvenanceSection.
- * @public
  */
 export interface ProvenanceDetails {
   /** Provider ID (e.g. "github", "gitlab") */

--- a/shared/utils/constants.ts
+++ b/shared/utils/constants.ts
@@ -31,9 +31,7 @@ export const ERROR_SUGGESTIONS_FETCH_FAILED = 'Failed to fetch suggestions.'
 export const ERROR_SKILLS_FETCH_FAILED = 'Failed to fetch skills.'
 export const ERROR_SKILL_NOT_FOUND = 'Skill not found.'
 export const ERROR_SKILL_FILE_NOT_FOUND = 'Skill file not found.'
-/** @public */
 export const ERROR_GRAVATAR_FETCH_FAILED = 'Failed to fetch Gravatar profile.'
-/** @public */
 export const ERROR_GRAVATAR_EMAIL_UNAVAILABLE = "User's email not accessible."
 export const ERROR_NEED_REAUTH = 'User needs to reauthenticate'
 

--- a/shared/utils/npm.ts
+++ b/shared/utils/npm.ts
@@ -52,7 +52,6 @@ export function assertValidPackageName(name: string): void {
 /**
  * Validate an npm username and throw an HTTP error if invalid.
  * Uses a regular expression to check against npm naming rules.
- * @public
  */
 export function assertValidUsername(username: string): void {
   if (!username || username.length > NPM_USERNAME_MAX_LENGTH || !NPM_USERNAME_RE.test(username)) {


### PR DESCRIPTION
### 🔗 Linked issue

N/A - cleanup

### 🧭 Context

Previously, knip didn't understand nuxt auto-imports, so we used `@public` jsdoc annotations as some sort of funny workaround

knip supports this now; so this is an outdated guideline

### 📚 Description

- Remove guideline about this
- Clean up some remaining uses of this pattern