### PR TITLE
fix(blog): format published date in blog post list card

### DIFF
--- a/app/components/BlogPostListCard.vue
+++ b/app/components/BlogPostListCard.vue
@@ -33,7 +33,9 @@ defineProps<{
       <!-- Text Content -->
       <div class="flex-1 min-w-0 text-start gap-2">
         <div class="flex items-center gap-2">
-          <span class="text-xs text-fg-muted font-mono">{{ published }}</span>
+          <span class="text-xs text-fg-muted font-mono">
+            <DateTime :datetime="published" year="numeric" month="short" day="numeric" />
+          </span>
           <span
             v-if="draft"
             class="text-xs px-1.5 py-0.5 rounded badge-orange font-sans font-medium"


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1889

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

The date format in the blog listing can be improved and may be localised.

### 📚 Description

Use the `DateTime` component to format the published date in the blog post list card, consistent with the blog post page.

| Before |  After |
| -|-|
| <img width="1538" height="728" alt="image" src="https://github.com/user-attachments/assets/84e1bb74-09c4-4eef-810a-928bb32d62ec" /> | <img width="1484" height="696" alt="image" src="https://github.com/user-attachments/assets/53fe6b58-2c27-49b1-b58d-fca6981c82f8" />|