### PR TITLE
fix(a11y): use a roving tabindex for connect menu

### DIFF
--- a/app/components/Header/AccountMenu.client.vue
+++ b/app/components/Header/AccountMenu.client.vue
@@ -13,6 +13,9 @@ const {
 
 const { user: atprotoUser } = useAtproto()
 
+const menuButtonRef = useTemplateRef('menuButtonRef')
+const menuRef = useTemplateRef('menuRef')
+
 const isOpen = shallowRef(false)
 
 /** Check if connected to at least one service */
@@ -32,6 +35,7 @@ onClickOutside(accountMenuRef, () => {
 
 useEventListener('keydown', event => {
   if (event.key === 'Escape' && isOpen.value) {
+    menuButtonRef.value?.focus()
     isOpen.value = false
   }
 })
@@ -53,14 +57,82 @@ function openAuthModal() {
     authModal.open()
   }
 }
+
+watch(menuRef, () => {
+  if (!menuRef.value) return
+  // Set up focus for the first menu item
+  const firstMenuItem = menuRef.value.querySelector('[role="menuitem"]') as HTMLButtonElement
+  firstMenuItem.tabIndex = 0
+  firstMenuItem.focus()
+})
+
+const menuItemNavKeys = {
+  next: 'ArrowDown',
+  prev: 'ArrowUp',
+  start: 'Home',
+  end: 'End',
+}
+
+function onMenuBlurWithin() {
+  requestAnimationFrame(() => {
+    if (!menuRef.value?.contains(document.activeElement)) {
+      isOpen.value = false
+    }
+  })
+}
+
+/**
+ * Use a roving tabindex for the menu widget
+ */
+function onMenuKeyDown(event: KeyboardEvent) {
+  const menu = event.currentTarget as HTMLElement
+  if (!menu) return
+
+  // Collect the menu items (i.e. focusable candidates)
+  const menuItems: HTMLElement[] = Array.from(menu.querySelectorAll('[role="menuitem"]'))
+  // Find the current item
+  let currentIndex = menuItems.findIndex(menuItem => menuItem.tabIndex !== -1)
+  let currentMenuItem = menuItems.at(currentIndex)!
+
+  switch (event.key) {
+    case menuItemNavKeys.prev:
+      currentIndex = mod(currentIndex - 1, menuItems.length)
+      break
+    case menuItemNavKeys.next:
+      currentIndex = mod(currentIndex + 1, menuItems.length)
+      break
+    case menuItemNavKeys.start:
+      currentIndex = 0
+      break
+    case menuItemNavKeys.end:
+      currentIndex = menuItems.length - 1
+      break
+    default:
+      // Ignore all other keys
+      return
+  }
+
+  event.preventDefault()
+
+  currentMenuItem.tabIndex = -1
+  // Update and focus the new current item
+  currentMenuItem = menuItems.at(currentIndex)!
+  currentMenuItem.tabIndex = 0
+  currentMenuItem.focus()
+}
+
+function mod(n: number, m: number): number {
+  return ((n % m) + m) % m
+}
 </script>
 
 <template>
   <div ref="accountMenuRef" class="relative flex min-w-28 justify-end">
     <ButtonBase
+      ref="menuButtonRef"
       type="button"
       :aria-expanded="isOpen"
-      aria-haspopup="true"
+      aria-haspopup="menu"
       @click="isOpen = !isOpen"
       class="border-none"
     >
@@ -135,7 +207,14 @@ function openAuthModal() {
       enter-from-class="opacity-0 translate-y-1"
       leave-to-class="opacity-0 translate-y-1"
     >
-      <div v-if="isOpen" class="absolute inset-ie-0 top-full pt-2 w-72 z-50" role="menu">
+      <div
+        v-if="isOpen"
+        class="absolute inset-ie-0 top-full pt-2 w-72 z-50"
+        ref="menuRef"
+        role="menu"
+        @blur.capture="onMenuBlurWithin"
+        @keydown="onMenuKeyDown"
+      >
         <div
           class="bg-bg-subtle/80 backdrop-blur-sm border border-border-subtle rounded-lg shadow-lg shadow-bg-elevated/50 overflow-hidden px-1"
         >
@@ -145,6 +224,7 @@ function openAuthModal() {
             <ButtonBase
               v-if="isNpmConnected && npmUser"
               role="menuitem"
+              tabindex="-1"
               class="w-full text-start gap-x-3 border-none"
               @click="openConnectorModal"
               out
@@ -188,6 +268,7 @@ function openAuthModal() {
             <ButtonBase
               v-if="atprotoUser"
               role="menuitem"
+              tabindex="-1"
               class="w-full text-start gap-x-3 border-none"
               @click="openAuthModal"
             >
@@ -225,6 +306,7 @@ function openAuthModal() {
             <ButtonBase
               v-if="!isNpmConnected"
               role="menuitem"
+              tabindex="-1"
               class="w-full text-start gap-x-3 border-none"
               @click="openConnectorModal"
             >
@@ -251,6 +333,7 @@ function openAuthModal() {
             <ButtonBase
               v-if="!atprotoUser"
               role="menuitem"
+              tabindex="-1"
               class="w-full text-start gap-x-3 border-none"
               @click="openAuthModal"
             >

--- a/app/components/Header/AccountMenu.client.vue
+++ b/app/components/Header/AccountMenu.client.vue
@@ -62,6 +62,9 @@ watch(menuRef, () => {
   if (!menuRef.value) return
   // Set up focus for the first menu item
   const firstMenuItem = menuRef.value.querySelector('[role="menuitem"]') as HTMLButtonElement
+  if (!firstMenuItem) {
+    throw new Error('Cannot find a menuitem to focus')
+  }
   firstMenuItem.tabIndex = 0
   firstMenuItem.focus()
 })
@@ -92,7 +95,10 @@ function onMenuKeyDown(event: KeyboardEvent) {
   const menuItems: HTMLElement[] = Array.from(menu.querySelectorAll('[role="menuitem"]'))
   // Find the current item
   let currentIndex = menuItems.findIndex(menuItem => menuItem.tabIndex !== -1)
-  let currentMenuItem = menuItems.at(currentIndex)!
+  const currentMenuItem = menuItems.at(currentIndex)
+  if (!currentMenuItem) {
+    throw new Error(`Missing menuitem at index ${currentIndex}`)
+  }
 
   switch (event.key) {
     case menuItemNavKeys.prev:
@@ -112,13 +118,16 @@ function onMenuKeyDown(event: KeyboardEvent) {
       return
   }
 
+  const menuItemToFocus = menuItems.at(currentIndex)
+  if (!menuItemToFocus) {
+    throw new RangeError(`currentIndex (${currentIndex}) outside of range of menu items`)
+  }
+
   event.preventDefault()
 
   currentMenuItem.tabIndex = -1
-  // Update and focus the new current item
-  currentMenuItem = menuItems.at(currentIndex)!
-  currentMenuItem.tabIndex = 0
-  currentMenuItem.focus()
+  menuItemToFocus.tabIndex = 0
+  menuItemToFocus.focus()
 }
 
 function mod(n: number, m: number): number {

--- a/test/e2e/connector.spec.ts
+++ b/test/e2e/connector.spec.ts
@@ -28,8 +28,8 @@ async function expectConnected(page: Page, username = 'testuser') {
  * the npm CLI menu item inside the dropdown.
  */
 async function openConnectorModal(page: Page) {
-  // The AccountMenu button has aria-haspopup="true"
-  await page.locator('button[aria-haspopup="true"]').click()
+  // The AccountMenu button has aria-haspopup="menu"
+  await page.locator('button[aria-haspopup="menu"]').click()
 
   // In the dropdown menu, click the npm CLI item (menuitem containing ~testuser)
   await page


### PR DESCRIPTION
A [`menu`](https://www.w3.org/TR/wai-aria-1.3/#menu) (`composite`) widget is [navigated with arrow keys](https://www.w3.org/TR/wai-aria-1.3/#managingfocus) as opposed to the <kbd>Tab</kbd> key. This means we need to implement a roving tabindex for our connect menu.

Here is the expected behaviour:

- When a user activates the “connect” menu button, it should open the menu and focus the first item.
- When the user presses the down arrow key, it navigates to the next menu item.
- When the user presses the up arrow key, it navigates to the previous menu item.
- When the user presses the <kbd>Home</kbd> or <kbd>End</kbd> keys, they navigate to the first or last menu item respectively (optional).
- When a user presses <kbd>Escape</kbd>, tabs, or clicks away from the menu, the menu should close. In the first case, the focus should return to the menu button.

Since `role=menu` has an implicit `aria-orientation=vertical` property, I’m just implementing the up/down arrow keys. It could be worth just doing up/left and down/right in all cases as the direction isn’t often exposed to users.

I’ve done my best with the Vue and TypeScript code, however, I imagine I’m doing a few things a bit strange, so feel free to edit or make suggestions.