### PR TITLE
fix: remove icon in anchor links in text

### DIFF
--- a/app/components/Readme.vue
+++ b/app/components/Readme.vue
@@ -150,6 +150,17 @@ function handleClick(event: MouseEvent) {
   @apply inline i-lucide:external-link rtl-flip ms-1 opacity-50;
 }
 
+.readme :deep(:is(h1, h2, h3, h4, h5, h6) a[href^='#']::after) {
+  /* I don't know what kind of sorcery this is, but it ensures this icon can't wrap to a new line on its own. */
+  content: '__';
+  @apply inline i-lucide:link rtl-flip ms-1 opacity-0;
+  font-size: 0.75em;
+}
+
+.readme :deep(:is(h1, h2, h3, h4, h5, h6) a[href^='#']:hover::after) {
+  @apply opacity-100;
+}
+
 .readme :deep(code) {
   @apply font-mono;
   font-size: 0.875em;


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1762 

### 📚 Description

We included a hash icon next to every anchor link in the text to indicate that it was an anchor link. We agreed in the Discord channel that we should remove it. We will keep the hash icons only for heading anchor links.
