### PR TITLE
fix(ui): register Geist font with canvas to fix badge width measurement

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -253,6 +253,12 @@ export default defineNuxtConfig({
     replace: {
       'import.meta.test': isTest,
     },
+    serverAssets: [
+      {
+        baseName: 'fonts',
+        dir: './public/fonts',
+      },
+    ],
   },
 
   fonts: {

--- a/server/api/registry/badge/[type]/[...pkg].get.ts
+++ b/server/api/registry/badge/[type]/[...pkg].get.ts
@@ -1,5 +1,5 @@
 import * as v from 'valibot'
-import { createCanvas, type SKRSContext2D } from '@napi-rs/canvas'
+import { createCanvas, GlobalFonts, type SKRSContext2D } from '@napi-rs/canvas'
 import { hash } from 'ohash'
 import { createError, getRouterParam, getQuery, setHeader } from 'h3'
 import { PackageRouteParamsSchema } from '#shared/schemas/package'
@@ -52,6 +52,25 @@ const BADGE_FONT_SHORTHAND = 'normal normal 400 11px Geist, system-ui, -apple-sy
 const SHIELDS_FONT_SHORTHAND = 'normal normal 400 11px Verdana, Geneva, DejaVu Sans, sans-serif'
 
 let cachedCanvasContext: SKRSContext2D | null | undefined
+let fontRegistered = false
+
+async function registerGeistFont(): Promise<void> {
+  if (fontRegistered) return
+
+  try {
+    const fontStorage = useStorage('assets:fonts')
+    const fontData = await fontStorage.getItemRaw('Geist-Regular.ttf')
+
+    if (fontData) {
+      const buffer = fontData instanceof Buffer ? fontData : Buffer.from(fontData as ArrayBuffer)
+      GlobalFonts.register(buffer, 'Geist')
+    }
+  } catch {
+    // font registration is best-effort; fallback measurement will be used
+  }
+
+  fontRegistered = true
+}
 
 function getCanvasContext(): SKRSContext2D | null {
   if (cachedCanvasContext !== undefined) {
@@ -431,6 +450,8 @@ const BadgeStyleSchema = v.picklist(['default', 'shieldsio'])
 
 export default defineCachedEventHandler(
   async event => {
+    await registerGeistFont()
+
     const query = getQuery(event)
     const typeParam = getRouterParam(event, 'type')
     const pkgParamSegments = getRouterParam(event, 'pkg')?.split('/') ?? []


### PR DESCRIPTION
## Summary
- Register the Geist font with `@napi-rs/canvas` `GlobalFonts` so server-side text measurement uses the same font the SVG specifies for browser rendering
- Add `serverAssets` config in Nitro to expose `public/fonts/` to server-side code via `useStorage`
- Font registration is lazy (once per process) and best-effort — falls back gracefully if the font file is unavailable

## Root cause
The badge SVG specifies `font-family="Geist, system-ui, ..."` but `@napi-rs/canvas` was never given the Geist font file. In production, canvas measured text with a wider system fallback font, producing oversized `width` attributes on the SVG. The browser then rendered the text narrower (using Geist or system-ui), leaving visible whitespace gaps — especially noticeable for longer badge values.

Locally, the Geist font may be installed system-wide, which is why `pnpm dev` produced correct-looking badges.

Closes #2187

## Test plan
- [ ] Verify `/api/registry/badge/engines/vitest` no longer has excessive whitespace
- [ ] Verify other badge types (version, license, downloads) render with correct widths
- [ ] Verify `style=shieldsio` badges are unaffected
- [ ] Verify badges still render correctly when canvas/font registration fails (graceful fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)