### PR TITLE
fix(ui): fix transparency bleeding of copied tooltip

### DIFF
--- a/app/components/CopyToClipboardButton.vue
+++ b/app/components/CopyToClipboardButton.vue
@@ -37,7 +37,7 @@ function handleClick() {
       class="absolute z-20 inset-is-0 top-full inline-flex items-center gap-1 px-2 py-1 rounded border text-xs font-mono whitespace-nowrap transition-all duration-150 opacity-0 -translate-y-1 pointer-events-none group-hover:opacity-100 group-hover:translate-y-0 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:translate-y-0 focus-visible:pointer-events-auto"
       :class="[
         $style.copyButton,
-        copied ? 'text-accent bg-accent/10' : 'text-fg-muted bg-bg border-border',
+        copied ? ['text-accent', $style.copiedBg] : 'text-fg-muted bg-bg border-border',
       ]"
       :aria-label="copied ? buttonAriaLabelCopied : buttonAriaLabelCopy"
       v-bind="buttonAttrs"
@@ -78,6 +78,10 @@ function handleClick() {
   transition:
     opacity 0.15s,
     translate 0.15s;
+}
+
+.copiedBg {
+  background-color: color-mix(in srgb, var(--accent) 10%, var(--bg));
 }
 
 @media (hover: none) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

n/a

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

The copied tooltip was transparent, which is inconsistent with the other tooltips.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->

| Scenario | Screenshot |
| :- | :- |
| Before | <img width="300" height="120" alt="5672cac651f1ed3a788b595c998a878b" src="https://github.com/user-attachments/assets/9fca39e9-ba40-48ee-88c5-4fbbee7df6e5" /> |
| After - Light | <img width="300" height="120" alt="124f83a133407d5522da6d458f1961f4" src="https://github.com/user-attachments/assets/94ae0db9-55ea-4a39-8e61-53c56bdeb2e1" /> |
| After - Dark | <img width="300" height="120" alt="Screenshot From 2026-03-04 11-33-16" src="https://github.com/user-attachments/assets/0c9747d1-522e-4c21-9cb9-bee6075c09be" /> |
| After - Different color | <img width="300" height="120" alt="Screenshot From 2026-03-04 11-34-54" src="https://github.com/user-attachments/assets/103befc3-8870-4335-8ffe-9d60dcb0405e" /> |
