### PR TITLE
fix: prevent Chrome Android date input value clipping

### DIFF
--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -2105,4 +2105,8 @@ watch(selectedMetric, value => {
 [data-minimap-visible='false'] .vue-data-ui-watermark {
   top: calc(100% - 2rem) !important;
 }
+
+input::-webkit-date-and-time-value {
+  margin-inline: 4px;
+}
 </style>


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #1931

### 🧭 Context

There's a bug where the date input value reserves margin right even when it doesn't need to, this leads to the value getting clipped.

We override the margin on the value element to fix that.

### 📚 Description

Set margin-inline to 4px on the ::-webkit-date-and-time-value pseudo-element which is what holds the date input value on mobile for WebKit browsers.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
