### PR TITLE
fix: hotfix for complex versions urls

### DIFF
--- a/app/utils/router.ts
+++ b/app/utils/router.ts
@@ -9,7 +9,8 @@ export function packageRoute(packageName: string, version?: string | null): Rout
       params: {
         org,
         name,
-        version,
+        // remove spaces to be correctly resolved by router
+        version: version.replace(/\s+/g, ''),
       },
     }
   }


### PR DESCRIPTION
### 🔗 Linked issue

Partially resolves https://github.com/npmx-dev/npmx.dev/issues/1120

### 🧭 Context

Complex versions expcted to be properly handled and resolved in normal package version by the current router implementation.

### 📚 Description
The quickfix to prevent some issues is - remove spaces from url: `1 || 2` -> `1||2`. But there are still cases when valid semver versions linked to Error 404

The app is relying on a third-party service (by @antfu) which is resolving complex semver expressions into a single max version.
https://github.com/npmx-dev/npmx.dev/blob/main/app/composables/npm/useResolvedVersion.ts#L13-L14

But it is not handling many valid cases, which results in 404 on npmx. See examples in comments in https://github.com/npmx-dev/npmx.dev/issues/1120
