### PR TITLE
fix: uncheck "apply correction" when there is no anomaly data

### DIFF
--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -1895,7 +1895,10 @@ watch(selectedMetric, value => {
               :class="{ 'opacity-50 pointer-events-none': !hasAnomalies }"
             >
               <input
-                v-model="settings.chartFilter.anomaliesFixed"
+                :checked="settings.chartFilter.anomaliesFixed && hasAnomalies"
+                @change="
+                  settings.chartFilter.anomaliesFixed = ($event.target as HTMLInputElement).checked
+                "
                 type="checkbox"
                 :disabled="!hasAnomalies"
                 class="accent-[var(--accent-color,var(--fg-subtle))]"


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
N/A

### 🧭 Context

<!-- Brief background and why this change is needed -->
In downloads chart at https://npmx.dev/package/react?modal=chart&start=2025-03-04&end=2026-03-02, "Apply correction" checkbox is disabled when there is no anomaly data.

However, in the current implementation, if users previously used this feature (this is true by default), it saved as user preference, so even if there is no anomaly data, this checkbox is checked by default. This is a bit misleading because users might think there is some anomaly data on `react` package and the chart is corrected even if actully no anomaly data (and they are prohibited to disable this feature for some reason).

<img width="1289" height="728" alt="screenshot of chart dialog, checkbox is unchecked" src="https://github.com/user-attachments/assets/2faeef26-f2e8-4059-8807-3bb94f417972" />

<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
- Changed to check the checkbox only when anomaly data.
- If there is anomaly data, the currently behaviors should be the same. You can test with `vite` package: https://npmxdev-git-shuuji3-fixuncheck-misleading-anomaly-npmx.vercel.app/package/vite?modal=chart&start=2025-03-04&end=2026-03-02
<img width="1289" height="728" alt="screenshot of chart dialog, checkbox is unchecked" src="https://github.com/user-attachments/assets/df54fe42-cd88-42f7-afd4-06c5deb07912" />

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
