### PR TITLE
fix(ui): remove redundant calendar icons from date inputs

### DIFF
--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -1618,7 +1618,7 @@ watch(selectedMetric, value => {
                 v-model="startDate"
                 type="date"
                 :max="DATE_INPUT_MAX"
-                class="w-full min-w-0 bg-transparent ps-2"
+                class="w-full min-w-0 bg-transparent"
                 size="medium"
               />
             </div>


### PR DESCRIPTION
### 🧭 Context
Resolves #2038

### 📚 Description
This PR removes the manual calendar icons, preventing duplication.

### 🛠️ Changes
- Removed redundant `<span>` icons with class `i-lucide:calendar`.
- Adjusted `InputBase` padding from `ps-7` to `ps-2` to align text correctly after icon removal.

### 🧪 Testing
- Verified on Chrome (Desktop): Only the native icon remains, picker works as expected.
<img width="829" height="548" alt="image" src="https://github.com/user-attachments/assets/1335c43d-57a2-4eb5-a23f-83a16150d265" />
<img width="794" height="555" alt="image" src="https://github.com/user-attachments/assets/dc78e45b-9df0-4940-b037-5f5965280076" />
