### PR TITLE
chore: bump vue-data-ui from 3.15.8 to 3.15.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "vite-plugin-pwa": "1.2.0",
     "vite-plus": "0.0.0-g52709db6.20260226-1136",
     "vue": "3.5.29",
-    "vue-data-ui": "3.15.8"
+    "vue-data-ui": "3.15.9"
   },
   "devDependencies": {
     "@e18e/eslint-plugin": "0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,8 +223,8 @@ importers:
         specifier: 3.5.29
         version: 3.5.29(typescript@5.9.3)
       vue-data-ui:
-        specifier: 3.15.8
-        version: 3.15.8(vue@3.5.29(typescript@5.9.3))
+        specifier: 3.15.9
+        version: 3.15.9(vue@3.5.29(typescript@5.9.3))
     devDependencies:
       '@e18e/eslint-plugin':
         specifier: 0.2.0
@@ -10363,8 +10363,8 @@ packages:
   vue-component-type-helpers@3.2.5:
     resolution: {integrity: sha512-tkvNr+bU8+xD/onAThIe7CHFvOJ/BO6XCOrxMzeytJq40nTfpGDJuVjyCM8ccGZKfAbGk2YfuZyDMXM56qheZQ==}
 
-  vue-data-ui@3.15.8:
-    resolution: {integrity: sha512-9Htys+aB95bC8cWGPv+jGptDORtA8i4xRfVx9QDEO99LmyUisaTOwkkhV753DAcfu4pbs+dAfCIOVaGM3nTaBA==}
+  vue-data-ui@3.15.9:
+    resolution: {integrity: sha512-xNv8u//zPkKQT+WNtPsxWLdRBgyZPpDn5X0z6klB/8CouHXYrC8FO5eul28bTE3cbmm/vZZDC2LRupfeeu7zNA==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -22967,7 +22967,7 @@ snapshots:
 
   vue-component-type-helpers@3.2.5: {}
 
-  vue-data-ui@3.15.8(vue@3.5.29(typescript@5.9.3)):
+  vue-data-ui@3.15.9(vue@3.5.29(typescript@5.9.3)):
     dependencies:
       vue: 3.5.29(typescript@5.9.3)
 


### PR DESCRIPTION
Fixes the downloads sparkline data label issue when the wrapper has a `rtl` direction.
Linked to #1727, the following css override can now be removed in `WeeklyDownloadStats.vue`:

```css
/* TODO: remove this style once we have rtl support */
.vue-ui-sparkline svg {
  direction: ltr;
}
```