### PR TITLE
feat: chat.npmx.dev + build.npmx.dev

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
       "has": [
         {
           "type": "host",
-          "value": "chat.npmx.dev"
+          "value": "build.npmx.dev"
         }
       ],
       "destination": "https://discord.gg/x9KE5U2q8w"
@@ -17,7 +17,7 @@
       "has": [
         {
           "type": "host",
-          "value": "community.npmx.dev"
+          "value": "chat.npmx.dev"
         }
       ],
       "destination": "https://discord.gg/CjZM5qRbCu"


### PR DESCRIPTION
The new discord is ready to receive users. See for context:
- https://github.com/npmx-dev/npmx.dev/issues/1583

This creates help.npmx.dev, equivalent to chat.npmx.dev but for the new discord.