### PR TITLE
feat(i18n): update UA translations: add missing keys, change tagline

### DIFF
--- a/i18n/locales/uk-UA.json
+++ b/i18n/locales/uk-UA.json
@@ -3,12 +3,12 @@
   "seo": {
     "home": {
       "title": "npmx - Браузер пакетів для реєстру npm",
-      "description": "Кращий браузер для реєстру npm. Пошук, перегляд та дослідження пакетів за допомогою сучасного інтерфейсу."
+      "description": "Швидкий сучасний браузер для реєстру npm. Пошук, перегляд та дослідження пакетів за допомогою сучасного інтерфейсу."
     }
   },
   "built_at": "збірка {0}",
   "alt_logo": "лого npmx",
-  "tagline": "кращий браузер для реєстру npm",
+  "tagline": "швидкий сучасний браузер для реєстру npm",
   "non_affiliation_disclaimer": "не пов'язаний з npm, Inc.",
   "trademark_disclaimer": "npm є зареєстрованою торговою маркою npm, Inc. Цей сайт не пов'язаний з npm, Inc.",
   "footer": {
@@ -33,7 +33,8 @@
     "navigate_results": "Навігація результатами",
     "go_to_result": "Перейти до результату",
     "open_code_view": "Відкрити перегляд коду",
-    "open_docs": "Відкрити документацію"
+    "open_docs": "Відкрити документацію",
+    "disable_shortcuts": "Ви можете вимкнути гарячі клавіші в {settings}."
   },
   "search": {
     "label": "Пошук пакетів npm",
@@ -84,7 +85,8 @@
       "appearance": "Зовнішній вигляд",
       "display": "Відображення",
       "search": "Джерело даних",
-      "language": "Мова"
+      "language": "Мова",
+      "keyboard_shortcuts": "Гарячі клавіші"
     },
     "data_source": {
       "label": "Джерело даних",
@@ -108,7 +110,9 @@
     "accent_colors": "Колірні акценти",
     "clear_accent": "Очистити колір акценту",
     "translation_progress": "Прогрес перекладу",
-    "background_themes": "Колір фону"
+    "background_themes": "Колір фону",
+    "keyboard_shortcuts_enabled": "Увімкнути гарячі клавіші",
+    "keyboard_shortcuts_enabled_description": "Гарячі клавіші можна вимкнути, якщо вони конфліктують з налаштуваннями браузера або системи"
   },
   "i18n": {
     "missing_keys": "Відсутній 1 переклад | Відсутні {count} переклади",
@@ -156,6 +160,13 @@
       "package": "Цей пакет більше не підтримується.",
       "version": "Ця версія більше не підтримується.",
       "no_reason": "Причину не вказано"
+    },
+    "size_increase": {
+      "title_size": "Значне збільшення розміру починаючи з v{version}",
+      "title_deps": "Значне збільшення кількості залежностей починаючи з v{version}",
+      "title_both": "Значне збільшення розміру і залежностей починаючи з v{version}",
+      "size": "Розмір встановлення збільшився на {percent} ({size} більше)",
+      "deps": "{count} додаткових залежностей"
     },
     "replacement": {
       "title": "Можливо вам не потрібна ця залежність.",
@@ -294,8 +305,16 @@
       "view_all": "Переглянути {count} версію | Переглянути всі {count} версій",
       "distribution_title": "Група Semver",
       "distribution_modal_title": "Версії",
+      "distribution_range_date_same_year": "від {from} до {to}, {endYear}",
+      "distribution_range_date_multiple_years": "від {from}, {startYear} до {to}, {endYear}",
       "grouping_major": "Основна",
       "grouping_minor": "Мінорна",
+      "grouping_versions_title": "Версії",
+      "grouping_versions_all": "Усі",
+      "grouping_versions_only_recent": "Тільки нещодавні",
+      "grouping_usage_title": "Використання",
+      "grouping_usage_all": "Усі",
+      "grouping_usage_low": "Низьке",
       "recent_versions_only_tooltip": "Показувати лише версії, опубліковані за останній рік.",
       "show_low_usage_tooltip": "Включити групи версій з менш ніж 1% від загальних завантажень.",
       "y_axis_label": "Завантаження",
@@ -304,13 +323,17 @@
       "filter_help": "Довідка з фільтра діапазону semver",
       "filter_tooltip": "Фільтрувати версії за {link}. Наприклад, ^3.0.0 показує всі версії 3.x.",
       "filter_tooltip_link": "діапазоном semver",
-      "no_matches": "Жодна версія не відповідає цьому діапазону"
+      "no_matches": "Жодна версія не відповідає цьому діапазону",
+      "copy_alt": {
+        "per_version_analysis": "Версія {version} була завантажена {downloads} разів",
+        "general_description": "Стовпчаста діаграма, що показує завантаження за версіями для {versions_count} {semver_grouping_mode} версій пакету {package_name}, {date_range_label} від версії {first_version} до версії {last_version}. Найбільш завантажувана версія — {max_downloaded_version} з {max_version_downloads} завантаженнями. {per_version_analysis}. {watermark}."
+      }
     },
     "dependencies": {
       "title": "Залежності ({count})",
       "list_label": "Залежності пакета",
       "show_all": "показати всі {count} залежностей",
-      "optional": "опціональні",
+      "optional": "опціонально",
       "view_vulnerabilities": "Переглянути вразливості",
       "outdated_major": "{count} мажорна версія відставання (остання: {latest}) | {count} мажорних версій відставання (остання: {latest})",
       "outdated_minor": "{count} мінорна версія відставання (остання: {latest}) | {count} мінорних версій відставання (остання: {latest})",
@@ -343,10 +366,10 @@
     },
     "trends": {
       "granularity": "Деталізація",
-      "granularity_daily": "Щоденно",
-      "granularity_weekly": "Щотижня",
-      "granularity_monthly": "Щомісяця",
-      "granularity_yearly": "Щороку",
+      "granularity_daily": "Щоденні",
+      "granularity_weekly": "Щотижневі",
+      "granularity_monthly": "Щомісячні",
+      "granularity_yearly": "Щорічні",
       "start_date": "Початок",
       "end_date": "Кінець",
       "loading": "Завантаження...",
@@ -354,6 +377,7 @@
       "date_range_multiline": "{start}\nдо {end}",
       "download_file": "Завантажити {fileType}",
       "toggle_annotator": "Перемкнути анотатор",
+      "toggle_stack_mode": "Перемкнути режим стека",
       "legend_estimation": "Оцінка",
       "no_data": "Дані недоступні",
       "y_axis_label": "{granularity} {facet}",
@@ -364,6 +388,33 @@
         "downloads": "Завантаження",
         "likes": "Вподобання",
         "contributors": "Супроводжувачі"
+      },
+      "play_animation": "Запустити анімацію",
+      "pause_animation": "Зупинити анімацію",
+      "data_correction": "Корекція даних",
+      "average_window": "Вікно усереднення",
+      "smoothing": "Згладжування",
+      "known_anomalies": "Відомі аномалії",
+      "known_anomalies_description": "Інтерполює відомі стрибки кількості завантажень, спричинені ботами або проблемами CI.",
+      "known_anomalies_ranges": "Діапазони аномалій",
+      "known_anomalies_range": "Від {start} до {end}",
+      "known_anomalies_range_named": "{packageName}: від {start} до {end}",
+      "known_anomalies_none": "Для цього пакету немає відомих аномалій. | Для цих пакетів немає відомих аномалій.",
+      "known_anomalies_contribute": "Додати дані про аномалію",
+      "apply_correction": "Застосувати корекцію",
+      "copy_alt": {
+        "trend_none": "здебільшого рівна",
+        "trend_strong": "сильна",
+        "trend_weak": "слабка",
+        "trend_undefined": "невизначена (недостатньо даних)",
+        "button_label": "Копіювати альтернативний текст",
+        "watermark": "Знизу є водяний знак із текстом \"./npmx a fast, modern browser for the npm registry\"",
+        "analysis": "{package_name} починається зі значення {start_value} і закінчується на {end_value}, демонструючи {trend} тенденцію з нахилом {downloads_slope} завантажень за часовий інтервал",
+        "estimation": "Кінцеве значення є оцінкою, заснованою на часткових даних за поточний період.",
+        "estimations": "Кінцеві значення є оцінками, заснованими на часткових даних за поточний період.",
+        "compare": "Лінійна діаграма порівняння завантажень пакетів для: {packages}.",
+        "single_package": "Лінійна діаграма завантажень пакету {package}.",
+        "general_description": "Вісь Y відображає кількість завантажень. Вісь X відображає діапазон дат, від {start_date} до {end_date}, з часовим інтервалом {granularity}.{estimation_notice} {packages_analysis}. {watermark}."
       }
     },
     "downloads": {
@@ -621,6 +672,7 @@
       "invalid_name": "Невірна назва пакета:",
       "available": "Ця назва доступна!",
       "taken": "Ця назва вже зайнята.",
+      "missing_permission": "Ви не маєте дозволу на додавання пакету до scope {'@'}{scope}.",
       "similar_warning": "Існують подібні пакети - npm може відхилити цю назву:",
       "related": "Пов'язані пакети:",
       "scope_warning_title": "Розглянути використання пакета з обсягом",
@@ -663,7 +715,8 @@
       "preview": "попередній перегляд",
       "code": "код"
     },
