### PR TITLE
fix: fix zindex issue of button in header

### DIFF
--- a/app/components/Package/Header.vue
+++ b/app/components/Package/Header.vue
@@ -395,7 +395,7 @@ const likeAction = async () => {
           v-if="mainLink"
           :to="mainLink"
           aria-keyshortcuts="m"
-          class="decoration-none border-b-2 p-1 hover:border-accent/50 lowercase"
+          class="decoration-none border-b-2 p-1 hover:border-accent/50 lowercase focus-visible:[outline-offset:-2px]!"
           :class="page === 'main' ? 'border-accent text-accent!' : 'border-transparent'"
         >
           {{ $t('package.links.main') }}
@@ -404,7 +404,7 @@ const likeAction = async () => {
           v-if="docsLink"
           :to="docsLink"
           aria-keyshortcuts="d"
-          class="decoration-none border-b-2 p-1 hover:border-accent/50"
+          class="decoration-none border-b-2 p-1 hover:border-accent/50 focus-visible:[outline-offset:-2px]!"
           :class="page === 'docs' ? 'border-accent text-accent!' : 'border-transparent'"
         >
           {{ $t('package.links.docs') }}
@@ -413,7 +413,7 @@ const likeAction = async () => {
           v-if="codeLink"
           :to="codeLink"
           aria-keyshortcuts="."
-          class="decoration-none border-b-2 p-1 hover:border-accent/50"
+          class="decoration-none border-b-2 p-1 hover:border-accent/50 focus-visible:[outline-offset:-2px]!"
           :class="page === 'code' ? 'border-accent text-accent!' : 'border-transparent'"
         >
           {{ $t('package.links.code') }}
@@ -423,7 +423,7 @@ const likeAction = async () => {
           :to="diffLink"
           :title="$t('compare.compare_versions_title')"
           aria-keyshortcuts="f"
-          class="decoration-none border-b-2 p-1 hover:border-accent/50"
+          class="decoration-none border-b-2 p-1 hover:border-accent/50 focus-visible:[outline-offset:-2px]!"
           :class="page === 'diff' ? 'border-accent text-accent!' : 'border-transparent'"
         >
           {{ $t('compare.compare_versions') }}
@@ -451,10 +451,6 @@ const likeAction = async () => {
 
 .packageNav::-webkit-scrollbar {
   display: none;
-}
-
-.packageNav > :global(a:focus-visible) {
-  outline-offset: -2px !important;
 }
 
 @media (max-width: 639.9px) {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2074 

### 🧭 Context

`CopyToClipboardButton` is hidden behind the header. This PR fixes it.

FYI @alexdln 

### 📚 Description

This button is also used in the compare page where it works fine, so the fix is applied locally rather than changing the z-index in the button component itself.

| Scenario | Screenshot |
| :- | :- |
| Copy button | <img width="468" height="228" alt="fixed-zindex" src="https://github.com/user-attachments/assets/68b34595-d1af-455e-a74e-0790c9871087" /> |
| Connect | <img width="528" height="309" alt="QQ20260316-104619" src="https://github.com/user-attachments/assets/7129e514-f6ed-4ae9-a645-569ac4240f27" /> |
| Outline of _compare_ button | <img width="538" height="241" alt="QQ20260316-104731" src="https://github.com/user-attachments/assets/94690ca0-76c0-4772-89a2-adfbea1c6499" /> |
| Outline of active menu | <img width="492" height="254" alt="QQ20260316-104720" src="https://github.com/user-attachments/assets/af44b020-82ff-4c30-bbce-d5af89fb27b3" /> |
| Outline of non-active menu | <img width="497" height="247" alt="QQ20260316-104704" src="https://github.com/user-attachments/assets/48fcabec-48c0-4c65-bc55-ee82bac9d542" /> |


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
