### PR TITLE
feat: display yaml frontmatter as a table

### DIFF
--- a/server/utils/readme.ts
+++ b/server/utils/readme.ts
@@ -648,7 +648,7 @@ ${html}
   // Strip trailing whitespace (tabs/spaces) from code block closing fences.
   // While marky-markdown handles these gracefully, marked fails to recognize
   // the end of a code block if the closing fences are followed by unexpected whitespaces.
-  const normalizedContent = content.replace(/^( {0,3}(?:`{3,}|~{3,}))\s*$/gm, '$1')
+  const normalizedContent = markdownBody.replace(/^( {0,3}(?:`{3,}|~{3,}))\s*$/gm, '$1')
   const rawHtml = frontmatterHtml + (marked.parse(normalizedContent) as string)
 
   const sanitized = sanitizeHtml(rawHtml, {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->
On npmx.dev, the YAML Frontmatter within `.md` files—specifically the key-value blocks enclosed by `---` symbols—is incorrectly rendered by `marked` as a horizontal rule (`<hr>`), while the key-value pairs are erroneously rendered as `<h3>` tags. In contrast, GitHub renders this content as a neat key-value table.
### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
Use `gray-matter` to parse the frontmatter, render it as a GitHub-style key-value table, and prepend it to the main HTML content.

Inspired by GitHub
<img width="1123" height="292" alt="image" src="https://github.com/user-attachments/assets/6bdce472-2491-4182-87df-69076c8a5f6f" />

before
<img width="1186" height="320" alt="image" src="https://github.com/user-attachments/assets/3c422b71-4fa0-4c9a-b1af-a3dcdad11786" />

after
<img width="1626" height="404" alt="image" src="https://github.com/user-attachments/assets/357b85b8-74a7-40a2-a7ce-e79a02707f44" />