-    "file_path": "Шлях до файлу"
+    "file_path": "Шлях до файлу",
+    "scroll_to_top": "Прокрутити вгору"
   },
   "badges": {
     "provenance": {
@@ -815,6 +868,12 @@
         "managers": "пакетів"
       }
     },
+    "sponsors": {
+      "title": "Спонсори"
+    },
+    "oss_partners": {
+      "title": "Партнери відкритого ПЗ"
+    },
     "team": {
       "title": "Команда",
       "governance": "Управління",
@@ -907,6 +966,7 @@
       "section_packages": "Пакети",
       "section_facets": "Аспекти",
       "section_comparison": "Порівняння",
+      "copy_as_markdown": "Копіювати таблицю",
       "loading": "Завантаження даних пакета...",
       "error": "Не вдалося завантажити дані пакета. Спробуйте ще раз.",
       "empty_title": "Виберіть пакети для порівняння",
@@ -1014,7 +1074,37 @@
       "trends": {
         "title": "Порівняти тренди"
       }
-    }
+    },
+    "file_changes": "Зміни файлів",
+    "files_count": "{count} файлів",
+    "lines_hidden": "{count} рядків приховано",
+    "compare_versions": "різниця",
+    "summary": "Підсумок",
+    "deps_count": "{count} залежн.",
+    "dependencies": "Залежності",
+    "dev_dependencies": "Dev-залежності",
+    "peer_dependencies": "Peer-залежності",
+    "optional_dependencies": "Опціональні залежності",
+    "no_dependency_changes": "Змін у залежностях немає",
+    "file_filter_option": {
+      "all": "Усі ({count})",
+      "added": "Додані ({count})",
+      "removed": "Видалені ({count})",
+      "modified": "Змінені ({count})"
+    },
+    "search_files_placeholder": "Пошук файлів...",
+    "no_files_all": "Немає файлів",
+    "no_files_search": "Немає файлів, що відповідають \"{query}\"",
+    "no_files_filtered": "Немає файлів типу {filter}",
+    "filter": {
+      "added": "додано",
+      "removed": "видалено",
+      "modified": "змінено"
+    },
+    "files_button": "Файли",
+    "select_file_prompt": "Виберіть файл з бічної панелі для перегляду різниці",
+    "close_files_panel": "Закрити панель файлів",
+    "filter_files_label": "Фільтрувати файли за типом зміни"
   },
   "privacy_policy": {
     "title": "політика конфіденційності",

--- a/lunaria/files/uk-UA.json
+++ b/lunaria/files/uk-UA.json
@@ -2,12 +2,12 @@
   "seo": {
     "home": {
       "title": "npmx - Браузер пакетів для реєстру npm",
-      "description": "Кращий браузер для реєстру npm. Пошук, перегляд та дослідження пакетів за допомогою сучасного інтерфейсу."
+      "description": "Швидкий сучасний браузер для реєстру npm. Пошук, перегляд та дослідження пакетів за допомогою сучасного інтерфейсу."
     }
   },
   "built_at": "збірка {0}",
   "alt_logo": "лого npmx",
-  "tagline": "кращий браузер для реєстру npm",
+  "tagline": "швидкий сучасний браузер для реєстру npm",
   "non_affiliation_disclaimer": "не пов'язаний з npm, Inc.",
   "trademark_disclaimer": "npm є зареєстрованою торговою маркою npm, Inc. Цей сайт не пов'язаний з npm, Inc.",
   "footer": {
@@ -32,7 +32,8 @@
     "navigate_results": "Навігація результатами",
     "go_to_result": "Перейти до результату",
     "open_code_view": "Відкрити перегляд коду",
-    "open_docs": "Відкрити документацію"
+    "open_docs": "Відкрити документацію",
+    "disable_shortcuts": "Ви можете вимкнути гарячі клавіші в {settings}."
   },
   "search": {
     "label": "Пошук пакетів npm",
@@ -83,7 +84,8 @@
       "appearance": "Зовнішній вигляд",
       "display": "Відображення",
       "search": "Джерело даних",
-      "language": "Мова"
+      "language": "Мова",
+      "keyboard_shortcuts": "Гарячі клавіші"
     },
     "data_source": {
       "label": "Джерело даних",
@@ -107,7 +109,9 @@
     "accent_colors": "Колірні акценти",
     "clear_accent": "Очистити колір акценту",
     "translation_progress": "Прогрес перекладу",
-    "background_themes": "Колір фону"
+    "background_themes": "Колір фону",
+    "keyboard_shortcuts_enabled": "Увімкнути гарячі клавіші",
+    "keyboard_shortcuts_enabled_description": "Гарячі клавіші можна вимкнути, якщо вони конфліктують з налаштуваннями браузера або системи"
   },
   "i18n": {
     "missing_keys": "Відсутній 1 переклад | Відсутні {count} переклади",
@@ -155,6 +159,13 @@
       "package": "Цей пакет більше не підтримується.",
       "version": "Ця версія більше не підтримується.",
       "no_reason": "Причину не вказано"
+    },
+    "size_increase": {
+      "title_size": "Значне збільшення розміру починаючи з v{version}",
+      "title_deps": "Значне збільшення кількості залежностей починаючи з v{version}",
+      "title_both": "Значне збільшення розміру і залежностей починаючи з v{version}",
+      "size": "Розмір встановлення збільшився на {percent} ({size} більше)",
+      "deps": "{count} додаткових залежностей"
     },
     "replacement": {
       "title": "Можливо вам не потрібна ця залежність.",
@@ -293,8 +304,16 @@
       "view_all": "Переглянути {count} версію | Переглянути всі {count} версій",
       "distribution_title": "Група Semver",
       "distribution_modal_title": "Версії",
+      "distribution_range_date_same_year": "від {from} до {to}, {endYear}",
+      "distribution_range_date_multiple_years": "від {from}, {startYear} до {to}, {endYear}",
       "grouping_major": "Основна",
       "grouping_minor": "Мінорна",
+      "grouping_versions_title": "Версії",
+      "grouping_versions_all": "Усі",
+      "grouping_versions_only_recent": "Тільки нещодавні",
+      "grouping_usage_title": "Використання",
+      "grouping_usage_all": "Усі",
+      "grouping_usage_low": "Низьке",
       "recent_versions_only_tooltip": "Показувати лише версії, опубліковані за останній рік.",
       "show_low_usage_tooltip": "Включити групи версій з менш ніж 1% від загальних завантажень.",
       "y_axis_label": "Завантаження",
@@ -303,13 +322,17 @@
       "filter_help": "Довідка з фільтра діапазону semver",
       "filter_tooltip": "Фільтрувати версії за {link}. Наприклад, ^3.0.0 показує всі версії 3.x.",
       "filter_tooltip_link": "діапазоном semver",
-      "no_matches": "Жодна версія не відповідає цьому діапазону"
+      "no_matches": "Жодна версія не відповідає цьому діапазону",
+      "copy_alt": {
+        "per_version_analysis": "Версія {version} була завантажена {downloads} разів",
+        "general_description": "Стовпчаста діаграма, що показує завантаження за версіями для {versions_count} {semver_grouping_mode} версій пакету {package_name}, {date_range_label} від версії {first_version} до версії {last_version}. Найбільш завантажувана версія — {max_downloaded_version} з {max_version_downloads} завантаженнями. {per_version_analysis}. {watermark}."
+      }
     },
     "dependencies": {
       "title": "Залежності ({count})",
       "list_label": "Залежності пакета",
       "show_all": "показати всі {count} залежностей",
-      "optional": "опціональні",
+      "optional": "опціонально",
       "view_vulnerabilities": "Переглянути вразливості",
       "outdated_major": "{count} мажорна версія відставання (остання: {latest}) | {count} мажорних версій відставання (остання: {latest})",
       "outdated_minor": "{count} мінорна версія відставання (остання: {latest}) | {count} мінорних версій відставання (остання: {latest})",
@@ -342,10 +365,10 @@
     },
     "trends": {
       "granularity": "Деталізація",
-      "granularity_daily": "Щоденно",
-      "granularity_weekly": "Щотижня",
-      "granularity_monthly": "Щомісяця",
-      "granularity_yearly": "Щороку",
+      "granularity_daily": "Щоденні",
+      "granularity_weekly": "Щотижневі",
+      "granularity_monthly": "Щомісячні",
+      "granularity_yearly": "Щорічні",
       "start_date": "Початок",
       "end_date": "Кінець",
       "loading": "Завантаження...",
@@ -353,6 +376,7 @@
       "date_range_multiline": "{start}\nдо {end}",
       "download_file": "Завантажити {fileType}",
       "toggle_annotator": "Перемкнути анотатор",
+      "toggle_stack_mode": "Перемкнути режим стека",
       "legend_estimation": "Оцінка",
       "no_data": "Дані недоступні",
       "y_axis_label": "{granularity} {facet}",
@@ -363,6 +387,33 @@
         "downloads": "Завантаження",
         "likes": "Вподобання",
         "contributors": "Супроводжувачі"
+      },
+      "play_animation": "Запустити анімацію",
+      "pause_animation": "Зупинити анімацію",
+      "data_correction": "Корекція даних",
+      "average_window": "Вікно усереднення",
+      "smoothing": "Згладжування",
+      "known_anomalies": "Відомі аномалії",
+      "known_anomalies_description": "Інтерполює відомі стрибки кількості завантажень, спричинені ботами або проблемами CI.",
+      "known_anomalies_ranges": "Діапазони аномалій",
+      "known_anomalies_range": "Від {start} до {end}",
+      "known_anomalies_range_named": "{packageName}: від {start} до {end}",
+      "known_anomalies_none": "Для цього пакету немає відомих аномалій. | Для цих пакетів немає відомих аномалій.",
+      "known_anomalies_contribute": "Додати дані про аномалію",
+      "apply_correction": "Застосувати корекцію",
+      "copy_alt": {
+        "trend_none": "здебільшого рівна",
+        "trend_strong": "сильна",
+        "trend_weak": "слабка",
+        "trend_undefined": "невизначена (недостатньо даних)",
+        "button_label": "Копіювати альтернативний текст",
+        "watermark": "Знизу є водяний знак із текстом \"./npmx a fast, modern browser for the npm registry\"",
+        "analysis": "{package_name} починається зі значення {start_value} і закінчується на {end_value}, демонструючи {trend} тенденцію з нахилом {downloads_slope} завантажень за часовий інтервал",
+        "estimation": "Кінцеве значення є оцінкою, заснованою на часткових даних за поточний період.",
+        "estimations": "Кінцеві значення є оцінками, заснованими на часткових даних за поточний період.",
+        "compare": "Лінійна діаграма порівняння завантажень пакетів для: {packages}.",
+        "single_package": "Лінійна діаграма завантажень пакету {package}.",
+        "general_description": "Вісь Y відображає кількість завантажень. Вісь X відображає діапазон дат, від {start_date} до {end_date}, з часовим інтервалом {granularity}.{estimation_notice} {packages_analysis}. {watermark}."
       }
     },
     "downloads": {
@@ -620,6 +671,7 @@
       "invalid_name": "Невірна назва пакета:",
       "available": "Ця назва доступна!",
       "taken": "Ця назва вже зайнята.",
+      "missing_permission": "Ви не маєте дозволу на додавання пакету до scope {'@'}{scope}.",
       "similar_warning": "Існують подібні пакети - npm може відхилити цю назву:",
       "related": "Пов'язані пакети:",
       "scope_warning_title": "Розглянути використання пакета з обсягом",
@@ -662,7 +714,8 @@
       "preview": "попередній перегляд",
       "code": "код"
     },
