### PR TITLE
fix: use varying widths for compare bar chart skeleton loaders

### DIFF
--- a/app/components/Compare/FacetBarChart.vue
+++ b/app/components/Compare/FacetBarChart.vue
@@ -332,12 +332,8 @@ const config = computed<VueUiHorizontalBarConfig>(() => {
           <SkeletonInline class="h-3 w-36 rounded" />
         </div>
         <div class="flex flex-col gap-2 px-2" aria-hidden="true">
-          <div
-            v-for="(pkg, i) in packages"
-            :key="pkg"
-            class="flex items-center gap-3"
-          >
-            <SkeletonInline class="h-3 shrink-0" :style="{ width: `${40 + (i * 17) % 40}%` }" />
+          <div v-for="(pkg, i) in packages" :key="pkg" class="flex items-center gap-3">
+            <SkeletonInline class="h-3 shrink-0" :style="{ width: `${40 + ((i * 17) % 40)}%` }" />
             <SkeletonInline class="h-7 flex-1 rounded" />
           </div>
         </div>
@@ -352,12 +348,8 @@ const config = computed<VueUiHorizontalBarConfig>(() => {
       </div>
       <!-- Bar skeletons with varying widths for visual realism -->
       <div class="flex flex-col gap-2 px-2" aria-hidden="true">
-        <div
-          v-for="(pkg, i) in packages"
-          :key="pkg"
-          class="flex items-center gap-3"
-        >
-          <SkeletonInline class="h-3 shrink-0" :style="{ width: `${40 + (i * 17) % 40}%` }" />
+        <div v-for="(pkg, i) in packages" :key="pkg" class="flex items-center gap-3">
+          <SkeletonInline class="h-3 shrink-0" :style="{ width: `${40 + ((i * 17) % 40)}%` }" />
           <SkeletonInline class="h-7 flex-1 rounded" />
         </div>
       </div>

--- a/test/nuxt/components/compare/FacetBarChart.spec.ts
+++ b/test/nuxt/components/compare/FacetBarChart.spec.ts
@@ -31,7 +31,7 @@ describe('FacetBarChart skeleton loaders', () => {
     // The formula used is: width = `${40 + (i * 17) % 40}%`
     // For 3 packages: i=0 -> 40%, i=1 -> 57%, i=2 -> 74%
     const packages = ['react', 'vue', 'svelte']
-    const widths = packages.map((_, i) => `${40 + (i * 17) % 40}%`)
+    const widths = packages.map((_, i) => `${40 + ((i * 17) % 40)}%`)
 
     // Verify they are not all the same (the bug was all bars had the same width)
     const uniqueWidths = new Set(widths)
@@ -41,7 +41,7 @@ describe('FacetBarChart skeleton loaders', () => {
   it('skeleton width formula produces values within 40-80% range', () => {
     const indices = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     for (const i of indices) {
-      const width = 40 + (i * 17) % 40
+      const width = 40 + ((i * 17) % 40)
       expect(width).toBeGreaterThanOrEqual(40)
       expect(width).toBeLessThan(80)
     }


### PR DESCRIPTION
### 🔗 Linked issue
resolves #2106

### 🧭 Context
The compare page FacetBarChart skeleton loaders showed all bars at the same fixed width, giving an unrealistic loading placeholder. Real bar charts show bars of varying widths corresponding to different values.

### 📚 Description
Updated the skeleton loader in `Compare/FacetBarChart.vue` to compute per-bar widths using `width: ${40 + (i * 17) % 40}%` so adjacent bars have different lengths, producing a more realistic loading state. Also added `aria-hidden="true"` to skeleton containers and updated the heading/subtitle skeletons to more realistic widths.

A regression test (`test/nuxt/components/compare/FacetBarChart.spec.ts`) verifies that the width formula produces different values across packages and that all widths stay within the expected 40–79% range.