### PR TITLE
fix: hide scroll-to-top button on non-mobile devices

### DIFF
--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -324,7 +324,7 @@ const { scrollToTop, isTouchDeviceClient } = useScrollToTop()
 
 const { y: scrollY } = useScroll(window)
 const showScrollToTop = computed(
-  () => isTouchDeviceClient.value && scrollY.value > SCROLL_TO_TOP_THRESHOLD,
+  () => isMobile.value && isTouchDeviceClient.value && scrollY.value > SCROLL_TO_TOP_THRESHOLD,
 )
 
 // Fetch dependency analysis (lazy, client-side)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

I've seen discussions on [Discord](https://discord.com/channels/1464542801676206113/1464926468751753269/1476941040576499815)  about "Scroll to Top" buttons on tablets/desktops.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
This PR is merely a safety measure to prevent the button from appearing where it shouldn't—you can always close this PR if you prefer the previously discussed approach.

This is a minimal fix.
- Add an `isMobile` media query check