### PR TITLE
fix: allow vercel preview builds to access the local connector

### DIFF
--- a/cli/src/server.ts
+++ b/cli/src/server.ts
@@ -82,7 +82,12 @@ function generateOperationId(): string {
 }
 
 const corsOptions: CorsOptions = {
-  origin: ['https://npmx.dev', /^http:\/\/localhost:\d+$/, /^http:\/\/127.0.0.1:\d+$/],
+  origin: [
+    'https://npmx.dev',
+    /^http:\/\/localhost:\d+$/,
+    /^http:\/\/127.0.0.1:\d+$/,
+    /^https:\/\/(.*)\.vercel\.app$/,
+  ],
   methods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
   allowHeaders: ['Content-Type', 'Authorization'],
 }


### PR DESCRIPTION
### 🔗 Linked issue

#1793 

### 🧭 Context

The CLI connector uses CORS headers to secure access to it, the headers however do not allow access from vercel preview deployments.

### 📚 Description

This PR adds the following regex to allowed origins

```
/^https:\/\/(.*)\.vercel\.app$/
```

Regex itself might need some work 😬

