### PR TITLE
fix: reword meta copy that compares npmx to npmjs.com

### DIFF
--- a/docs/content/1.getting-started/1.introduction.md
+++ b/docs/content/1.getting-started/1.introduction.md
@@ -5,11 +5,11 @@ navigation:
   icon: i-lucide:house
 ---
 
-npmx.dev provides a better way to browse the npm registry.
+npmx.dev is a fast, modern way to browse the npm registry.
 
 ## What is npmx.dev?
 
-npmx.dev is a fast, modern browser for the npm registry. It doesn't aim to replace [npmjs.com](https://www.npmjs.com/), but provides a better UI and developer experience for browsing packages, viewing documentation, and exploring code.
+npmx.dev is a fast, modern browser for the npm registry, focused on a great developer experience for browsing packages, viewing documentation, and exploring code.
 
 ## What you can do
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -920,19 +920,19 @@
   "about": {
     "title": "About",
     "heading": "about",
-    "meta_description": "npmx is a fast, modern browser for the npm registry. A better UX/DX for exploring npm packages.",
+    "meta_description": "npmx is a fast, modern browser for the npm registry. A great UX/DX for exploring npm packages.",
     "what_we_are": {
       "title": "What we are",
-      "better_ux_dx": "better UX/DX",
+      "better_ux_dx": "great UX/DX",
       "admin_ui": "admin UI",
-      "description": "npmx is a {betterUxDx} for the npm package registry and tooling. We provide a fast, modern interface for exploring packages, with features like dark mode, keyboard navigation, code browsing, and connections to alternative registries like {jsr}.",
-      "admin_description": "We also aim to provide a better {adminUi} for managing your packages, teams, and organizations — all from the browser, powered by your local npm CLI."
+      "description": "npmx is a {betterUxDx} for the npm package registry and tooling. We strive to provide a fast, modern interface for exploring packages, with features like dark mode, keyboard navigation, code browsing, and connections to alternative registries like {jsr}.",
+      "admin_description": "We also aim to provide a great {adminUi} for managing your packages, teams, and organizations — all from the browser, powered by your local npm CLI."
     },
     "what_we_are_not": {
       "title": "What we're not",
       "not_package_manager": "Not a package manager.",
       "not_registry": "Not a registry.",
-      "registry_description": "We don't host packages. We're just a better way to browse them.",
+      "registry_description": "We don't host packages. We're just a fast, modern way to browse them.",
       "package_managers_exist": "{already} {people} {building} {really} {cool} {package} {managers}.",
       "words": {
         "already": "There are",
@@ -969,7 +969,7 @@
       "title": "Get involved",
       "contribute": {
         "title": "Contribute",
-        "description": "Help us build a better npm experience.",
+        "description": "Help us build the npm experience we all want.",
         "cta": "View on GitHub"
       },
       "community": {

--- a/i18n/locales/fr-FR.json
+++ b/i18n/locales/fr-FR.json
@@ -903,19 +903,19 @@
   "about": {
     "title": "À propos",
     "heading": "à propos",
-    "meta_description": "npmx est un navigateur rapide et moderne pour le registre npm. Une meilleure UX/DX pour explorer les paquets npm.",
+    "meta_description": "npmx est un navigateur rapide et moderne pour le registre npm. Une excellente UX/DX pour explorer les paquets npm.",
     "what_we_are": {
       "title": "Ce que nous sommes",
-      "better_ux_dx": "meilleure UX/DX",
+      "better_ux_dx": "excellente UX/DX",
       "admin_ui": "interface d'administration",
       "description": "npmx est une {betterUxDx} pour le registre npm et ses outils. Nous fournissons une interface rapide et moderne pour explorer les paquets, avec des fonctionnalités comme le mode sombre, la navigation au clavier, la visualisation du code, et des connexions à des registres alternatifs comme {jsr}.",
-      "admin_description": "Nous visons également à fournir une meilleure {adminUi} pour gérer vos paquets, équipes et organisations — le tout depuis le navigateur, alimenté par votre CLI npm local."
+      "admin_description": "Nous visons également à fournir une excellente {adminUi} pour gérer vos paquets, équipes et organisations — le tout depuis le navigateur, alimenté par votre CLI npm local."
     },
     "what_we_are_not": {
       "title": "Ce que nous ne sommes pas",
       "not_package_manager": "Nous ne sommes pas un gestionnaire de paquets.",
       "not_registry": "Nous ne sommes pas un registre.",
-      "registry_description": "Nous n'hébergeons pas de paquets. Nous sommes juste une meilleure façon de les explorer.",
+      "registry_description": "Nous n'hébergeons pas de paquets. Nous sommes une façon rapide et moderne de les explorer.",
       "package_managers_exist": "{already} {people} {building} {managers} {package} {really} {cool}.",
       "words": {
         "already": "Il y a",
@@ -952,7 +952,7 @@
       "title": "Participer",
       "contribute": {
         "title": "Contribuer",
-        "description": "Aidez-nous à créer une meilleure expérience npm.",
+        "description": "Aidez-nous à créer l'expérience npm que nous voulons tous.",
         "cta": "Voir sur GitHub"
       },
       "community": {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

We intend to describe npmx for what it is and intends to be, not for how it compares to alternatives.

We already made such adjustments many weeks ago, but a couple slipped through the cracks.

### 📚 Description

Reword the last remaining "better than..." wordings.

I believe this also supersedes #1988