### PR TITLE
fix: fetch resolved version for install size

### DIFF
--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -143,7 +143,17 @@ const {
     immediate: false,
   },
 )
-onMounted(() => fetchInstallSize())
+
+// Trigger fetch only when we have the real resolved version
+watch(
+  [resolvedVersion, resolvedStatus],
+  ([version, status]) => {
+    if (version && status === 'success') {
+      fetchInstallSize()
+    }
+  },
+  { immediate: true },
+)
 
 const { data: skillsData } = useLazyFetch<SkillsListResponse>(
   () => {


### PR DESCRIPTION
Fixes package install size resolution by fetching resolved version for install size

Example: https://npmx.dev/package/fd-package-json/v/%5E2.0.0

Before:

<img width="283" height="137" alt="image" src="https://github.com/user-attachments/assets/62a983b9-b505-419d-9dbe-115f8bd1a36a" />

After:

<img width="373" height="149" alt="image" src="https://github.com/user-attachments/assets/99dfad03-13f9-45dd-a8e1-65284cea0abf" />
