### PR TITLE
fix: correct homepage git tag page url

### DIFF
--- a/app/components/BuildEnvironment.vue
+++ b/app/components/BuildEnvironment.vue
@@ -23,7 +23,7 @@ const buildTime = computed(() => new Date(buildInfo.value.time))
     <span>&middot;</span>
     <LinkBase
       v-if="buildInfo.env === 'release'"
-      :to="`https://github.com/npmx-dev/npmx.dev/tag/v${buildInfo.version}`"
+      :to="`https://github.com/npmx-dev/npmx.dev/releases/tag/v${buildInfo.version}`"
     >
       v{{ buildInfo.version }}
     </LinkBase>


### PR DESCRIPTION
### 🔗 Linked issue

N / A

### 🧭 Context

N / A

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description
<img width="651" height="383" alt="image" src="https://github.com/user-attachments/assets/03b3234a-8043-42e1-a51d-d87e22d8ca17" />

The current version tag seems linked to an invalid url, while github use `https://github.com/${owner}/${repo}/releases/tag/${version}` actually
