### PR TITLE
fix: improve sponsors layout on the about page for mobile users

### DIFF
--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -164,7 +164,7 @@ const roleLabels = computed(
           </h2>
           <AboutLogoList
             :list="SPONSORS"
-            class="grid grid-cols-2 gap-4 md:flex md:flex-row md:items-center"
+            class="grid grid-cols-2 md:flex md:flex-row md:items-center"
           />
         </div>
 


### PR DESCRIPTION
Before: 

<img width="668" height="568" alt="wrong" src="https://github.com/user-attachments/assets/6c24a5a9-b235-4e77-a509-10e202077be2" />

After: 

<img width="647" height="635" alt="correct" src="https://github.com/user-attachments/assets/de4fc13b-3a99-4212-bd0b-971543bad272" />
