### PR TITLE
fix: enhance repository URL handling in useRepositoryUrl

### DIFF
--- a/app/composables/useRepositoryUrl.ts
+++ b/app/composables/useRepositoryUrl.ts
@@ -1,4 +1,4 @@
-import { joinURL } from 'ufo'
+import { joinURL, withoutTrailingSlash } from 'ufo'
 
 type RequestedVersion = SlimPackument['requestedVersion'] | null
 
@@ -21,9 +21,11 @@ export function useRepositoryUrl(
       return null
     }
 
-    // append `repository.directory` for monorepo packages
+    // Fix: Strip trailing .git (and any leftovers) before constructing the directory link
+    url = url.replace(/\.git\/?$/, '')
+
     if (repo.directory) {
-      url = joinURL(`${url}/tree/HEAD`, repo.directory)
+      url = joinURL(`${withoutTrailingSlash(url)}/tree/HEAD`, repo.directory)
     }
 
     return url


### PR DESCRIPTION
Updated URL construction to strip trailing .git and ensure proper formatting.

### 🔗 Linked issue

https://github.com/npmx-dev/npmx.dev/issues/2142


### 📚 Description

When constructing repository links for monorepo packages, the `.git` suffix from the original repository URL was not being removed before appending the `/tree/HEAD/{directory}` path. This resulted in malformed GitHub URLs that GitHub cannot resolve.

**Problem:**
For a package like `@astrojs/ts-plugin` with repository URL `https://github.com/withastro/astro.git` and directory `packages/language-tools/ts-plugin`, the link was being constructed as: