### PR TITLE
refactor: remove redundant title attributes from package nav

### DIFF
--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -863,7 +863,6 @@ const showSkeleton = shallowRef(false)
               :to="docsLink"
               aria-keyshortcuts="d"
               classicon="i-lucide:file-text"
-              :title="$t('package.links.docs')"
             >
               <span class="max-sm:sr-only">{{ $t('package.links.docs') }}</span>
             </LinkBase>
@@ -873,7 +872,6 @@ const showSkeleton = shallowRef(false)
               :to="codeLink"
               aria-keyshortcuts="."
               classicon="i-lucide:code"
-              :title="$t('package.links.code')"
             >
               <span class="max-sm:sr-only">{{ $t('package.links.code') }}</span>
             </LinkBase>
@@ -882,7 +880,6 @@ const showSkeleton = shallowRef(false)
               :to="{ name: 'compare', query: { packages: pkg.name } }"
               aria-keyshortcuts="c"
               classicon="i-lucide:git-compare"
-              :title="$t('package.links.compare')"
             >
               <span class="max-sm:sr-only">{{ $t('package.links.compare') }}</span>
             </LinkBase>
@@ -900,7 +897,6 @@ const showSkeleton = shallowRef(false)
             <ButtonBase
               v-if="showScrollToTop"
               variant="secondary"
-              :title="$t('common.scroll_to_top')"
               :aria-label="$t('common.scroll_to_top')"
               @click="scrollToTop"
               classicon="i-lucide:arrow-up"


### PR DESCRIPTION
This is the beginning of a iterative refactor to remove `title` attributes throughout the app.

These are all for the package navigation bar (on the package page). I left the `title` for “diff” because its description was actually descriptive (eventually it will replaced with a tooltip). You could argue that they would be useful for smaller viewports, but they don’t show up on touchscreens anyway.

Ideally, we’ll use tooltips instead of `title` in all situations, but our tooltip implementation is not correct (something I’ll detail more in an issue I’ll create soon, along with a proposal of how we should fix it).

Further reading:

- [The HTML Standard’s advisory note to avoid `title`](https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute:~:text=Relying%20on%20the%20title%20attribute%20is%20currently%20discouraged%20as%20many%20user%20agents%20do%20not%20expose%20the%20attribute%20in%20an%20accessible%20manner%20as%20required%20by%20this%20specification)
- [“The Trials and Tribulations of the Title Attribute” by Scott O’Hara](https://www.24a11y.com/2017/the-trials-and-tribulations-of-the-title-attribute/)
- [“Tooltips in the time of WCAG 2.1” by Sarah Higley](https://sarahmhigley.com/writing/tooltips-in-wcag-21/)