### PR TITLE
feat(docs): add links to advanced badges generator

### DIFF
--- a/docs/content/2.guide/6.badges.md
+++ b/docs/content/2.guide/6.badges.md
@@ -70,7 +70,7 @@ Use this generator to get the Markdown code you desire:
 :badge-generator-parameters
 
 ::tip
-For a more advanced badges generator, check out https://npmx-badge.vercel.app/.
+For a more advanced badges generator, check out [this community website](https://npmx-badge.vercel.app/).
 ::
 
 ### `label`


### PR DESCRIPTION
#### Description

As quickly mentioned in [this comment](https://github.com/npmx-dev/npmx.dev/pull/2152#issuecomment-4103580529), we could link to the advanced badges generator (https://npmx-badge.vercel.app/) from our docs to inform more people about it and make it accessible faster.