### PR TITLE
fix: remove install size tooltip when size is not available

### DIFF
--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -1145,7 +1145,7 @@ const showSkeleton = shallowRef(false)
           <div class="space-y-1 sm:col-span-3">
             <dt class="text-xs text-fg-subtle uppercase tracking-wider flex items-center gap-1">
               {{ $t('package.stats.install_size') }}
-              <TooltipApp :text="sizeTooltip">
+              <TooltipApp v-if="sizeTooltip" :text="sizeTooltip">
                 <span
                   tabindex="0"
                   class="inline-flex items-center justify-center min-w-6 min-h-6 -m-1 p-1 text-fg-subtle cursor-help focus-visible:outline-2 focus-visible:outline-accent/70 rounded"


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1694

### 🧭 Context

There's an empty tooltip when the install size isn't available for a given package.

### 📚 Description

Adds a `v-if` if the tooltip text is empty so we don't render it!

<img width="628" height="212" alt="CleanShot 2026-02-27 at 23 35 10@2x" src="https://github.com/user-attachments/assets/92defa07-dd25-4540-9bb9-fca31a6a5364" />
