### PR TITLE
fix: remove hidden overflow from sparkline wrapper

### DIFF
--- a/app/components/Package/WeeklyDownloadStats.vue
+++ b/app/components/Package/WeeklyDownloadStats.vue
@@ -413,10 +413,7 @@ const config = computed<VueUiSparklineConfig>(() => {
         <span v-else-if="isLoadingWeeklyDownloads" class="min-w-6 min-h-6 -m-1 p-1" />
       </template>
 
-      <div
-        class="w-full overflow-hidden h-[76px] egg-pulse-target"
-        :class="{ 'egg-pulse': eggPulse }"
-      >
+      <div class="w-full h-[76px] egg-pulse-target" :class="{ 'egg-pulse': eggPulse }">
         <template v-if="isLoadingWeeklyDownloads || hasWeeklyDownloads">
           <ClientOnly>
             <VueUiSparkline class="w-full max-w-xs" :dataset :config>


### PR DESCRIPTION
This removes the hidden overflow from the sparkline wrapper, which cropped the selector when positioned on the last datapoint.

| Before | After |
|-------|-------|
|<img width="360" height="168" alt="image" src="https://github.com/user-attachments/assets/88cb3440-27d1-472f-ab29-d145c91708c4" />|<img width="360" height="168" alt="image" src="https://github.com/user-attachments/assets/33b1860b-3622-4267-8fb6-db17d36c0940" />|