-    "file_path": "Шлях до файлу"
+    "file_path": "Шлях до файлу",
+    "scroll_to_top": "Прокрутити вгору"
   },
   "badges": {
     "provenance": {
@@ -814,6 +867,12 @@
         "managers": "пакетів"
       }
     },
+    "sponsors": {
+      "title": "Спонсори"
+    },
+    "oss_partners": {
+      "title": "Партнери відкритого ПЗ"
+    },
     "team": {
       "title": "Команда",
       "governance": "Управління",
@@ -906,6 +965,7 @@
       "section_packages": "Пакети",
       "section_facets": "Аспекти",
       "section_comparison": "Порівняння",
+      "copy_as_markdown": "Копіювати таблицю",
       "loading": "Завантаження даних пакета...",
       "error": "Не вдалося завантажити дані пакета. Спробуйте ще раз.",
       "empty_title": "Виберіть пакети для порівняння",
@@ -1013,7 +1073,37 @@
       "trends": {
         "title": "Порівняти тренди"
       }
-    }
+    },
+    "file_changes": "Зміни файлів",
+    "files_count": "{count} файлів",
+    "lines_hidden": "{count} рядків приховано",
+    "compare_versions": "різниця",
+    "summary": "Підсумок",
+    "deps_count": "{count} залежн.",
+    "dependencies": "Залежності",
+    "dev_dependencies": "Dev-залежності",
+    "peer_dependencies": "Peer-залежності",
+    "optional_dependencies": "Опціональні залежності",
+    "no_dependency_changes": "Змін у залежностях немає",
+    "file_filter_option": {
+      "all": "Усі ({count})",
+      "added": "Додані ({count})",
+      "removed": "Видалені ({count})",
+      "modified": "Змінені ({count})"
+    },
+    "search_files_placeholder": "Пошук файлів...",
+    "no_files_all": "Немає файлів",
+    "no_files_search": "Немає файлів, що відповідають \"{query}\"",
+    "no_files_filtered": "Немає файлів типу {filter}",
+    "filter": {
+      "added": "додано",
+      "removed": "видалено",
+      "modified": "змінено"
+    },
+    "files_button": "Файли",
+    "select_file_prompt": "Виберіть файл з бічної панелі для перегляду різниці",
+    "close_files_panel": "Закрити панель файлів",
+    "filter_files_label": "Фільтрувати файли за типом зміни"
   },
   "privacy_policy": {
     "title": "політика конфіденційності",


### PR DESCRIPTION
### 🔗 Linked issue

See #1689 

### 📚 Description

- updated "tagline" and others where we put "fast, modern"
- added keys for trends, Settings shortcuts
- other minor translation improvements
