### PR TITLE
fix(i18n): update French UI strings

### DIFF
--- a/i18n/locales/fr-FR.json
+++ b/i18n/locales/fr-FR.json
@@ -33,7 +33,8 @@
     "navigate_results": "Parcourir les résultats",
     "go_to_result": "Aller au résultat",
     "open_code_view": "Ouvrir la vue code",
-    "open_docs": "Ouvrir la doc"
+    "open_docs": "Ouvrir la doc",
+    "disable_shortcuts": "Vous pouvez désactiver les raccourcis clavier dans {settings}."
   },
   "search": {
     "label": "Rechercher des paquets npm",
@@ -84,7 +85,8 @@
       "appearance": "Apparence",
       "display": "Affichage",
       "search": "Source de données",
-      "language": "Langue"
+      "language": "Langue",
+      "keyboard_shortcuts": "Raccourcis clavier"
     },
     "data_source": {
       "label": "Source de données",
@@ -108,7 +110,9 @@
     "accent_colors": "Couleurs d'accentuation",
     "clear_accent": "Supprimer la couleur d'accentuation",
     "translation_progress": "Progression de la traduction",
-    "background_themes": "Teinte de fond"
+    "background_themes": "Teinte de fond",
+    "keyboard_shortcuts_enabled": "Activer les raccourcis clavier",
+    "keyboard_shortcuts_enabled_description": "Les raccourcis clavier peuvent être désactivés s'ils entrent en conflit avec d'autres raccourcis du navigateur ou du système"
   },
   "i18n": {
     "missing_keys": "{count} traduction manquante | {count} traductions manquantes",
@@ -140,7 +144,28 @@
       "role": "rôle",
       "members": "membres"
     },
-    "scroll_to_top": "Retour en haut"
+    "scroll_to_top": "Retour en haut",
+    "cancel": "Annuler",
+    "save": "Enregistrer",
+    "edit": "Modifier",
+    "error": "Erreur"
+  },
+  "profile": {
+    "display_name": "Nom d'affichage",
+    "description": "Description",
+    "no_description": "Aucune description",
+    "website": "Site web",
+    "website_placeholder": "https://exemple.com",
+    "likes": "Mentions j'aime",
+    "seo_title": "{handle} - npmx",
+    "seo_description": "Profil npmx par {handle}",
+    "not_found": "Profil introuvable",
+    "not_found_message": "Le profil de {handle} est introuvable.",
+    "invite": {
+      "message": "Il semblerait qu'ils n'utilisent pas encore npmx. Vous voulez leur en parler ?",
+      "share_button": "Partager sur Bluesky",
+      "compose_text": "Salut {'@'}{handle} ! As-tu déjà testé npmx.dev ? C'est un navigateur pour le registre npm : rapide, moderne et open source.\nhttps://npmx.dev"
+    }
   },
   "package": {
     "not_found": "Paquet introuvable",
@@ -712,7 +737,8 @@
       "preview": "aperçu",
       "code": "code"
     },
-    "file_path": "Chemin du fichier"
+    "file_path": "Chemin du fichier",
+    "scroll_to_top": "Remonter en haut"
   },
   "badges": {
     "provenance": {
@@ -929,7 +955,8 @@
       "connect_bluesky": "Connexion avec Bluesky",
       "what_is_atmosphere": "Qu'est-ce qu'un compte Atmosphere ?",
       "atmosphere_explanation": "{npmx} utilise {atproto} pour alimenter plusieurs de ses fonctionnalités sociales, permettant aux utilisateurs de posséder leurs données et d'utiliser un seul compte pour toutes les applications compatibles. Une fois votre compte créé, vous pouvez utiliser d'autres applications comme {bluesky} ou {tangled} avec le même compte.",
-      "default_input_error": "Veuillez entrer un identifiant, DID ou URL PDS valide"
+      "default_input_error": "Veuillez entrer un identifiant, DID ou URL PDS valide",
+      "profile": "Profil"
     }
   },
   "header": {
@@ -1074,6 +1101,8 @@
     "file_changes": "Modifications de fichiers",
     "files_count": "{count} fichiers",
     "lines_hidden": "{count} lignes masquées",
+    "file_too_large": "Fichier trop volumineux pour être comparé",
+    "file_size_warning": "{size} dépasse la limite de 250 Ko pour la comparaison",
     "compare_versions": "diff",
     "summary": "Résumé",
     "deps_count": "{count} dépendances",

--- a/lunaria/files/fr-FR.json
+++ b/lunaria/files/fr-FR.json
@@ -32,7 +32,8 @@
     "navigate_results": "Parcourir les résultats",
     "go_to_result": "Aller au résultat",
     "open_code_view": "Ouvrir la vue code",
-    "open_docs": "Ouvrir la doc"
+    "open_docs": "Ouvrir la doc",
+    "disable_shortcuts": "Vous pouvez désactiver les raccourcis clavier dans {settings}."
   },
   "search": {
     "label": "Rechercher des paquets npm",
@@ -83,7 +84,8 @@
       "appearance": "Apparence",
       "display": "Affichage",
       "search": "Source de données",
-      "language": "Langue"
+      "language": "Langue",
+      "keyboard_shortcuts": "Raccourcis clavier"
     },
     "data_source": {
       "label": "Source de données",
@@ -107,7 +109,9 @@
     "accent_colors": "Couleurs d'accentuation",
     "clear_accent": "Supprimer la couleur d'accentuation",
     "translation_progress": "Progression de la traduction",
-    "background_themes": "Teinte de fond"
+    "background_themes": "Teinte de fond",
+    "keyboard_shortcuts_enabled": "Activer les raccourcis clavier",
+    "keyboard_shortcuts_enabled_description": "Les raccourcis clavier peuvent être désactivés s'ils entrent en conflit avec d'autres raccourcis du navigateur ou du système"
   },
   "i18n": {
     "missing_keys": "{count} traduction manquante | {count} traductions manquantes",
@@ -139,7 +143,28 @@
       "role": "rôle",
       "members": "membres"
     },
