### PR TITLE
fix: increase chart right padding

### DIFF
--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -1410,7 +1410,7 @@ const chartConfig = computed<VueUiXyConfig>(() => {
     chart: {
       height: isMobile.value ? 950 : 600,
       backgroundColor: colors.value.bg,
-      padding: { bottom: displayedGranularity.value === 'yearly' ? 84 : 64, right: 100 }, // padding right is set to leave space of last datapoint label(s)
+      padding: { bottom: displayedGranularity.value === 'yearly' ? 84 : 64, right: 128 }, // padding right is set to leave space of last datapoint label(s)
       userOptions: {
         buttons: {
           pdf: false,


### PR DESCRIPTION
Resolves #1618 

- Increases the right padding value of the chart to fit magnitude labels in some languages
(tested with 999.9)