### PR TITLE
fix: package name not detected in code view

### DIFF
--- a/server/utils/code-highlight.ts
+++ b/server/utils/code-highlight.ts
@@ -167,7 +167,7 @@ interface LinkifyOptions {
  * @param html - The HTML to process
  * @param options - Dependencies map and optional relative import resolver
  */
-function linkifyModuleSpecifiers(html: string, options?: LinkifyOptions): string {
+export function linkifyModuleSpecifiers(html: string, options?: LinkifyOptions): string {
   const { dependencies, resolveRelative } = options ?? {}
 
   const getHref = (moduleSpecifier: string): string | null => {

--- a/test/unit/server/utils/code-highlight.spec.ts
+++ b/test/unit/server/utils/code-highlight.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { linkifyModuleSpecifiers } from '../../../../server/utils/code-highlight'
+
+describe('linkifyModuleSpecifiers', () => {
+  const dependencies = {
+    'vue': { version: '3.4.0' },
+    '@unocss/webpack': { version: '0.65.3' },
+  }
+
+  it('should linkify import ... from "package"', () => {
+    // Shiki output for: import { ref } from "vue"
+    const html =
+      '<span class="line">' +
+      '<span style="color:#F97583">import</span>' +
+      '<span style="color:#E1E4E8"> { ref }</span>' +
+      '<span style="color:#F97583">from</span>' +
+      '<span style="color:#9ECBFF"> "vue"</span>' +
+      '</span>'
+
+    const result = linkifyModuleSpecifiers(html, { dependencies })
+    expect(result).toContain('<a href="/package-code/vue/v/3.4.0" class="import-link">')
+  })
+
+  it('should linkify export * from "package"', () => {
+    // Shiki output for: export * from "@unocss/webpack"
+    // Note: Shiki puts a leading space before "from" in the same span
+    const html =
+      '<span class="line">' +
+      '<span style="color:#F97583">export</span>' +
+      '<span style="color:#E1E4E8"> *</span>' +
+      '<span style="color:#F97583"> from</span>' +
+      '<span style="color:#9ECBFF"> "@unocss/webpack"</span>' +
+      '<span style="color:#E1E4E8">;</span>' +
+      '</span>'
+
+    const result = linkifyModuleSpecifiers(html, { dependencies })
+    expect(result).toContain(
+      '<a href="/package-code/@unocss/webpack/v/0.65.3" class="import-link">',
+    )
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1664 

### 🧭 Context

Bug report (see the issue).

After the change `export * from 'package'` now adds a link around the package name.

### 📚 Description

Shiki generates something along these lines for the export statement in question:
```html
<span class="line"
  ><span style="...">export</span
  ><span style="..."> *</span
  ><span style="..."> from</span
  ><span style="..."> "@unocss/webpack"</span
  ><span style="...">;</span>
</span>
```

The leading whitespace (at "from") means it's not caught by the first regex. Adding an optional whitespace before from makes it work. I also considered if the regexes could be structured differently, but that's a bigger undertaking, and would need a set of tests imo. I'm happy to contribute a test file (in `/test/unit/server/utils`?) either as part of this PR or as a follow-up.

I also decided to rename the function, to clarify that it not only handles import statements.

I'm not a regex-master and I used Opus 4.6 to analyze the html from Shiki and the three regexes. The model suggested a fourth regex, but I think that's overkill, and I'd want test coverage before making changes that big anyway.  