### PR TITLE
fix: allow did in /profile urls as well as resolve a bug in first npmx profile create

### DIFF
--- a/app/components/Header/AuthModal.client.vue
+++ b/app/components/Header/AuthModal.client.vue
@@ -78,7 +78,7 @@ watch(user, async newUser => {
       <div class="flex flex-col space-y-4">
         <LinkBase
           variant="button-secondary"
-          :to="{ name: 'profile-handle', params: { handle: user.handle } }"
+          :to="{ name: 'profile-identity', params: { identity: user.handle } }"
           prefetch-on="interaction"
           class="w-full"
           @click="authModal.close()"

--- a/server/api/auth/atproto.get.ts
+++ b/server/api/auth/atproto.get.ts
@@ -302,9 +302,7 @@ async function getNpmxProfile(handle: string, authSession: OAuthSession) {
     return profileResult.body.value
   } else {
     const profile = {
-      website: '',
       displayName: handle,
-      description: '',
     }
 
     await client.createRecord(

--- a/shared/types/social.ts
+++ b/shared/types/social.ts
@@ -29,4 +29,5 @@ export type NPMXProfile = {
   description?: string
   // If the atproto record exists for the profile
   recordExists: boolean
+  handle?: string
 }


### PR DESCRIPTION

### 🧭 Context
Resolves a couple of things
- Bug on the profile lexicon create that causes the lexicon to not be valid by setting the profile lexicon to a non valid uri
- Allows the profile endpoint to work with either a did or atproto handle

