### PR TITLE
fix: fix more svg icons

### DIFF
--- a/app/components/Code/DirectoryListing.vue
+++ b/app/components/Code/DirectoryListing.vue
@@ -85,7 +85,6 @@ const bytesFormatter = useBytesFormatter()
               <svg
                 class="size-[1em] me-1 shrink-0 text-yellow-600"
                 viewBox="0 0 16 16"
-                fill="currentColor"
                 aria-hidden="true"
               >
                 <use :href="`/file-tree-sprite.svg#${ADDITIONAL_ICONS['folder']}`" />
@@ -110,7 +109,6 @@ const bytesFormatter = useBytesFormatter()
               <svg
                 class="size-[1em] me-1 shrink-0"
                 viewBox="0 0 16 16"
-                fill="currentColor"
                 :class="node.type === 'directory' ? 'text-yellow-600' : undefined"
                 aria-hidden="true"
               >

--- a/app/components/Code/FileTree.vue
+++ b/app/components/Code/FileTree.vue
@@ -65,7 +65,6 @@ watch(
             class="size-[1em] me-1 shrink-0"
             :class="isExpanded(node.path) ? 'text-yellow-500' : 'text-yellow-600'"
             viewBox="0 0 16 16"
-            fill="currentColor"
             aria-hidden="true"
           >
             <use


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

Same as #1734 fix more.

### 📚 Description

before:

<img width="351" height="639" alt="image" src="https://github.com/user-attachments/assets/33bd6388-7b86-4d57-be76-5c37522a52e7" />

after:

<img width="507" height="661" alt="image" src="https://github.com/user-attachments/assets/2617605c-110d-4450-9221-55bd47bb7617" />


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
