### PR TITLE
fix(ui): make install size tooltip interactive for copying

### DIFF
--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -1156,7 +1156,7 @@ const showSkeleton = shallowRef(false)
           <div class="space-y-1 sm:col-span-3">
             <dt class="text-xs text-fg-subtle uppercase tracking-wider flex items-center gap-1">
               {{ $t('package.stats.install_size') }}
-              <TooltipApp v-if="sizeTooltip" :text="sizeTooltip">
+              <TooltipApp v-if="sizeTooltip" :text="sizeTooltip" interactive>
                 <span
                   tabindex="0"
                   class="inline-flex items-center justify-center min-w-6 min-h-6 -m-1 p-1 text-fg-subtle cursor-help focus-visible:outline-2 focus-visible:outline-accent/70 rounded"


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1936

### 🧭 Context

The Install Size tooltip contains relatively rich information that users may want to copy. 

However, it is non-interactive by default, which prevents users from selecting and copying the text.

### 📚 Description

Add the `interactive` prop to the Install Size Tooltip component.

There are already other tooltips in the project using `interactive` in similar cases.

| Before |  After |
| - |  - |
| <video src="https://github.com/user-attachments/assets/376fcd66-d103-4824-919d-b464192d3a4d" /> | <video src="https://github.com/user-attachments/assets/a724677d-46a0-4f44-b9c2-f940a17be351" /> |