-    "scroll_to_top": "Retour en haut"
+    "scroll_to_top": "Retour en haut",
+    "cancel": "Annuler",
+    "save": "Enregistrer",
+    "edit": "Modifier",
+    "error": "Erreur"
+  },
+  "profile": {
+    "display_name": "Nom d'affichage",
+    "description": "Description",
+    "no_description": "Aucune description",
+    "website": "Site web",
+    "website_placeholder": "https://exemple.com",
+    "likes": "Mentions j'aime",
+    "seo_title": "{handle} - npmx",
+    "seo_description": "Profil npmx par {handle}",
+    "not_found": "Profil introuvable",
+    "not_found_message": "Le profil de {handle} est introuvable.",
+    "invite": {
+      "message": "Il semblerait qu'ils n'utilisent pas encore npmx. Vous voulez leur en parler ?",
+      "share_button": "Partager sur Bluesky",
+      "compose_text": "Salut {'@'}{handle} ! As-tu déjà testé npmx.dev ? C'est un navigateur pour le registre npm : rapide, moderne et open source.\nhttps://npmx.dev"
+    }
   },
   "package": {
     "not_found": "Paquet introuvable",
@@ -711,7 +736,8 @@
       "preview": "aperçu",
       "code": "code"
     },
-    "file_path": "Chemin du fichier"
+    "file_path": "Chemin du fichier",
+    "scroll_to_top": "Remonter en haut"
   },
   "badges": {
     "provenance": {
@@ -928,7 +954,8 @@
       "connect_bluesky": "Connexion avec Bluesky",
       "what_is_atmosphere": "Qu'est-ce qu'un compte Atmosphere ?",
       "atmosphere_explanation": "{npmx} utilise {atproto} pour alimenter plusieurs de ses fonctionnalités sociales, permettant aux utilisateurs de posséder leurs données et d'utiliser un seul compte pour toutes les applications compatibles. Une fois votre compte créé, vous pouvez utiliser d'autres applications comme {bluesky} ou {tangled} avec le même compte.",
-      "default_input_error": "Veuillez entrer un identifiant, DID ou URL PDS valide"
+      "default_input_error": "Veuillez entrer un identifiant, DID ou URL PDS valide",
+      "profile": "Profil"
     }
   },
   "header": {
@@ -1073,6 +1100,8 @@
     "file_changes": "Modifications de fichiers",
     "files_count": "{count} fichiers",
     "lines_hidden": "{count} lignes masquées",
+    "file_too_large": "Fichier trop volumineux pour être comparé",
+    "file_size_warning": "{size} dépasse la limite de 250 Ko pour la comparaison",
     "compare_versions": "diff",
     "summary": "Résumé",
     "deps_count": "{count} dépendances",


### PR DESCRIPTION
### 🔗 Linked issue

None

### 🧭 Context

New English UI strings have been added.

### 📚 Description

Adds missing UI strings to the French translation.

Note that I'm using non breaking spaces before punctuation (`:`, `?`) because I always find this horrible when a colon or an interrogation mark end up alone on a new line (this shouldn't happen according to the typographic rules...). It doesn't seem those kinds of spaces are used elsewhere, so let me know if using regular spaces is a requirement.

I'll also leave a comment where I had a doubt ("vous" vs "tu").

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
