### PR TITLE
fix: add neutral to accentColorIds in prehydration

### DIFF
--- a/app/utils/prehydrate.ts
+++ b/app/utils/prehydrate.ts
@@ -10,7 +10,15 @@ export function initPreferencesOnPrehydrate() {
   // All constants must be hardcoded inside the callback.
   onPrehydrate(() => {
     // Valid accent color IDs (must match --swatch-* variables defined in main.css)
-    const accentColorIds = new Set(['coral', 'amber', 'emerald', 'sky', 'violet', 'magenta'])
+    const accentColorIds = new Set([
+      'sky',
+      'coral',
+      'amber',
+      'emerald',
+      'violet',
+      'magenta',
+      'neutral',
+    ])
 
     // Valid package manager IDs
     const validPMs = new Set(['npm', 'pnpm', 'yarn', 'bun', 'deno', 'vlt'])


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #1792

### 🧭 Context

`neutral` was missing from `accentColorIds`, so the `has()` check skipped it on page load, and `--accent-color` was not applied, falling back to the CSS default.

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->

- Added `neutral` to `accentColorIds`
- Reordered entries to match `ACCENT_COLORS`

A better way to enforce exhaustiveness of `accentColorIds` against `AccentColorId` may be worth exploring.