### PR TITLE
fix: data anomalies in chart

### DIFF
--- a/app/utils/download-anomalies.ts
+++ b/app/utils/download-anomalies.ts
@@ -49,14 +49,18 @@ function isDateAffected(
       return startWeek < anomaly.end.date && endWeek > anomaly.start.date
     }
     case 'monthly': {
-      const startMonth = anomaly.start.date.slice(0, 7) + '-01'
-      const endMonth = anomaly.end.date.slice(0, 7) + '-01'
-      return date >= startMonth && date <= endMonth
+      const monthStart = date
+      const monthStartDate = new Date(`${date}T00:00:00Z`)
+      const monthEndDate = new Date(monthStartDate)
+      monthEndDate.setUTCMonth(monthEndDate.getUTCMonth() + 1)
+      monthEndDate.setUTCDate(monthEndDate.getUTCDate() - 1)
+      const monthEnd = monthEndDate.toISOString().slice(0, 10)
+      return monthStart < anomaly.end.date && monthEnd > anomaly.start.date
     }
     case 'yearly': {
-      const startYear = anomaly.start.date.slice(0, 4) + '-01-01'
-      const endYear = anomaly.end.date.slice(0, 4) + '-01-01'
-      return date >= startYear && date <= endYear
+      const yearStart = date
+      const yearEnd = `${date.slice(0, 4)}-12-31`
+      return yearStart < anomaly.end.date && yearEnd > anomaly.start.date
     }
   }
 }

--- a/test/unit/app/utils/download-anomalies.spec.ts
+++ b/test/unit/app/utils/download-anomalies.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { applyBlocklistCorrection } from '../../../../app/utils/download-anomalies'
-import type { WeeklyDataPoint } from '../../../../app/types/chart'
+import type {
+  MonthlyDataPoint,
+  WeeklyDataPoint,
+  YearlyDataPoint,
+} from '../../../../app/types/chart'
 
 /** Helper to build a WeeklyDataPoint from a start date and value. */
 function week(weekStart: string, value: number): WeeklyDataPoint {
@@ -15,6 +19,22 @@ function week(weekStart: string, value: number): WeeklyDataPoint {
     weekEnd,
     timestampStart: start.getTime(),
     timestampEnd: end.getTime(),
+  }
+}
+
+function month(monthStr: string, value: number): MonthlyDataPoint {
+  return {
+    value,
+    month: monthStr,
+    timestamp: new Date(`${monthStr}-01T00:00:00Z`).getTime(),
+  }
+}
+
+function year(yearStr: string, value: number): YearlyDataPoint {
+  return {
+    value,
+    year: yearStr,
+    timestamp: new Date(`${yearStr}-01-01T00:00:00Z`).getTime(),
   }
 }
 
@@ -89,5 +109,75 @@ describe('applyBlocklistCorrection', () => {
     // The spike week must be corrected
     expect(result[1]!.hasAnomaly).toBe(true)
     expect(result[1]!.value).toBeLessThan(1_000_000)
+  })
+
+  // Vite anomaly: start=2025-08-04, end=2025-09-08 (spans Aug-Sep)
+  it('does not over-correct a month that only touches the anomaly end boundary', () => {
+    const data = [
+      month('2025-07', 30_000_000),
+      month('2025-08', 100_000_000), // contains spike
+      month('2025-09', 100_000_000), // contains spike (Sep 1-7)
+      month('2025-10', 30_000_000), // after anomaly end — normal!
+    ]
+
+    const result = applyBlocklistCorrection({
+      data,
+      packageName: 'vite',
+      granularity: 'monthly',
+    }) as MonthlyDataPoint[]
+
+    expect(result[1]!.hasAnomaly).toBe(true)
+    expect(result[2]!.hasAnomaly).toBe(true)
+
+    // October must NOT be modified
+    expect(result[3]!.value).toBe(30_000_000)
+    expect(result[3]!.hasAnomaly).toBeUndefined()
+  })
+
+  it('does not over-correct a month that only touches the anomaly start boundary', () => {
+    const data = [
+      month('2025-07', 30_000_000), // before anomaly start — normal!
+      month('2025-08', 100_000_000), // contains spike
+      month('2025-09', 100_000_000), // contains spike
+      month('2025-10', 30_000_000),
+    ]
+
+    const result = applyBlocklistCorrection({
+      data,
+      packageName: 'vite',
+      granularity: 'monthly',
+    }) as MonthlyDataPoint[]
+
+    // July must NOT be modified
+    expect(result[0]!.value).toBe(30_000_000)
+    expect(result[0]!.hasAnomaly).toBeUndefined()
+
+    expect(result[1]!.hasAnomaly).toBe(true)
+    expect(result[2]!.hasAnomaly).toBe(true)
+  })
+
+  it('does not over-correct a year that only touches the anomaly boundary', () => {
+    const data = [
+      year('2024', 500_000_000),
+      year('2025', 2_000_000_000), // contains spike
+      year('2026', 500_000_000),
+    ]
+
+    const result = applyBlocklistCorrection({
+      data,
+      packageName: 'vite',
+      granularity: 'yearly',
+    }) as YearlyDataPoint[]
+
+    // 2024 must NOT be modified
+    expect(result[0]!.value).toBe(500_000_000)
+    expect(result[0]!.hasAnomaly).toBeUndefined()
+
+    // 2025 must be corrected
+    expect(result[1]!.hasAnomaly).toBe(true)
+
+    // 2026 must NOT be modified
+    expect(result[2]!.value).toBe(500_000_000)
+    expect(result[2]!.hasAnomaly).toBeUndefined()
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Closes: #2005

### 🧭 Context

- Depending on what week / day of the week we select, the chart is not rendering with correct data fix

### 📚 Description

Fix range boundaries

 Tests:
 1. Corrects weeks overlapping the anomaly (existing) 
 2. Week starting on anomaly end boundary → not touched
 3. Week ending on anomaly start boundary → not touched
 4. Month touching anomaly end boundary → not touched
 5. Month touching anomaly start boundary → not touched
 6. Year touching anomaly boundary → not touched

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
