### PR TITLE
fix: playground heading matching theme

### DIFF
--- a/app/components/Package/Playgrounds.vue
+++ b/app/components/Package/Playgrounds.vue
@@ -119,10 +119,7 @@ function focusMenuItem(index: number) {
 
 <template>
   <section v-if="links.length > 0" class="px-1">
-    <h2
-      id="playgrounds-heading"
-      class="text-xs font-mono text-fg uppercase tracking-wider mb-3"
-    >
+    <h2 id="playgrounds-heading" class="text-xs font-mono text-fg uppercase tracking-wider mb-3">
       {{ $t('package.playgrounds.title') }}
     </h2>
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

Fixed the playground heading styles ("Try It Out") to match the theme instead of always being white. Also changed it from `fg-subtle` to `fg` to match the other headings in the sidebar, which gets `fg` from the `Link` component.

**Before:**

![Clipboard-20260226-102643-378](https://github.com/user-attachments/assets/6105c4a1-ecd3-499c-96f5-f326abdda310)

**After:**

<div style="display: flex; flex-direction: row">
<img width="400" height="367" alt="image" src="https://github.com/user-attachments/assets/1c549a08-79fe-4dab-9a0b-2480ee4b7c38" />

<img width="417" height="250" alt="image" src="https://github.com/user-attachments/assets/5562d56b-3bda-4f72-afe8-2d8bde2eef25" />
</div>

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
