### PR TITLE
fix: add fragments to headings

### DIFF
--- a/modules/blog.ts
+++ b/modules/blog.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 import Markdown from 'unplugin-vue-markdown/vite'
 import { addTemplate, addVitePlugin, defineNuxtModule, useNuxt, createResolver } from 'nuxt/kit'
 import shiki from '@shikijs/markdown-it'
+import MarkdownItAnchor from 'markdown-it-anchor'
 import { defu } from 'defu'
 import { read } from 'gray-matter'
 import { safeParse } from 'valibot'
@@ -72,6 +73,7 @@ export default defineNuxtModule({
               },
             }),
           )
+          md.use(MarkdownItAnchor)
         },
       }),
     )

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "focus-trap": "^8.0.0",
     "gray-matter": "4.0.3",
     "ipaddr.js": "2.3.0",
+    "markdown-it-anchor": "9.2.0",
     "marked": "17.0.3",
     "module-replacements": "2.11.0",
     "nuxt": "4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       ipaddr.js:
         specifier: 2.3.0
         version: 2.3.0
+      markdown-it-anchor:
+        specifier: 9.2.0
+        version: 9.2.0(@types/markdown-it@14.1.2)(markdown-it@14.1.1)
       marked:
         specifier: 17.0.3
         version: 17.0.3
@@ -7820,6 +7823,12 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  markdown-it-anchor@9.2.0:
+    resolution: {integrity: sha512-sa2ErMQ6kKOA4l31gLGYliFQrMKkqSO0ZJgGhDHKijPf0pNFM9vghjAh3gn26pS4JDRs7Iwa9S36gxm3vgZTzg==}
+    peerDependencies:
+      '@types/markdown-it': '*'
+      markdown-it: '*'
 
   markdown-it-async@2.2.0:
     resolution: {integrity: sha512-sITME+kf799vMeO/ww/CjH6q+c05f6TLpn6VOmmWCGNqPJzSh+uFgZoMB9s0plNtW6afy63qglNAC3MhrhP/gg==}
@@ -19282,6 +19291,11 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
+
+  markdown-it-anchor@9.2.0(@types/markdown-it@14.1.2)(markdown-it@14.1.1):
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.1.1
 
   markdown-it-async@2.2.0:
     dependencies:


### PR DESCRIPTION
### 🔗 Linked issue

This fix was trivial so I decided to just create a PR.

### 🧭 Context

On the blog, headings do not have fragments, so cannot be linked to:

```
<h2>The need for npmx</h2>
```

### 📚 Description

I used [_markdown-it-anchor_](https://www.npmjs.com/package/markdown-it-anchor) to automatically add fragments to headings:

```
<h2 id="the-need-for-npmx" tabindex="-1">The need for npmx</h2>
```