### PR TITLE
fix: tag sorting on package versions page

### DIFF
--- a/app/pages/package/[[org]]/[name]/versions.vue
+++ b/app/pages/package/[[org]]/[name]/versions.vue
@@ -5,10 +5,11 @@ import { compare, validRange } from 'semver'
 import {
   buildVersionToTagsMap,
   buildTaggedVersionRows,
+  compareTagRows,
+  compareVersionGroupKeys,
   filterVersions,
   getVersionGroupKey,
   getVersionGroupLabel,
-  getTagPriority,
 } from '~/utils/versions'
 import { fetchAllPackageVersions } from '~/utils/npm/api'
 
@@ -71,14 +72,7 @@ const latestTagRow = computed(() => tagRows.value.find(r => r.tags.includes('lat
 const otherTagRows = computed(() =>
   tagRows.value
     .filter(r => !r.tags.includes('latest'))
-    .sort((rowA, rowB) => {
-      const priorityA = Math.min(...rowA.tags.map(getTagPriority))
-      const priorityB = Math.min(...rowB.tags.map(getTagPriority))
-      if (priorityA !== priorityB) return priorityA - priorityB
-      const timeA = versionTimes.value[rowA.version] ?? ''
-      const timeB = versionTimes.value[rowB.version] ?? ''
-      return timeB.localeCompare(timeA)
-    }),
+    .sort((rowA, rowB) => compareTagRows(rowA, rowB, versionTimes.value)),
 )
 
 function getVersionTime(version: string): string | undefined {
@@ -99,12 +93,7 @@ const versionGroups = computed(() => {
   }
 
   return Array.from(byKey.keys())
-    .sort((a, b) => {
-      const [aMajor, aMinor] = a.split('.').map(Number)
-      const [bMajor, bMinor] = b.split('.').map(Number)
-      if (aMajor !== bMajor) return (bMajor ?? 0) - (aMajor ?? 0)
-      return (bMinor ?? -1) - (aMinor ?? -1)
-    })
+    .sort(compareVersionGroupKeys)
     .map(groupKey => ({
       groupKey,
       label: getVersionGroupLabel(groupKey),

--- a/app/utils/versions.ts
+++ b/app/utils/versions.ts
@@ -84,6 +84,41 @@ export function getTagPriority(tag: string | undefined): number {
 }
 
 /**
+ * Compare two tagged version rows for display ordering.
+ * Sorts by minimum tag priority first; falls back to publish date descending.
+ * @param rowA - First row
+ * @param rowB - Second row
+ * @param versionTimes - Map of version string to ISO publish time
+ * @returns Negative/zero/positive comparator value
+ */
+export function compareTagRows(
+  rowA: TaggedVersionRow,
+  rowB: TaggedVersionRow,
+  versionTimes: Record<string, string>,
+): number {
+  const priorityA = Math.min(...rowA.tags.map(getTagPriority))
+  const priorityB = Math.min(...rowB.tags.map(getTagPriority))
+  if (priorityA !== priorityB) return priorityA - priorityB
+  const timeA = versionTimes[rowA.version] ?? ''
+  const timeB = versionTimes[rowB.version] ?? ''
+  return timeB.localeCompare(timeA)
+}
+
+/**
+ * Compare two version group keys for display ordering.
+ * Sorts by major descending, then by minor descending for 0.x groups.
+ * @param a - Group key (e.g. "1", "0.9")
+ * @param b - Group key (e.g. "2", "0.10")
+ * @returns Negative/zero/positive comparator value
+ */
+export function compareVersionGroupKeys(a: string, b: string): number {
+  const [majorA, minorA] = a.split('.').map(Number)
+  const [majorB, minorB] = b.split('.').map(Number)
+  if (majorA !== majorB) return (majorB ?? 0) - (majorA ?? 0)
+  return (minorB ?? -1) - (minorA ?? -1)
+}
+
+/**
  * Sort tags with 'latest' first, then alphabetically
  * @param tags - Array of tag names
  * @returns New sorted array

--- a/test/unit/app/utils/versions.spec.ts
+++ b/test/unit/app/utils/versions.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   buildTaggedVersionRows,
   buildVersionToTagsMap,
+  compareTagRows,
+  compareVersionGroupKeys,
   filterExcludedTags,
   filterVersions,
   getPrereleaseChannel,
@@ -420,6 +422,105 @@ describe('isSameVersionGroup', () => {
     expect(isSameVersionGroup('0.5.0-beta.1', '0.5.0')).toBe(true)
     expect(isSameVersionGroup('0.5.0-alpha.1', '0.5.3')).toBe(true)
     expect(isSameVersionGroup('0.5.0-beta.1', '0.6.0')).toBe(false)
+  })
+})
+
+describe('compareTagRows', () => {
+  function row(version: string, tags: string[]) {
+    return { id: `version:${version}`, primaryTag: tags[0]!, tags, version }
+  }
+
+  it('sorts by tag priority ascending (rc before beta)', () => {
+    const rc = row('2.0.0-rc.1', ['rc'])
+    const beta = row('2.0.0-beta.1', ['beta'])
+    expect(compareTagRows(rc, beta, {})).toBeLessThan(0)
+    expect(compareTagRows(beta, rc, {})).toBeGreaterThan(0)
+  })
+
+  it('sorts by tag priority ascending (beta before alpha)', () => {
+    const beta = row('2.0.0-beta.1', ['beta'])
+    const alpha = row('2.0.0-alpha.1', ['alpha'])
+    expect(compareTagRows(beta, alpha, {})).toBeLessThan(0)
+  })
+
+  it('falls back to publish date descending when priorities are equal', () => {
+    const newer = row('1.1.0', ['legacy'])
+    const older = row('1.0.0', ['legacy'])
+    const times = { '1.1.0': '2024-06-01T00:00:00.000Z', '1.0.0': '2024-01-01T00:00:00.000Z' }
+    expect(compareTagRows(newer, older, times)).toBeLessThan(0)
+    expect(compareTagRows(older, newer, times)).toBeGreaterThan(0)
+  })
+
+  it('returns 0 for equal priority and equal publish time', () => {
+    const a = row('1.0.0', ['legacy'])
+    const b = row('1.0.1', ['legacy'])
+    const times = { '1.0.0': '2024-01-01T00:00:00.000Z', '1.0.1': '2024-01-01T00:00:00.000Z' }
+    expect(compareTagRows(a, b, times)).toBe(0)
+  })
+
+  it('uses minimum tag priority for multi-tag rows', () => {
+    // Row with ['rc', 'next'] has min priority of rc (2)
+    // Row with ['beta'] has priority 3 — so rc-row should sort first
+    const rcAndNext = row('3.0.0-rc.1', ['rc', 'next'])
+    const beta = row('3.0.0-beta.1', ['beta'])
+    expect(compareTagRows(rcAndNext, beta, {})).toBeLessThan(0)
+  })
+
+  it('sorts unknown tags after known priority tags', () => {
+    const known = row('2.0.0-alpha.1', ['alpha'])
+    const unknown = row('2.0.0-custom.1', ['custom-tag'])
+    expect(compareTagRows(known, unknown, {})).toBeLessThan(0)
+  })
+
+  it('sorts unknown tags by publish date descending', () => {
+    const newer = row('2.0.0', ['v2-custom'])
+    const older = row('1.0.0', ['v1-custom'])
+    const times = { '2.0.0': '2025-01-01T00:00:00.000Z', '1.0.0': '2024-01-01T00:00:00.000Z' }
+    expect(compareTagRows(newer, older, times)).toBeLessThan(0)
+  })
+
+  it('treats missing publish time as empty string (sorts last among same-priority rows)', () => {
+    const withTime = row('1.1.0', ['legacy'])
+    const withoutTime = row('1.0.0', ['legacy'])
+    const times = { '1.1.0': '2024-06-01T00:00:00.000Z' }
+    expect(compareTagRows(withTime, withoutTime, times)).toBeLessThan(0)
+  })
+})
+
+describe('compareVersionGroupKeys', () => {
+  it('sorts higher major before lower major', () => {
+    expect(compareVersionGroupKeys('2', '1')).toBeLessThan(0)
+    expect(compareVersionGroupKeys('1', '2')).toBeGreaterThan(0)
+  })
+
+  it('returns 0 for equal keys', () => {
+    expect(compareVersionGroupKeys('3', '3')).toBe(0)
+    expect(compareVersionGroupKeys('0.9', '0.9')).toBe(0)
+  })
+
+  it('sorts higher minor before lower minor for 0.x groups', () => {
+    expect(compareVersionGroupKeys('0.10', '0.9')).toBeLessThan(0)
+    expect(compareVersionGroupKeys('0.9', '0.10')).toBeGreaterThan(0)
+  })
+
+  it('sorts non-0.x keys (no minor) before 0.x keys with same major', () => {
+    // major-only key "0" has no minor (undefined → -1), so "0.1" sorts before "0"
+    expect(compareVersionGroupKeys('0.1', '0')).toBeLessThan(0)
+  })
+
+  it('sorts major-version groups in descending order when used with Array.sort', () => {
+    const keys = ['1', '3', '2', '10']
+    expect(keys.sort(compareVersionGroupKeys)).toEqual(['10', '3', '2', '1'])
+  })
+
+  it('sorts 0.x groups in descending minor order when used with Array.sort', () => {
+    const keys = ['0.1', '0.10', '0.9', '0.2']
+    expect(keys.sort(compareVersionGroupKeys)).toEqual(['0.10', '0.9', '0.2', '0.1'])
+  })
+
+  it('interleaves major and 0.x groups correctly', () => {
+    const keys = ['0.9', '1', '0.10', '2']
+    expect(keys.sort(compareVersionGroupKeys)).toEqual(['2', '1', '0.10', '0.9'])
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2102 

### 🧭 Context

A implementation bug caused the confusing UI.

### 📚 Description

Fix unstable ordering of the tagged versions array. Tags are now sorted by semantic priority, with the exception of latest which remains pinned at the top.

| Scenario | Screenshot |
| :- | :- |
| After | <img width="763" height="352" alt="QQ20260316-231723" src="https://github.com/user-attachments/assets/34c6edf3-70d8-4c32-8738-c73d2b8bf4e5" /> |
| Before | <img width="763" height="352" alt="version list page before" src="https://github.com/user-attachments/assets/6093f40f-e870-405a-b063-8b7eec2e0db7" /> |

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
