### PR TITLE
feat(ui): highlight slash keyboard shortcut on header/home search bars

### DIFF
--- a/app/components/Header/SearchBox.vue
+++ b/app/components/Header/SearchBox.vue
@@ -40,6 +40,7 @@ defineExpose({ focus })
         <div class="search-box relative flex items-center">
           <kbd
             class="absolute inset-is-3 text-fg-subtle font-mono text-sm pointer-events-none transition-colors duration-200 motion-reduce:transition-none [.group:hover:not(:focus-within)_&]:text-fg/80 group-focus-within:text-accent z-1 rounded"
+            aria-hidden="true"
           >
             /
           </kbd>
@@ -56,6 +57,7 @@ defineExpose({ focus })
             @focus="isSearchFocused = true"
             @blur="isSearchFocused = false"
             size="small"
+            ariaKeyshortcuts="/"
           />
           <button type="submit" class="sr-only">{{ $t('search.button') }}</button>
         </div>

--- a/app/components/Input/Base.vue
+++ b/app/components/Input/Base.vue
@@ -14,6 +14,8 @@ const props = withDefaults(
      * @default true
      */
     noCorrect?: boolean
+    /** Keyboard shortcut hint */
+    ariaKeyshortcuts?: string
   }>(),
   {
     size: 'medium',
@@ -27,6 +29,8 @@ const emit = defineEmits<{
 }>()
 
 const el = useTemplateRef('el')
+
+const keyboardShortcutsEnabled = useKeyboardShortcuts()
 
 defineExpose({
   focus: () => el.value?.focus(),
@@ -51,5 +55,6 @@ defineExpose({
       /** Catching Vue render-bug of invalid `disabled=false` attribute in the final HTML */
       disabled ? true : undefined
     "
+    :aria-keyshortcuts="keyboardShortcutsEnabled ? ariaKeyshortcuts : undefined"
   />
 </template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -71,6 +71,7 @@ defineOgImageComponent('Default', {
               <div class="search-box relative flex items-center">
                 <kbd
                   class="absolute inset-is-4 text-fg-subtle font-mono text-lg pointer-events-none transition-colors duration-200 motion-reduce:transition-none [.group:hover:not(:focus-within)_&]:text-fg/80 group-focus-within:text-accent z-1 rounded"
+                  aria-hidden="true"
                 >
                   /
                 </kbd>
@@ -87,6 +88,7 @@ defineOgImageComponent('Default', {
                   class="w-full ps-8 pe-24"
                   @focus="isSearchFocused = true"
                   @blur="isSearchFocused = false"
+                  ariaKeyshortcuts="/"
                 />
 
                 <ButtonBase


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

n/a

### 🧭 Context

<!-- Brief background and why this change is needed -->
The keyboard shortcut highlighting feature introduced in #440 does not highlight the slash labels in the homepage's/header's search inputs.

<!-- High-level summary of what changed -->
Pressing `?` now highlights the search inputs' keyboard shortcut hints, in addition to other keyboard shortcut hints.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

These slash labels are currently `span`s. Semantically, they make more sense as `kbd`s, since they indicate the key used to focus the search input.

I've clarified the slash labels' purpose in the a11y tree accordingly. Now the `kbd` elements have `aria-hidden="true"`, and a keyboard shortcut hint is set through `aria-keyshortcuts` on the focusable element itself, similar to `BaseLink`:

https://github.com/npmx-dev/npmx.dev/blob/58da597516879bc60851049b6f348aa410d5c0d8/app/components/Link/Base.vue#L128

https://github.com/npmx-dev/npmx.dev/blob/58da597516879bc60851049b6f348aa410d5c0d8/app/components/Link/Base.vue#L108

### Demo

https://github.com/user-attachments/assets/08c115fc-8cfe-415b-92ae-09107951d55f

https://github.com/user-attachments/assets/6409f20f-1f5e-4bd8-87bd-4b48a8ad5604

### old a11y information

screenshots taken from macOS VoiceOver

<img width="606" height="115" alt="image" src="https://github.com/user-attachments/assets/e05a19cc-df11-45a4-bf7c-41adecdf8ef5" />

<img width="606" height="115" alt="image" src="https://github.com/user-attachments/assets/ddf4c6ed-83c7-4141-97c6-c9ec764908a8" />

The word "slash" was being read aloud when first focusing the input.

### new a11y information

<img width="606" height="115" alt="image" src="https://github.com/user-attachments/assets/e8d30885-450c-47d4-a455-b69c1b7beb27" />

<img width="606" height="115" alt="image" src="https://github.com/user-attachments/assets/624c0057-c000-40f0-9c4e-de364f2a632e" />

"Slash" is now announced as an available shortcut.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
