### PR TITLE
chore: fix harcoded oauth dev port

### DIFF
--- a/config/env.ts
+++ b/config/env.ts
@@ -2,6 +2,7 @@
 
 import Git from 'simple-git'
 import * as process from 'node:process'
+import { useNuxt } from 'nuxt/kit'
 
 export { version } from '../package.json'
 
@@ -149,6 +150,8 @@ export async function getEnv(isDevelopment: boolean) {
       : branch === 'main'
         ? 'canary'
         : 'release'
+  const nuxt = useNuxt()
+  const devUrl = isDevelopment ? `http://127.0.0.1:${nuxt.options.devServer.port}` : undefined
   const previewUrl = getPreviewUrl()
   const productionUrl = getProductionUrl()
   return {
@@ -156,6 +159,7 @@ export async function getEnv(isDevelopment: boolean) {
     shortCommit,
     branch,
     env,
+    devUrl,
     previewUrl,
     productionUrl,
     prNumber,

--- a/modules/oauth.ts
+++ b/modules/oauth.ts
@@ -12,8 +12,8 @@ export default defineNuxtModule({
   async setup() {
     const nuxt = useNuxt()
 
-    const { previewUrl, productionUrl } = await getEnv(nuxt.options.dev)
-    const clientUri = productionUrl || previewUrl || 'http://127.0.0.1:3000'
+    const { devUrl, previewUrl, productionUrl } = await getEnv(nuxt.options.dev)
+    const clientUri = productionUrl || previewUrl || devUrl || 'http://127.0.0.1:3000'
 
     // bake it into a virtual file
     addServerTemplate({


### PR DESCRIPTION
### 🔗 Linked issue

N/A - just found this while working on something else

### 🧭 Context

When the dev server runs on another port, you can't auth because it redirects back to to port 3000.

### 📚 Description

Use the nuxt dev server port instead of hardcoding