### PR TITLE
fix(ui): readme toc dropdown scroll to the selected item position

### DIFF
--- a/app/components/ReadmeTocDropdown.vue
+++ b/app/components/ReadmeTocDropdown.vue
@@ -145,17 +145,21 @@ const itemScrollIntoView = (index: number) => {
   if (!item) return
   const el = document.getElementById(`${listboxId}-${item.id}`)
   if (el) {
-    el.scrollIntoView({ block: 'center'})
+    el.scrollIntoView({ block: 'center' })
   }
-} 
+}
 
-watch(isOpen, (open) => {
-  if (open && highlightedIndex.value >= 0) {
-    itemScrollIntoView(highlightedIndex.value)
-  }
-}, {
-  flush: 'post',
-})
+watch(
+  isOpen,
+  open => {
+    if (open && highlightedIndex.value >= 0) {
+      itemScrollIntoView(highlightedIndex.value)
+    }
+  },
+  {
+    flush: 'post',
+  },
+)
 </script>
 
 <template>


### PR DESCRIPTION
### 🔗 Linked issue
/ 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context
![npmx](https://github.com/user-attachments/assets/3f50bf4b-9f63-47d0-9a50-47c540442685)

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description
When the ReadmeTocDropdown component's dropdown menu is opened, the default selected option should be moved to the viewport area for easier viewing and switching.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
