### PR TITLE
fix: use package license for skills

### DIFF
--- a/server/utils/skills.ts
+++ b/server/utils/skills.ts
@@ -162,9 +162,12 @@ export async function fetchSkillContent(
 /**
  * Validate skill frontmatter and return warnings.
  */
-export function validateSkill(frontmatter: SkillFrontmatter): SkillWarning[] {
+export function validateSkill(
+  frontmatter: SkillFrontmatter,
+  packageLicense?: string,
+): SkillWarning[] {
   const warnings: SkillWarning[] = []
-  if (!frontmatter.license) {
+  if (!frontmatter.license && !packageLicense) {
     warnings.push({ type: 'warning', message: 'No license specified' })
   }
   if (!frontmatter.compatibility) {
@@ -181,17 +184,28 @@ export async function fetchSkillsList(
   version: string,
   skillDirs: SkillDirInfo[],
 ): Promise<SkillListItem[]> {
+  // Get package license for fallback if skill doesn't specify one
+  let packageLicense: string | undefined
+  try {
+    const packument = await fetchNpmPackage(packageName)
+    const license = packument.versions?.[version]?.license ?? packument.license
+    packageLicense = typeof license === 'string' ? license : license?.type
+  } catch {
+    // If we can't fetch package info, just proceed without it
+  }
   const skills = await Promise.all(
     skillDirs.map(async ({ name: dirName, children }) => {
       try {
         const { frontmatter } = await fetchSkillContent(packageName, version, dirName)
-        const warnings = validateSkill(frontmatter)
+        const warnings = validateSkill(frontmatter, packageLicense)
         const fileCounts = countSkillFiles(children)
+        // Use skill license if specified, otherwise fallback to package license
+        const license = frontmatter.license || packageLicense
         const item: SkillListItem = {
           name: frontmatter.name,
           description: frontmatter.description,
           dirName,
-          license: frontmatter.license,
+          license,
           compatibility: frontmatter.compatibility,
           warnings: warnings.length > 0 ? warnings : undefined,
           fileCounts,


### PR DESCRIPTION
### 🔗 Linked issue

resolves #2043

### 🧭 Context

Currently, the logic for retrieving a skill’s license only checks the frontmatter.

As a result, when a skill does not specify a license there, the system displays a misleading "No license specified" warning, even if the parent package already defines a valid license.

### 📚 Description

This PR improves license handling in `skills.ts` by retrieving and passing the package license as a fallback when a skill does not specify its own license.

---

_(A related question: if a skill's license differs from the package's license, should we explicitly surface this (or even treat it as a warning)?)_