### PR TITLE
feat(i18n): fix some translation error and add missing key for indonesian (id-ID)

### DIFF
--- a/i18n/locales/id-ID.json
+++ b/i18n/locales/id-ID.json
@@ -1299,7 +1299,7 @@
     },
     "changes": {
       "title": "Perubahan pada kebijakan ini",
-      "p1": "Kami mungkin mengubah kebijakan privasi ini dari waktu ke waktu, setiap perubahan akan di publikasikan pada halaman ini dengan tanggal perubahan."
+      "p1": "Kami mungkin mengubah kebijakan privasi ini dari waktu ke waktu, setiap perubahan akan dipublikasikan pada halaman ini dengan tanggal perubahan."
     }
   },
   "a11y": {


### PR DESCRIPTION
This PR is fixing some translation error, and some missing keys.

- Rewrite some sentence to make it sound natural to native speaker
- Retranslating text that was incorrectly translated to ms-MY instead of id-ID.
- add missing key for
  - `shortcuts.open_main`
  - `shortcuts.open_diff`
  - `package.links.main`
  - `compare.version_selector_title`
  
  