### PR TITLE
fix(ui): remove redundant back button in selection-view

### DIFF
--- a/app/components/Package/SelectionView.vue
+++ b/app/components/Package/SelectionView.vue
@@ -3,8 +3,7 @@ defineProps<{
   viewMode?: ViewMode
 }>()
 
-const { selectedPackages, clearSelectedPackages, selectedPackagesParam, closeSelectionView } =
-  usePackageSelection()
+const { selectedPackages, clearSelectedPackages, selectedPackagesParam } = usePackageSelection()
 
 const { data, pending } = useAsyncData(
   async () => {


### PR DESCRIPTION
### 🧭 Context
The search page's selection view has two back buttons, likely caused by a merge conflict issue.

### 📚 Description
Removes extra back button in the view

<img width="824" height="299" alt="Screenshot 2026-03-17 at 15 15 50" src="https://github.com/user-attachments/assets/91763ffa-a7de-4b4c-9ea1-7987731b0a40" />
