### PR TITLE
refactor: resue NPM_REGISTRY from shared constants file

### DIFF
--- a/server/utils/npm.ts
+++ b/server/utils/npm.ts
@@ -1,9 +1,11 @@
 import type { Packument, NpmSearchResponse } from '#shared/types'
 import { encodePackageName, fetchLatestVersion } from '#shared/utils/npm'
 import { maxSatisfying, prerelease } from 'semver'
-import { CACHE_MAX_AGE_FIVE_MINUTES, CACHE_MAX_AGE_ONE_DAY } from '#shared/utils/constants'
-
-const NPM_REGISTRY = 'https://registry.npmjs.org'
+import {
+  CACHE_MAX_AGE_FIVE_MINUTES,
+  CACHE_MAX_AGE_ONE_DAY,
+  NPM_REGISTRY,
+} from '#shared/utils/constants'
 
 export const fetchNpmPackage = defineCachedFunction(
   async (name: string): Promise<Packument> => {


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### 🧭 Context

Duplicated `NPM_REGISTRY` definition in the `npm.ts` file, it would be better to reuse the existing one from the shared file.

### 📚 Description

Use `NPM_REGISTRY` from `#shared/utils/constants` in the `server/utils/npm.ts`
`scripts/generate-fixtures.ts` also has the same redundant definition, but since it is a script, so I leave it as is.