### PR TITLE
fix: correct package weekly download stats safe-size

### DIFF
--- a/app/components/Package/WeeklyDownloadStats.vue
+++ b/app/components/Package/WeeklyDownloadStats.vue
@@ -296,7 +296,7 @@ const config = computed<VueUiSparklineConfig>(() => {
         <span v-else-if="isLoadingWeeklyDownloads" class="min-w-6 min-h-6 -m-1 p-1" />
       </template>
 
-      <div class="w-full overflow-hidden h-[110px] motion-safe:h-[140px]">
+      <div class="w-full overflow-hidden h-[76px] motion-safe:h-[calc(92px+0.75rem)]">
         <template v-if="isLoadingWeeklyDownloads || hasWeeklyDownloads">
           <ClientOnly>
             <VueUiSparkline class="w-full max-w-xs" :dataset :config>


### PR DESCRIPTION
### 🧭 Context

There's too much space under the weekly download graph on package pages. The problem is that when we were adjusting the dimensions to fix the CLS, we set the height of the entire dropdown (_including the heading_) to the content. Updated it to fit the content dimensions only

<details>
<summary>before/after</summary>
<img width="563" alt="image" src="https://github.com/user-attachments/assets/50821baf-ded8-453a-8e77-b4dc6ea06ddb" />
<img width="563" alt="image" src="https://github.com/user-attachments/assets/18d89eec-e34c-469f-bbd0-2ea3738be5d8" />
</details>