### PR TITLE
fix(ui): remove duplicate native tooltip on like button

### DIFF
--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -921,9 +921,6 @@ const showSkeleton = shallowRef(false)
               <ButtonBase
                 @click="likeAction"
                 size="small"
-                :title="
-                  likesData?.userHasLiked ? $t('package.likes.unlike') : $t('package.likes.like')
-                "
                 :aria-label="
                   likesData?.userHasLiked ? $t('package.likes.unlike') : $t('package.likes.like')
                 "


### PR DESCRIPTION
### 🔗 Linked issue

This issue is small enough, creating an issue would have been more noise.

### 🧭 Context

Like button shows both the component tooltip and the browser native tooltip on hover.

### 📚 Description

Removed the `title` attribute from the atproto like button - `aria-label` is kept for a11y, matching all other tooltip usages.

| Before | After |
| --- | --- |
| <img width="360" height="85" alt="duplicate tooltips on like button - component tooltip and native title tooltip both visible" src="https://github.com/user-attachments/assets/53912c78-7a6c-48ca-a762-0e7127f74d59" /> | <img width="360" height="85" alt="single component tooltip on like button - no duplicate native tooltip" src="https://github.com/user-attachments/assets/6634bc9c-3908-4f85-961b-75292b8e12ad" /> |