### PR TITLE
refactor: remove unnecessary arrow functions

### DIFF
--- a/app/components/ScrollToTop.client.vue
+++ b/app/components/ScrollToTop.client.vue
@@ -50,7 +50,7 @@ const shouldShowButton = computed(() => isActive.value && isTouchDeviceClient.va
       type="button"
       class="fixed bottom-4 inset-ie-4 z-50 w-12 h-12 bg-bg-elevated border border-border rounded-full shadow-lg flex items-center justify-center text-fg-muted hover:text-fg transition-colors active:scale-95"
       :aria-label="$t('common.scroll_to_top')"
-      @click="() => scrollToTop()"
+      @click="scrollToTop"
     >
       <span class="i-lucide:arrow-up w-5 h-5" aria-hidden="true" />
     </button>

--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -892,7 +892,7 @@ const showSkeleton = shallowRef(false)
               variant="secondary"
               :title="$t('common.scroll_to_top')"
               :aria-label="$t('common.scroll_to_top')"
-              @click="() => scrollToTop()"
+              @click="scrollToTop"
               classicon="i-lucide:arrow-up"
             />
           </ButtonGroup>


### PR DESCRIPTION
### 🔗 Linked issue
/
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context
/
<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description
`scrollToTop` is a function in itself, so there's no need to nest it as an arrow function.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
