### PR TITLE
fix: update about page description

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -909,7 +909,7 @@
       "title": "What we are",
       "better_ux_dx": "better UX/DX",
       "admin_ui": "admin UI",
-      "description": "npmx is a {betterUxDx} for the npm package registry and tooling. We provide a fast, modern interface for exploring packages, with features like dark mode, keyboard navigation, code browsing, and connections to alternative registries like {jsr}.",
+      "description": "npmx is a package browser offering a {betterUxDx} for the npm package registry. We provide a fast, modern interface for exploring packages, with features like dark mode, keyboard navigation, code browsing, and connections to alternative registries like {jsr}.",
       "admin_description": "We also aim to provide a better {adminUi} for managing your packages, teams, and organizations — all from the browser, powered by your local npm CLI."
     },
     "what_we_are_not": {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

The current description is:

> npmx is a better UX/DX for the npm package registry and tooling.

I don't think this makes sense, for two reasons.

First, “npmx is a better user experience for the npm package registry” implies “npmx is a user experience”. But that doesn't really make sense. npmx is a package browser that _provides_ a better user experience.

Secondly, in “npmx is a better UX for the npm package registry and tooling”, I'm not clear on what the “tooling” is. At best, this would be something like “npmx offers a better UX for the npm tooling”. But what is the npm tooling? I don't think this short description of the basics of npmx needs to get into the weeds about this, though.

### 📚 Description

I've rewritten this as follows:

> npmx is a package browser offering a better UX/DX for the npm package registry.

I think this solves the above problems.