### PR TITLE
feat: add marko playground links

### DIFF
--- a/app/components/Package/Playgrounds.vue
+++ b/app/components/Package/Playgrounds.vue
@@ -21,6 +21,7 @@ const providerIcons: Record<string, string> = {
   'svelte-playground': 'i-simple-icons:svelte',
   'tailwind-playground': 'i-simple-icons:tailwindcss',
   'storybook': 'i-simple-icons:storybook',
+  'marko-playground': 'i-simple-icons:marko',
 }
 
 // Map provider id to color class
@@ -39,6 +40,7 @@ const providerColors: Record<string, string> = {
   'svelte-playground': 'text-provider-svelte',
   'tailwind-playground': 'text-provider-tailwind',
   'storybook': 'text-provider-storybook',
+  'marko-playground': 'text-provider-marko',
 }
 
 function getIcon(provider: string): string {

--- a/server/utils/readme.ts
+++ b/server/utils/readme.ts
@@ -104,6 +104,13 @@ const PLAYGROUND_PROVIDERS: PlaygroundProvider[] = [
     domains: ['play.tailwindcss.com'],
     icon: 'tailwindcss',
   },
+  {
+    id: 'marko-playground',
+    name: 'Marko Playground',
+    domains: ['markojs.com'],
+    paths: ['/playground'],
+    icon: 'marko',
+  },
 ]
 
 /**

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -107,6 +107,7 @@ export default defineConfig({
         svelte: '#FF3E00',
         tailwind: '#06B6D4',
         storybook: '#FF4785',
+        marko: '#CC0067',
       },
     },
     animation: {


### PR DESCRIPTION

<img width="454" height="247" alt="screenshot of the 'try it out' tab on Marko's page in npmx, with a link to the playground" src="https://github.com/user-attachments/assets/f08d99bc-e2f6-47d0-ad78-c3fe8a8fb4bc" />

### 🔗 Linked issue

I didn't make one 😳, sorry everybody

### 🧭 Context

The maintainers here did an _amazing_ job of making the link detection for playgrounds generic and extensible. Any chance we can add [Marko](https://markojs.com/) to the mix?

### 📚 Description

We don't _really_ have a primary brand color since we're sort of "the rainbow", but we often lean on the [dark red](https://github.com/marko-js/website/blob/main/src/styles/colors.scss#L7) part of our logo so I chose that one. Hope it's not too close to any other playground colors!