### PR TITLE
refactor: move fund link

### DIFF
--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -729,6 +729,16 @@ onKeyStroke(
   },
 )
 
+onKeyStroke(
+  e => keyboardShortcuts.value && isKeyWithoutModifiers(e, 'f') && !isEditableElement(e.target),
+  e => {
+    if (!fundingUrl.value) return
+    e.preventDefault()
+    navigateTo(fundingUrl.value, { external: true, open: { target: '_blank' } })
+  },
+  { dedupe: true },
+)
+
 const showSkeleton = shallowRef(false)
 </script>
 


### PR DESCRIPTION
resolves #1835 

### 🧭 Context

For the reasons given in the attached issue, the fund button needed more visibility on package pages. I moved the fund link from the external link list to the top button group. This also enables the `f` key to activate the fund link.

**Please provide any feedback on this design change!** I'm noticing this button bar is getting pretty wide, I was considering scaling it down.

#### Desktop View
<img width="2544" height="560" alt="image" src="https://github.com/user-attachments/assets/8112de6b-518b-4d49-b6a4-c42dbdadba6d" />

#### Mobile View
<img width="728" height="286" alt="image" src="https://github.com/user-attachments/assets/3bbb2d5b-03fc-47e2-909a-099c761e4bd7" />
