### PR TITLE
fix: prevent semver filter placeholder text from being truncated on s…

### DIFF
--- a/app/components/Package/Versions.vue
+++ b/app/components/Package/Versions.vue
@@ -554,7 +554,7 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
             :aria-invalid="isInvalidRange ? 'true' : undefined"
             :aria-describedby="isInvalidRange ? 'semver-filter-error' : undefined"
             autocomplete="off"
-            class="flex-1 min-w-0"
+            class="flex-1 min-w-0 max-sm:placeholder:text-2xs"
             :class="isInvalidRange ? '!border-red-500' : ''"
             size="small"
           />


### PR DESCRIPTION
On iPhone SE 2nd gen (375px width, iOS 14.6), the semver filter placeholder text "Filter by semver (e.g. ^3.0.0)" in the Versions section gets truncated/cut off because the input field doesn't have enough horizontal space. The input uses font-mono at text-xs (12px) and shares its row with an info icon, gap spacing, and padding — leaving insufficient room for the full placeholder on narrow viewports.

Fix: Added max-sm:placeholder:text-2xs class to the filter input in `Versions.vue`. This reduces the placeholder font size from 12px to 11px (text-2xs, defined in uno.config.ts) only on screens below the sm breakpoint. The typed text size remains at 12px, and wider screens are unaffected.

Before: 

<img width="710" height="601" alt="before" src="https://github.com/user-attachments/assets/2f103274-55a8-45fd-8839-317ecd1ea595" />

After: 

<img width="611" height="400" alt="after" src="https://github.com/user-attachments/assets/f86ba9c8-cc55-46be-80df-aca0e2393b50" />
