### PR TITLE
docs: add patak.cat to alpha launch

### DIFF
--- a/app/pages/blog/alpha-release.md
+++ b/app/pages/blog/alpha-release.md
@@ -99,7 +99,7 @@ headline="Read more from the community"
     url: 'https://patak.cat/npmx/converging-communities',
     title: 'npmx: converging communities',
     authorHandle: 'patak.cat',
-    description: 'The story of the many people and communities and converged to build npmx together.'
+    description: 'The story of the many people and communities that converged to build npmx together.'
   },
   {
     url: 'https://graphieros.github.io/graphieros-blog/blog/2026/npmx.html',


### PR DESCRIPTION
### 🔗 Linked issue

- #178

### 🧭 Context

Adding patak.cat's stable URL for the alpha launch. I'll publish the post there tomorrow morning.