### PR TITLE
fix: fix column picker reset button margin

### DIFF
--- a/app/components/ColumnPicker.vue
+++ b/app/components/ColumnPicker.vue
@@ -129,7 +129,7 @@ function handleReset() {
             </label>
           </div>
 
-          <div class="border-t border-border py-1">
+          <div class="border-t border-border p-2 pb-1">
             <ButtonBase @click="handleReset">
               {{ $t('filters.columns.reset') }}
             </ButtonBase>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
N/A (skipped because of small fix)

### 🧭 Context

<!-- Brief background and why this change is needed -->
The reset button in the column picker (on table view) has no margin at the left side.
<!-- High-level summary of what changed -->

### 📚 Description

- Adjusted the button margin by setting equal margins around the button.

#### Before
<img width="893" height="532" alt="Screenshot of reset button, left side is at the left border of popup component" src="https://github.com/user-attachments/assets/01da0dea-0d0a-41ad-904e-aa78c598fcbb" />

#### After
<img width="893" height="532" alt="Screenshot of reset button, having equal margins aroung the button" src="https://github.com/user-attachments/assets/3574c4fe-cb8e-489e-998a-946e16d343df" />


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
