### PR TITLE
fix: handle empty package description in table row display

### DIFF
--- a/app/components/Package/TableRow.vue
+++ b/app/components/Package/TableRow.vue
@@ -69,7 +69,7 @@ const allMaintainersText = computed(() => {
       v-if="isColumnVisible('description')"
       class="py-2 px-3 text-sm text-fg-muted max-w-xs truncate"
     >
-      {{ stripHtmlTags(decodeHtmlEntities(pkg.description || '-')) }}
+      {{ stripHtmlTags(decodeHtmlEntities(pkg.description || '')) || '-' }}
     </td>
 
     <!-- Downloads -->


### PR DESCRIPTION
### 🔗 Linked issue

Extra PR for the issue #1681

### 🧭 Context

In the first PR, we are not handling the scenario where the description contains only HTML tags. We would end up with empty boxes for the description package on the search page. Instead, we want to display dashes (-).
