### PR TITLE
fix: parse markdown headings without space after `#` to match npmjs

### DIFF
--- a/server/utils/readme.ts
+++ b/server/utils/readme.ts
@@ -228,6 +228,46 @@ function slugify(text: string): string {
     .replace(/^-|-$/g, '') // Trim leading/trailing hyphens
 }
 
+/**
+ * Lazy ATX heading extension for marked: allows headings without a space after `#`.
+ *
+ * Reimplements the behavior of markdown-it-lazy-headers
+ * (https://npmx.dev/package/markdown-it-lazy-headers), which is used by npm's own markdown renderer
+ * marky-markdown (https://npmx.dev/package/marky-markdown).
+ *
+ * CommonMark requires a space after # for ATX headings, but many READMEs in the npm registry omit
+ * this space. This extension allows marked to parse these headings the same way npm does.
+ */
+marked.use({
+  tokenizer: {
+    heading(src: string) {
+      // Only match headings where `#` is immediately followed by non-whitespace, non-`#` content.
+      // Normal headings (with space) return false to fall through to marked's default tokenizer.
+      const match = /^ {0,3}(#{1,6})([^\s#][^\n]*)(?:\n+|$)/.exec(src)
+      if (!match) return false
+
+      let text = match[2]!.trim()
+
+      // Strip trailing # characters only if preceded by a space (CommonMark behavior).
+      // e.g., "#heading ##" → "heading", but "#heading#" stays as "heading#"
+      if (text.endsWith('#')) {
+        const stripped = text.replace(/#+$/, '')
+        if (!stripped || stripped.endsWith(' ')) {
+          text = stripped.trim()
+        }
+      }
+
+      return {
+        type: 'heading' as const,
+        raw: match[0]!,
+        depth: match[1]!.length as number,
+        text,
+        tokens: this.lexer.inline(text),
+      }
+    },
+  },
+})
+
 /** These path on npmjs.com don't belong to packages or search, so we shouldn't try to replace them with npmx.dev urls */
 const reservedPathsNpmJs = [
   'products',


### PR DESCRIPTION
### 🔗 Linked issue

Closes #1697

### 🧭 Context

Some READMEs in the npm registry use `#Foo` instead of `# Foo`. CommonMark (and the lib we use to parse markdown, `marked`) requires the space, so currently these render as plain text instead of headings on npmx.dev.

However, npmjs.com treats this as a heading. You can see an example here: https://www.npmjs.com/package/boolbase (see [the raw source here](https://cdn.jsdelivr.net/npm/boolbase@1.0.0/README.md)).

### 📚 Description

npm's own renderer (https://npmx.dev/package/marky-markdown) handles this via https://npmx.dev/package/markdown-it-lazy-headers, a `markdown-it` plugin that relaxes the space requirement. This commit reimplements that behavior as a marked "tokenizer extension", since we use marked rather than markdown-it, and we definitely don't want to use a package that hasn't been updated in 10 years.

The extension only handles this special case and falls through to marked's default tokenizer for standard headings. I used the 56-line `markdown-it-lazy-headers` source as reference implementation.