### PR TITLE
fix(ui): ensure selected line highlights full width in code viewer

### DIFF
--- a/app/components/Code/Viewer.vue
+++ b/app/components/Code/Viewer.vue
@@ -157,7 +157,7 @@ watch(
 
 /* Highlighted lines in code content - extend full width with negative margin */
 .code-content :deep(.line.highlighted) {
-  background: rgb(234 179 8 / 0.2); /* yellow-500/20 */
+  @apply bg-yellow-500/20;
   margin: 0 -1rem;
   padding: 0 1rem;
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->


Before:
https://npmx.dev/package-code/vue/v/3.5.29/dist%2Fvue.cjs.js#L8
<img width="1470" height="800" alt="image" src="https://github.com/user-attachments/assets/09ae9667-17da-42f1-a90b-a04fc3a2d3fa" />

After:
https://npmxdev-git-fork-9romise-fix-code-select-npmx.vercel.app/package-code/vue/v/3.5.29/dist%2Fvue.cjs.js#L8
<img width="1470" height="800" alt="image" src="https://github.com/user-attachments/assets/0468ecf2-f2eb-4cc7-8b61-65caddbf9a6f" />

This PR also replace hardcoded background with UnoCSS  `@apply` directive.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
