### PR TITLE
fix: change paragraph to small tag for legal copy

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -131,10 +131,10 @@ const closeModal = () => modalRef.value?.close?.()
           </div>
         </div>
       </div>
-      <p class="text-xs text-fg-muted text-center sm:text-start m-0">
+      <small class="text-xs text-fg-muted text-center sm:text-start m-0">
         <span class="sm:hidden">{{ $t('non_affiliation_disclaimer') }}</span>
         <span class="hidden sm:inline">{{ $t('trademark_disclaimer') }}</span>
-      </p>
+      </small>
     </div>
   </footer>
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

None 🫣

### 🧭 Context

Use `<small>` to semantically represent legal disclaimers or copyright notices.

### 📚 Description

Just a small (get it?) change to show my support. 😅
