### PR TITLE
fix: normalize metrics language across possible values

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -524,11 +524,11 @@
     "metrics": {
       "esm": "ES Modules supported",
       "cjs": "CommonJS supported",
-      "no_esm": "No ES Modules support",
+      "no_esm": "ES Modules unsupported",
       "types_label": "Types",
       "types_included": "Types included",
       "types_available": "Types available via {package}",
-      "no_types": "No TypeScript types"
+      "no_types": "No types"
     },
     "license": {
       "view_spdx": "View license text on SPDX",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
resolves #2131

### 🧭 Context

<!-- Brief background and why this change is needed -->

Tiny change to normalize a few strings just to bring the structure of what's being communicated in-line so it's consistent across the board.

<!-- High-level summary of what changed -->

Normalizes two strings into the same formats as their peers.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Currently, the tooltip for ESM says `No ESM Support` if there is no ESM but `ESM Supported` if there is ESM. CJS Says `CJS Supported`. This PR normalizes the first to be `ESM Supported` so it's consistent with the others.

The tooltops for Types are `Types included`, `Types available via {package}`, and `No TypeScript types`. This PR normalizes the last to be the same as the other two and changes it to `No types`.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
