### PR TITLE
fix(a11y): improve non-text (border) colour contrast

### DIFF
--- a/app/assets/main.css
+++ b/app/assets/main.css
@@ -19,9 +19,9 @@
   --fg-subtle: oklch(0.673 0 0);
 
   /* border, separator colors */
-  --border: oklch(0.269 0 0);
+  --border: oklch(0.5 0 0);
   --border-subtle: oklch(0.239 0 0);
-  --border-hover: oklch(0.371 0 0);
+  --border-hover: oklch(0.6 0 0);
 
   /* accent color, set by user from settings */
   --accent: var(--accent-color, oklch(1 0 0));
@@ -90,9 +90,9 @@
   --fg-muted: oklch(0.398 0 0);
   --fg-subtle: oklch(0.48 0 0);
 
-  --border: oklch(0.8514 0 0);
+  --border: oklch(0.666 0 0);
   --border-subtle: oklch(0.922 0 0);
-  --border-hover: oklch(0.715 0 0);
+  --border-hover: oklch(0.6 0 0);
 
   --accent: var(--accent-color, oklch(0.145 0 0));
   --accent-muted: var(--accent-color, oklch(0.205 0 0));


### PR DESCRIPTION
A step towards resolving #1510, but it does have a wide effect on a lot of components (e.g. search boxes, buttons, etc.) that would be failing (and causes them to pass).

As stated in #1510, we are currently failing [WCAG 2.2 SC 1.4.11 (Level AA)](https://www.w3.org/WAI/WCAG22/quickref/#non-text-contrast) which requires a minimum non-text colour ratio of 3:1 for user interface components and graphical objects. This was most notable for the search field and buttons.

This PR increases the lightness channels of the `--border` and `--border-hover` values for the light and dark colour schemes which in effect causes their contrast on the main background to just pass 3:1. The original issue did include the ratios of the borders and the inner surface (i.e. the background colour of the component itself). For buttons, I don’t think this is necessary. For text fields, this maybe necessary unless there are other visual elements within the border (e.g. our main search field has the leading `./`).

Admittedly, just increasing the border contrast alone isn’t a great design decision. Adding other visual effects could help, but it would be a bit of a departure from the current design paradigm. There’s also the issue of pairing these border colours with different background colours—there could be failures.

| Before | After |
|-|-|
| <img width="612" height="371" alt="The original, dark mode, cropped view of the main logo and search on the homepage." src="https://github.com/user-attachments/assets/34cc4c72-8752-4156-995f-da2a741a3fec" /> Contrast ratio: 1.257:1 (`#262626` / `#101010`) | <img width="612" height="371" alt="The increased-contrast, dark mode, cropped view of the main logo and search on the homepage." src="https://github.com/user-attachments/assets/8acb96f5-38c6-4622-8346-87fbec2d083e" /> Contrast ratio: 3.167:1 (`#636363` / `#101010`) |
| <img width="612" height="371" alt="The original, light mode, cropped view of the main logo and search on the homepage." src="https://github.com/user-attachments/assets/0180df83-69c6-4897-8ea0-244d6ebcb634" /> Contrast ratio: 1.574:1 (`#CECECE` / `#FFFFFF`) | <img width="612" height="371" alt="The increased-contrast, light mode, cropped view of the main logo and search on the homepage." src="https://github.com/user-attachments/assets/8005fe54-320d-4de3-aa17-95446184dab5" /> Contrast ratio: 3.033:1 (`#949494` / `#FFFFFF`) |

<details><summary>Full page comparison of home and package views</summary>

Ignore other non-border-contrast visual differences. I’ve got screenshots of different builds. This is tedious work.

| Before | After |
|-|-|
| <img width="2932" height="2920" alt="The original, dark-mode, home page, full screenshot" src="https://github.com/user-attachments/assets/a02ca5e6-47ae-4610-9b32-cdcff84774a8" /> | <img width="2932" height="2920" alt="The increased-contrast, dark-mode, home page, full screenshot" src="https://github.com/user-attachments/assets/333d73b2-f11c-432b-8fdd-2d50806ec1ae" /> |
| <img width="2932" height="2920" alt="The original, light-mode, home page, full screenshot" src="https://github.com/user-attachments/assets/206e9f77-3c71-4cad-9083-5a13a3dc736b" /> | <img width="2932" height="2920" alt="The increased-contrast, light-mode, home page, full screenshot" src="https://github.com/user-attachments/assets/202f2108-c5f3-4fe0-8d15-3b2ae6c45af7" /> |
| <img width="2932" height="9338" alt="The original, dark-mode, package page, full screenshot" src="https://github.com/user-attachments/assets/45076460-7a91-4389-9ae4-2bbda16b287e" /> | <img width="2932" height="9108" alt="The increased-contrast, dark-mode, package page, full screenshot" src="https://github.com/user-attachments/assets/d955db60-7d89-436e-af1e-73226d820382" /> |
| <img width="2932" height="9338" alt="The original, light-mode, package page, full screenshot" src="https://github.com/user-attachments/assets/d17e3d4a-f8ca-47bc-9f95-e26b2959274b" /> | <img width="2932" height="9108" alt="The increased-contrast, light-mode, package page, full screenshot" src="https://github.com/user-attachments/assets/4dfb3772-bf33-4beb-904b-09d1c3ae632d" /> |

</details>