### PR TITLE
fix: correct org name regexp

### DIFF
--- a/server/api/registry/org/[org]/packages.get.ts
+++ b/server/api/registry/org/[org]/packages.get.ts
@@ -1,7 +1,7 @@
 import { CACHE_MAX_AGE_ONE_HOUR, NPM_REGISTRY } from '#shared/utils/constants'
 import { FetchError } from 'ofetch'
 
-// Validation pattern for npm org names (alphanumeric with hyphens)
+// Validation pattern for npm org names - url-sage symbold and not start with a dot (incl. ~test24214. or -ex~-)
 const NPM_ORG_NAME_RE = /^[\w~-][\w.~-]*$/
 
 function validateOrgName(name: string): void {


### PR DESCRIPTION
### 🔗 Linked issue

Related post - [bsky.app](https://bsky.app/profile/samuel.fm/post/3mfykv4v5zs2l)

### 🧭 Context

We had a very basic rule that was much stricter than what is available in npm

In npm [as I found] only two rules - url-safe symbols and does not start with a dot:

`https://www.npmjs.com/org/~test24214.`

`https://www.npmjs.com/org/-ex~-`

### 📚 Description

Updated regexp to match npm rules

* https://npmxdev-git-fork-alexdln-fix-update-org-name-rule-npmx.vercel.app/org/bsky.app
* https://npmxdev-git-fork-alexdln-fix-update-org-name-rule-npmx.vercel.app/org/~test24214.
* https://npmxdev-git-fork-alexdln-fix-update-org-name-rule-npmx.vercel.app/org/-ex~-

<img width="1120" height="473" alt="image" src="https://github.com/user-attachments/assets/bad0d5d6-1f95-4c5e-b723-ef84038e01a6" />
