### PR TITLE
fix: added scroll preservation opt in to the compare page

### DIFF
--- a/app/pages/compare.vue
+++ b/app/pages/compare.vue
@@ -5,6 +5,7 @@ import FacetBarChart from '~/components/Compare/FacetBarChart.vue'
 
 definePageMeta({
   name: 'compare',
+  preserveScrollOnQuery: true,
 })
 
 const { locale } = useI18n()

--- a/app/router.options.ts
+++ b/app/router.options.ts
@@ -1,7 +1,7 @@
 import type { RouterConfig } from 'nuxt/schema'
 
 export default {
-  scrollBehavior(to, _from, savedPosition) {
+  scrollBehavior(to, from, savedPosition) {
     // If the browser has a saved position (e.g. back/forward navigation), restore it
 
     if (savedPosition) {
@@ -11,8 +11,8 @@ export default {
     // Preserve the current viewport for query-only updates on pages that opt in,
     // such as compare where controls sync state to the URL in-place.
     if (
-      to.path === _from.path &&
-      to.hash === _from.hash &&
+      to.path === from.path &&
+      to.hash === from.hash &&
       to.meta.preserveScrollOnQuery === true
     ) {
       return false

--- a/app/router.options.ts
+++ b/app/router.options.ts
@@ -7,6 +7,17 @@ export default {
     if (savedPosition) {
       return savedPosition
     }
+
+    // Preserve the current viewport for query-only updates on pages that opt in,
+    // such as compare where controls sync state to the URL in-place.
+    if (
+      to.path === _from.path &&
+      to.hash === _from.hash &&
+      to.meta.preserveScrollOnQuery === true
+    ) {
+      return false
+    }
+
     // If navigating to a hash anchor, scroll to it
     if (to.hash) {
       const { scrollMargin } = to.meta

--- a/app/router.options.ts
+++ b/app/router.options.ts
@@ -10,11 +10,7 @@ export default {
 
     // Preserve the current viewport for query-only updates on pages that opt in,
     // such as compare where controls sync state to the URL in-place.
-    if (
-      to.path === from.path &&
-      to.hash === from.hash &&
-      to.meta.preserveScrollOnQuery === true
-    ) {
+    if (to.path === from.path && to.hash === from.hash && to.meta.preserveScrollOnQuery === true) {
       return false
     }
 

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -10,5 +10,9 @@ declare module '#app' {
      * @default 70
      */
     scrollMargin?: number
+    /**
+     * preserve scroll position when only query params change on same path/hash
+     */
+    preserveScrollOnQuery?: boolean
   }
 }

--- a/test/unit/app/router.options.spec.ts
+++ b/test/unit/app/router.options.spec.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from 'vitest'
 import routerOptions from '../../../app/router.options'
 
-function createRoute(overrides: Record<string, unknown> = {}) {
+type ScrollBehavior = NonNullable<typeof routerOptions.scrollBehavior>
+type RouteArg = Parameters<ScrollBehavior>[0]
+
+function createRoute(overrides: Partial<RouteArg> = {}) {
   return {
     path: '/',
     hash: '',
+    query: {},
     meta: {},
     ...overrides,
-  } as any
+  } as RouteArg
 }
 
 describe('router scrollBehavior', () => {
@@ -22,14 +26,29 @@ describe('router scrollBehavior', () => {
   it('preserves scroll on query-only updates for pages that opt in', () => {
     const to = createRoute({
       path: '/compare',
+      query: { packages: 'vue,nuxt', facets: 'downloads,license' },
       meta: { preserveScrollOnQuery: true },
     })
     const from = createRoute({
       path: '/compare',
+      query: { packages: 'vue', facets: 'downloads' },
       meta: { preserveScrollOnQuery: true },
     })
 
     expect(routerOptions.scrollBehavior(to, from, null)).toBe(false)
+  })
+
+  it('does not preserve scroll on query-only updates without opt-in', () => {
+    const to = createRoute({
+      path: '/compare',
+      query: { packages: 'vue,nuxt', facets: 'downloads,license' },
+    })
+    const from = createRoute({
+      path: '/compare',
+      query: { packages: 'vue', facets: 'downloads' },
+    })
+
+    expect(routerOptions.scrollBehavior(to, from, null)).toEqual({ left: 0, top: 0 })
   })
 
   it('scrolls to hash anchors', () => {

--- a/test/unit/app/router.options.spec.ts
+++ b/test/unit/app/router.options.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import routerOptions from '../../../app/router.options'
+
+function createRoute(overrides: Record<string, unknown> = {}) {
+  return {
+    path: '/',
+    hash: '',
+    meta: {},
+    ...overrides,
+  } as any
+}
+
+describe('router scrollBehavior', () => {
+  it('restores saved position when available', () => {
+    const savedPosition = { left: 12, top: 345 }
+
+    expect(routerOptions.scrollBehavior(createRoute(), createRoute(), savedPosition)).toEqual(
+      savedPosition,
+    )
+  })
+
+  it('preserves scroll on query-only updates for pages that opt in', () => {
+    const to = createRoute({
+      path: '/compare',
+      meta: { preserveScrollOnQuery: true },
+    })
+    const from = createRoute({
+      path: '/compare',
+      meta: { preserveScrollOnQuery: true },
+    })
+
+    expect(routerOptions.scrollBehavior(to, from, null)).toBe(false)
+  })
+
+  it('scrolls to hash anchors', () => {
+    const to = createRoute({
+      hash: '#section-function',
+      meta: { scrollMargin: 96 },
+    })
+
+    expect(routerOptions.scrollBehavior(to, createRoute(), null)).toEqual({
+      el: '#section-function',
+      behavior: 'smooth',
+      top: 96,
+    })
+  })
+
+  it('scrolls to top for regular navigations', () => {
+    const to = createRoute({ path: '/compare', meta: { preserveScrollOnQuery: true } })
+    const from = createRoute({ path: '/search' })
+
+    expect(routerOptions.scrollBehavior(to, from, null)).toEqual({ left: 0, top: 0 })
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves #2098 

### 🧭 Context

Fixes the compare page jumping back to the top when compare state is updated on the page.

On /compare, both package selection and facet selection sync state into the route query, being treated like normal navigations by the router scroll behavior, which caused the page to reset. This change makes scroll preservation opt-in at the page level and enables it for the compare page, so query-only updates keep the current scroll position.

Do note that this does not change normal page-to-page navigation scroll behavior, hash scrolling, or back/forward saved-position restoration.

I basically changed two files and added one test:
- Added `preserveScrollOnQuery: true` to the compare page meta
- Updated app/router.options.ts to return false from scrollBehavior for same-path, same-hash navigations on pages that opt in
- Added router-level unit coverage for:
    - saved position restoration
    - scroll preservation on compare-style query updates
    - hash anchor scrolling
    - normal navigation scrolling to top

I wanted to implement this in a clean way that fixes both affected compare controls with one router-level change:
- package updates via packages=...
- facet updates via facets=...

I wanted to avoid duplicating special-case URL update logic in multiple compare components/composables, and thus keep the behavior scoped to pages that explicitly opt in.

https://github.com/user-attachments/assets/03b7d66c-0c72-4538-acf8-7dfc6dbcdf32