### PR TITLE
chore: standardize stories

### DIFF
--- a/app/components/Button/Base.stories.ts
+++ b/app/components/Button/Base.stories.ts
@@ -3,12 +3,14 @@ import Component from './Base.vue'
 
 const meta = {
   component: Component,
+  tags: ['autodocs'],
 } satisfies Meta<typeof Component>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const Primary: Story = {
+  tags: ['!dev'],
   args: {
     default: 'Primary Button',
   },

--- a/app/components/Input/Base.stories.ts
+++ b/app/components/Input/Base.stories.ts
@@ -4,6 +4,7 @@ import Component from './Base.vue'
 
 const meta = {
   component: Component,
+  tags: ['autodocs'],
   argTypes: {
     disabled: { control: 'boolean' },
     size: {

--- a/app/components/Link/Link.stories.ts
+++ b/app/components/Link/Link.stories.ts
@@ -3,6 +3,7 @@ import LinkBase from './Base.vue'
 
 const meta = {
   component: LinkBase,
+  tags: ['autodocs'],
   args: {
     to: '/',
     default: 'Click me',


### PR DESCRIPTION
Co-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>

### My notes
- enable autodics
  - need support for dark mode
  - i18n is causing errors
- remove snapshot story (replaced by autodocs)
- add a playground story
  - autodocs has this but requires scrolling

#### types of stories
- visual stories - only show in autodocs 
- interactive stories only show in sidebar
- test focused stories - only show in sidebar (or not at all? if it isnt visually apparent)

`!dev` do not show in sidebar
`!test` do not run test
`!autodocs` do not show in autodocs
https://storybook.js.org/docs/writing-stories/tags
https://storybook.js.org/addons/storybook-addon-tag-badges

https://github.com/npmx-dev/npmx.dev/pull/1270/changes/812c3f5c83b9eda4518bca1c661854292c519a9a#diff-4897215af822c794e6551f7d720b2035ef72d004f1cfc36e60238cf2e8b6bd98L18
https://github.com/npmx-dev/npmx.dev/pull/1270

### problems
- double playground component in autodocs
- double evnts in story actions


### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
