### PR TITLE
chore: add link to Netlify post to alpha blog post

### DIFF
--- a/app/pages/blog/alpha-release.md
+++ b/app/pages/blog/alpha-release.md
@@ -117,7 +117,7 @@ headline="Read more from the community"
     url: 'https://www.netlify.com/blog/sponsoring-npmx',
     title: 'Sponsoring npmx',
     authorHandle: 'netlify.com',
-    descriptipn: 'It’s more important than ever that companies come together across competitive boundaries to sponsor and support the open ecosystem that lifts all boats.',
+    description: 'It’s more important than ever that companies come together across competitive boundaries to sponsor and support the open ecosystem that lifts all boats.',
   },
   {
     url: 'https://johnnyreilly.com/npmx-with-a-little-help-from-my-friends',


### PR DESCRIPTION
### 🔗 Linked issue

#178

### 🧭 Context

It isn't up yet. It will go up at the designated time per #1152.

### 📚 Description

Adds Netlify blog post link to alpha blog post