### PR TITLE
fix(ui): link "Help translate npmx" to actionable, canonical i18n landing page

### DIFF
--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -252,12 +252,12 @@ const setLocale: typeof setNuxti18nLocale = locale => {
             <!-- Simple help link for source locale -->
             <template v-else>
               <a
-                href="https://github.com/npmx-dev/npmx.dev/tree/main/i18n/locales"
+                href="https://i18n.npmx.dev/"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="inline-flex items-center gap-2 text-sm text-fg-muted hover:text-fg transition-colors duration-200 focus-visible:outline-accent/70 rounded"
               >
-                <span class="i-simple-icons:github w-4 h-4" aria-hidden="true" />
+                <span class="i-lucide:languages w-4 h-4" aria-hidden="true" />
                 {{ $t('settings.help_translate') }}
               </a>
             </template>


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

The "Help translate npmx" link goes directly to a directory on the GitHub repo. This isn't very actionable.

### 📚 Description

We have a landing page for i18n and it links out to further details about contributing. Link to that.