### PR TITLE
docs: add missing `i18n:schema` command to `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -466,6 +466,7 @@ The following scripts help manage translation files. `en.json` is the reference 
 | `pnpm i18n:check:fix [locale]` | Same as check, but adds missing keys to other locales with English placeholders.                                                                                                        |
 | `pnpm i18n:report`             | Audits translation keys against code usage in `.vue` and `.ts` files. Reports missing keys (used in code but not in locale), unused keys (in locale but not in code), and dynamic keys. |
 | `pnpm i18n:report:fix`         | Removes unused keys from `en.json` and all other locale files.                                                                                                                          |
+| `pnpm i18n:schema`             | Generates a JSON Schema from `en.json` at `i18n/schema.json`. Locale files reference this schema for IDE validation and autocompletion.                                                 |
 
 ### Adding a new locale
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

I added this command a couple weeks ago, but didn't think to document it.

### 📚 Description

Document the command where the other i18n commands are documented