### PR TITLE
fix: use `displayVersion` instead of `pkg`

### DIFF
--- a/app/components/OgImage/Package.vue
+++ b/app/components/OgImage/Package.vue
@@ -158,7 +158,11 @@ try {
         </span>
 
         <!-- License (if any) -->
-        <span v-if="displayVersion?.license || pkg?.license" class="flex items-center gap-2" data-testid="license">
+        <span
+          v-if="displayVersion?.license || pkg?.license"
+          class="flex items-center gap-2"
+          data-testid="license"
+        >
           <svg
             viewBox="0 0 32 32"
             :fill="primaryColor"

--- a/app/components/OgImage/Package.vue
+++ b/app/components/OgImage/Package.vue
@@ -158,7 +158,7 @@ try {
         </span>
 
         <!-- License (if any) -->
-        <span v-if="pkg?.license" class="flex items-center gap-2" data-testid="license">
+        <span v-if="displayVersion?.license || pkg?.license" class="flex items-center gap-2" data-testid="license">
           <svg
             viewBox="0 0 32 32"
             :fill="primaryColor"
@@ -178,7 +178,7 @@ try {
             />
           </svg>
           <span>
-            {{ pkg.license }}
+            {{ displayVersion?.license || pkg?.license }}
           </span>
         </span>
 

--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -583,7 +583,10 @@ const showSkeleton = shallowRef(false)
                 {{ $t('package.stats.license') }}
               </dt>
               <dd class="font-mono text-sm text-fg">
-                <LicenseDisplay v-if="displayVersion?.license || pkg.license" :license="displayVersion?.license || pkg.license!" />
+                <LicenseDisplay
+                  v-if="displayVersion?.license || pkg.license"
+                  :license="displayVersion?.license || pkg.license!"
+                />
                 <span v-else>{{ $t('package.license.none') }}</span>
               </dd>
             </div>

--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -583,7 +583,7 @@ const showSkeleton = shallowRef(false)
                 {{ $t('package.stats.license') }}
               </dt>
               <dd class="font-mono text-sm text-fg">
-                <LicenseDisplay v-if="pkg.license" :license="pkg.license" />
+                <LicenseDisplay v-if="displayVersion?.license || pkg.license" :license="displayVersion?.license || pkg.license!" />
                 <span v-else>{{ $t('package.license.none') }}</span>
               </dd>
             </div>


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #2163

### 🧭 Context

If you switch to older/other versions in a package which have a different version the version doesn't change

### 📚 Description

Problem is the loaded packages (latest/current version) was used to show license informations. Now we use the `displayVersion` for that and we now always see the current license.
