### PR TITLE
fix(ui): safari clipboard fallback for copy as markdown button

### DIFF
--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -119,8 +119,7 @@ function copyViaExecCommand(text: string): boolean {
   textarea.select()
   try {
     return document.execCommand('copy')
-  }
-  finally {
+  } finally {
     document.body.removeChild(textarea)
   }
 }
@@ -138,14 +137,15 @@ async function copyReadmeHandler() {
   try {
     await navigator.clipboard.writeText(markdown)
     success = true
-  }
-  catch {
+  } catch {
     success = copyViaExecCommand(markdown)
   }
 
   if (success) {
     copiedReadme.value = true
-    setTimeout(() => { copiedReadme.value = false }, 2000)
+    setTimeout(() => {
+      copiedReadme.value = false
+    }, 2000)
   }
 }
 

--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -96,10 +96,7 @@ const {
 )
 
 //copy README file as Markdown
-const { copied: copiedReadme, copy: copyReadme } = useClipboard({
-  source: () => '',
-  copiedDuring: 2000,
-})
+const copiedReadme = shallowRef(false)
 
 function prefetchReadmeMarkdown() {
   if (readmeMarkdownStatus.value === 'idle') {

--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -120,7 +120,9 @@ async function copyReadmeHandler() {
     })
     await navigator.clipboard.write([item])
     copiedReadme.value = true
-    setTimeout(() => { copiedReadme.value = false }, 2000)
+    setTimeout(() => {
+      copiedReadme.value = false
+    }, 2000)
   } catch {
     // Fallback for browsers without ClipboardItem Promise support
     await fetchReadmeMarkdown()
@@ -129,7 +131,9 @@ async function copyReadmeHandler() {
     try {
       await navigator.clipboard.writeText(markdown)
       copiedReadme.value = true
-      setTimeout(() => { copiedReadme.value = false }, 2000)
+      setTimeout(() => {
+        copiedReadme.value = false
+      }, 2000)
     } catch {
       // last resort: execCommand
       const textarea = document.createElement('textarea')
@@ -142,7 +146,9 @@ async function copyReadmeHandler() {
       document.body.removeChild(textarea)
       if (ok) {
         copiedReadme.value = true
-        setTimeout(() => { copiedReadme.value = false }, 2000)
+        setTimeout(() => {
+          copiedReadme.value = false
+        }, 2000)
       }
     }
   }

--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -109,6 +109,8 @@ function prefetchReadmeMarkdown() {
 // synchronous while the fetch resolves asynchronously inside the item.
 // See: https://wolfgangrittner.dev/how-to-use-clipboard-api-in-safari/
 async function copyReadmeHandler() {
+  let copied = false
+
   try {
     const item = new ClipboardItem({
       'text/plain': (async () => {
@@ -119,38 +121,34 @@ async function copyReadmeHandler() {
       })(),
     })
     await navigator.clipboard.write([item])
-    copiedReadme.value = true
-    setTimeout(() => {
-      copiedReadme.value = false
-    }, 2000)
+    copied = true
   } catch {
     // Fallback for browsers without ClipboardItem Promise support
     await fetchReadmeMarkdown()
     const markdown = readmeMarkdownData.value?.markdown
-    if (!markdown) return
-    try {
-      await navigator.clipboard.writeText(markdown)
-      copiedReadme.value = true
-      setTimeout(() => {
-        copiedReadme.value = false
-      }, 2000)
-    } catch {
-      // last resort: execCommand
-      const textarea = document.createElement('textarea')
-      textarea.value = markdown
-      textarea.style.position = 'fixed'
-      textarea.style.opacity = '0'
-      document.body.appendChild(textarea)
-      textarea.select()
-      const ok = document.execCommand('copy')
-      document.body.removeChild(textarea)
-      if (ok) {
-        copiedReadme.value = true
-        setTimeout(() => {
-          copiedReadme.value = false
-        }, 2000)
+    if (markdown) {
+      try {
+        await navigator.clipboard.writeText(markdown)
+        copied = true
+      } catch {
+        // last resort: execCommand
+        const textarea = document.createElement('textarea')
+        textarea.value = markdown
+        textarea.style.position = 'fixed'
+        textarea.style.opacity = '0'
+        document.body.appendChild(textarea)
+        textarea.select()
+        copied = document.execCommand('copy')
+        document.body.removeChild(textarea)
       }
     }
+  }
+
+  if (copied) {
+    copiedReadme.value = true
+    setTimeout(() => {
+      copiedReadme.value = false
+    }, 2000)
   }
 }
 

--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -107,13 +107,46 @@ function prefetchReadmeMarkdown() {
   }
 }
 
+// Fallback for Safari: navigator.clipboard.writeText() must be called
+// synchronously within a user gesture. The async fetch breaks that chain,
+// so we fall back to execCommand('copy') via a temporary textarea.
+function copyViaExecCommand(text: string): boolean {
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  document.body.appendChild(textarea)
+  textarea.select()
+  try {
+    return document.execCommand('copy')
+  }
+  finally {
+    document.body.removeChild(textarea)
+  }
+}
+
 async function copyReadmeHandler() {
   await fetchReadmeMarkdown()
 
   const markdown = readmeMarkdownData.value?.markdown
   if (!markdown) return
 
-  await copyReadme(markdown)
+  // Try the modern clipboard API first, then fall back to execCommand.
+  // Safari requires clipboard writes synchronously within a user gesture —
+  // the async fetch above breaks that chain, so writeText() will reject.
+  let success = false
+  try {
+    await navigator.clipboard.writeText(markdown)
+    success = true
+  }
+  catch {
+    success = copyViaExecCommand(markdown)
+  }
+
+  if (success) {
+    copiedReadme.value = true
+    setTimeout(() => { copiedReadme.value = false }, 2000)
+  }
 }
 
 // Track active TOC item based on scroll position

--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -104,45 +104,47 @@ function prefetchReadmeMarkdown() {
   }
 }
 
-// Fallback for Safari: navigator.clipboard.writeText() must be called
-// synchronously within a user gesture. The async fetch breaks that chain,
-// so we fall back to execCommand('copy') via a temporary textarea.
-function copyViaExecCommand(text: string): boolean {
-  const textarea = document.createElement('textarea')
-  textarea.value = text
-  textarea.style.position = 'fixed'
-  textarea.style.opacity = '0'
-  document.body.appendChild(textarea)
-  textarea.select()
-  try {
-    return document.execCommand('copy')
-  } finally {
-    document.body.removeChild(textarea)
-  }
-}
-
+// Safari requires clipboard writes synchronously within a user gesture.
+// Passing a Promise into ClipboardItem lets clipboard.write() stay
+// synchronous while the fetch resolves asynchronously inside the item.
+// See: https://wolfgangrittner.dev/how-to-use-clipboard-api-in-safari/
 async function copyReadmeHandler() {
-  await fetchReadmeMarkdown()
-
-  const markdown = readmeMarkdownData.value?.markdown
-  if (!markdown) return
-
-  // Try the modern clipboard API first, then fall back to execCommand.
-  // Safari requires clipboard writes synchronously within a user gesture —
-  // the async fetch above breaks that chain, so writeText() will reject.
-  let success = false
   try {
-    await navigator.clipboard.writeText(markdown)
-    success = true
-  } catch {
-    success = copyViaExecCommand(markdown)
-  }
-
-  if (success) {
+    const item = new ClipboardItem({
+      'text/plain': (async () => {
+        await fetchReadmeMarkdown()
+        const markdown = readmeMarkdownData.value?.markdown
+        if (!markdown) throw new Error('No markdown')
+        return new Blob([markdown], { type: 'text/plain' })
+      })(),
+    })
+    await navigator.clipboard.write([item])
     copiedReadme.value = true
-    setTimeout(() => {
-      copiedReadme.value = false
-    }, 2000)
+    setTimeout(() => { copiedReadme.value = false }, 2000)
+  } catch {
+    // Fallback for browsers without ClipboardItem Promise support
+    await fetchReadmeMarkdown()
+    const markdown = readmeMarkdownData.value?.markdown
+    if (!markdown) return
+    try {
+      await navigator.clipboard.writeText(markdown)
+      copiedReadme.value = true
+      setTimeout(() => { copiedReadme.value = false }, 2000)
+    } catch {
+      // last resort: execCommand
+      const textarea = document.createElement('textarea')
+      textarea.value = markdown
+      textarea.style.position = 'fixed'
+      textarea.style.opacity = '0'
+      document.body.appendChild(textarea)
+      textarea.select()
+      const ok = document.execCommand('copy')
+      document.body.removeChild(textarea)
+      if (ok) {
+        copiedReadme.value = true
+        setTimeout(() => { copiedReadme.value = false }, 2000)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2151

### 🧭 Context

Safari requires clipboard writes to happen synchronously within a user gesture. The `copyReadmeHandler` does `await fetchReadmeMarkdown()` before writing to clipboard, breaking that chain — so `writeText()` silently rejects.

### 📚 Description

Uses the [`ClipboardItem` with Promise](https://wolfgangrittner.dev/how-to-use-clipboard-api-in-safari/) pattern: pass the async fetch as a Promise *into* `ClipboardItem`, so `clipboard.write()` stays synchronous within the gesture while the data resolves internally.

```js
const item = new ClipboardItem({
  'text/plain': (async () => {
    await fetchReadmeMarkdown()
    return new Blob([markdown], { type: 'text/plain' })
  })(),
})
await navigator.clipboard.write([item])
```

Fallback chain for older browsers: `writeText()` → `execCommand('copy')`.

### What it doesn't change

- No changes to prefetch behavior or existing hover prefetch
- No new dependencies or components
- Template stays untouched — only the handler logic changes