### PR TITLE
fix: correctly exclude primary version from expanded tag list

### DIFF
--- a/app/components/Package/Versions.vue
+++ b/app/components/Package/Versions.vue
@@ -427,9 +427,10 @@ function getTagVersions(tag: string): VersionDisplay[] {
   return tagVersions.value.get(tag) ?? []
 }
 
-// Get filtered versions for a tag (applies semver filter when active)
-function getFilteredTagVersions(tag: string): VersionDisplay[] {
-  const versions = getTagVersions(tag)
+// Get the expanded child versions for a tag row (excludes the primary version shown in the row header,
+// and applies semver filter when active)
+function getExpandedTagVersions(tag: string, primaryVersion: string): VersionDisplay[] {
+  const versions = getTagVersions(tag).filter(v => v.version !== primaryVersion)
   if (!isFilterActive.value) return versions
   return versions.filter(v => filteredVersionSet.value.has(v.version))
 }
@@ -670,11 +671,14 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
 
         <!-- Expanded versions -->
         <div
-          v-if="expandedTags.has(row.tag) && getFilteredTagVersions(row.tag).length > 1"
+          v-if="
+            expandedTags.has(row.tag) &&
+            getExpandedTagVersions(row.tag, row.primaryVersion.version).length
+          "
           class="ms-4 ps-2 border-is border-border space-y-0.5 pe-2"
         >
           <div
-            v-for="v in getFilteredTagVersions(row.tag).slice(1)"
+            v-for="v in getExpandedTagVersions(row.tag, row.primaryVersion.version)"
             :key="v.version"
             class="py-1 relative group/version-row hover:bg-bg-elevated/20 focus-within:bg-bg-elevated/20 transition-colors duration-200"
             :class="v.version === effectiveCurrentVersion ? 'bg-bg-elevated/20 rounded' : ''"


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1789

### 🧭 Context

When expanding a dist-tag row, versions newer than the dist-tag version could be silently dropped when the dist-tag does not point to the latest version in its major.

### 📚 Description

Taking [`@types/node`](https://npm.antfu.dev/versions/@types/node?metadata=true) as an example, `ts5.1 -> 24.1.0`, but the latest `24.x` is `24.11.0`. 

`channelVersions` is sorted by semver descending, so `[0]` is always the **newest** version in the channel, not the dist-tag version:

```
tagVersions['ts5.1'] = [
  { version: '24.11.0' },  // newest, but NOT the dist-tag version
  { version: '24.10.15' },
  ...
  { version: '24.1.0' },   // actual dist-tag version, shown in row header
]
```

The old code used `.slice(1)` to exclude the primary version from the expanded list, assuming `[0]` was always the primary version. This assumption only holds when the dist-tag points to the latest version in its major.

The fix replaces `getFilteredTagVersions` + `.slice(1)` with `getExpandedTagVersions`, which filters out the primary version by version string match instead of by array position.

| Before | After |
| :-: | :-: |
| <img src="https://github.com/user-attachments/assets/84014448-456b-408b-b26d-edd1635105e4" /> | <img width="50%" src="https://github.com/user-attachments/assets/f201d252-885c-412b-9e2c-4f4606599314" /> |