### PR TITLE
docs: add atprotocol.dev to alpha launch

### DIFF
--- a/app/pages/blog/alpha-release.md
+++ b/app/pages/blog/alpha-release.md
@@ -191,6 +191,7 @@ headline="Read more from the community"
     authorHandle: 'atprotocol.dev',
     description: 'Announcing npmx speakers, and congratulations on launch day!'
   },
+  {
     url: 'https://www.radosvet.dev/posts/career/from-newsletter-to-open-source',
     title: 'From a Newsletter Link to My First Open Source Contribution',
     authorHandle: 'radosvet.dev',


### PR DESCRIPTION
### 🔗 Linked issue

- #178

### 🧭 Context

The blog post will probably be at https://leaflet.pub/ceff48a4-bc95-42b0-9ade-447e27892268, but they aren't yet able to confirm the URL. Adding a placeholder for now. We can merge this one and i'll update it later. Or we can wait for the URL.

