### PR TITLE
test(ui): add tests for mobile menu default closed state

### DIFF
--- a/test/nuxt/components/Header/MobileMenu.spec.ts
+++ b/test/nuxt/components/Header/MobileMenu.spec.ts
@@ -33,7 +33,15 @@ describe('MobileMenu', () => {
             type: 'group' as const,
             name: 'main',
             label: 'Navigation',
-            items: [{ type: 'link' as const, name: 'home', label: 'Home', to: '/', iconClass: 'i-lucide:home' }],
+            items: [
+              {
+                type: 'link' as const,
+                name: 'home',
+                label: 'Home',
+                to: '/',
+                iconClass: 'i-lucide:home',
+              },
+            ],
           },
         ],
       },


### PR DESCRIPTION
### 🔗 Linked issue

Closes #1505

### 🧭 Context

The mobile menu had no tests verifying its default state or basic open/close behavior.

### 📚 Description

Adds a test suite for `MobileMenu.client.vue` covering:

- **Closed by default** — dialog element is not in DOM when `open` is false
- **Opens on request** — dialog with `role="dialog"` and `aria-modal="true"` appears when `open` is true
- **Closes on prop change** — dialog removed when `open` goes from true to false
- **Backdrop click** — emits `update:open` with `false`
- **Close button click** — emits `update:open` with `false`

Mocks `useConnector`, `useAtproto`, and `useFocusTrap` to isolate the menu logic. Follows existing patterns from `HeaderConnectorModal.spec.ts` and `Tooltip.spec.ts` (Teleport + cleanup).

### What it doesn't change

- No changes to the component itself
- No changes to existing tests