### PR TITLE
fix(ui): dependency name readability

### DIFF
--- a/app/components/Package/Dependencies.vue
+++ b/app/components/Package/Dependencies.vue
@@ -219,7 +219,7 @@ const numberFormatter = useNumberFormatter()
           class="flex items-center justify-between py-1 text-sm gap-1 min-w-0"
         >
           <div class="flex items-center gap-2 min-w-0 flex-1">
-            <LinkBase :to="packageRoute(peer.name)" class="block max-w-[70%]" dir="ltr">
+            <LinkBase :to="packageRoute(peer.name)" class="block max-w-[70%] break-words" dir="ltr">
               {{ peer.name }}
             </LinkBase>
             <TagStatic v-if="peer.optional" :title="$t('package.dependencies.optional')">
@@ -280,7 +280,7 @@ const numberFormatter = useNumberFormatter()
           :key="dep"
           class="flex items-baseline justify-between py-1 text-sm gap-2"
         >
-          <LinkBase :to="packageRoute(dep)" class="block max-w-[80%]" dir="ltr">
+          <LinkBase :to="packageRoute(dep)" class="block max-w-[80%] break-words" dir="ltr">
             {{ dep }}
           </LinkBase>
           <LinkBase


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
closes #1925  

### 🧭 Context

<!-- Brief background and why this change is needed -->
The names of dependencies become unreadable when they are very long.

<!-- High-level summary of what changed -->
The dependencies simply wrap so they remain readable even when they're long.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
The dependency names are hard to read, and I don't think adding tooltips is the best fix. Since this is a key functional part of the package view, the names should be easily visible.

before
<img width="431" height="382" alt="Image" src="https://github.com/user-attachments/assets/49a22eaf-e0cb-43e0-9166-5e60342d85da" />

after
<img width="441" height="549" alt="Image" src="https://github.com/user-attachments/assets/43dd24b3-c622-4669-874b-40adc3f375b8" />