### PR TITLE
fix(ui): correct show-scroll-to-top logic

### DIFF
--- a/app/components/Package/Header.vue
+++ b/app/components/Package/Header.vue
@@ -18,7 +18,7 @@ const props = defineProps<{
 }>()
 
 const { requestedVersion, orgName } = usePackageRoute()
-const { scrollToTop, isTouchDeviceClient } = useScrollToTop()
+const { scrollToTop } = useScrollToTop()
 const packageHeaderHeight = usePackageHeaderHeight()
 
 const header = useTemplateRef('header')


### PR DESCRIPTION
### 🧭 Context

A small edit, as I missed the condition that scrolling only appeared on devices with touch support, but it was expected to work for all devices

Related to https://github.com/npmx-dev/npmx.dev/pull/2035#issuecomment-4081141402