### PR TITLE
fix: prevent external CSS from affecting SVG icons

### DIFF
--- a/app/components/Code/FileTree.vue
+++ b/app/components/Code/FileTree.vue
@@ -94,12 +94,7 @@ watch(
           block
           :style="{ paddingLeft: `${depth * 12 + 32}px` }"
         >
-          <svg
-            class="size-[1em] me-1 shrink-0"
-            viewBox="0 0 16 16"
-            fill="currentColor"
-            aria-hidden="true"
-          >
+          <svg class="size-[1em] me-1 shrink-0" viewBox="0 0 16 16" aria-hidden="true">
             <use :href="`/file-tree-sprite.svg#${getFileIcon(node.name)}`" />
           </svg>
           <span class="truncate">{{ node.name }}</span>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

Remove `fill`, prevent external CSS affect icon.

Before: 
<img width="448" height="588" alt="image" src="https://github.com/user-attachments/assets/c96cc714-fc72-40ad-8cb1-cb420a8011a3" />

After:

<img width="451" height="577" alt="image" src="https://github.com/user-attachments/assets/2c2d53d9-ae59-401b-b90d-7dbf269df1e7" />

The LICENSE icon was missing because vscode-icons-theme uses a linearGradient in the icon, which is not valid inside Shadow DOM.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
