### PR TITLE
fix: connector modal should show pnpm dlx command instead of exec

### DIFF
--- a/app/components/Header/ConnectorModal.vue
+++ b/app/components/Header/ConnectorModal.vue
@@ -41,6 +41,7 @@ const executeNpmxConnectorCommand = computed(() => {
   return getExecuteCommand({
     packageName: 'npmx-connector',
     packageManager: selectedPM.value,
+    isBinaryOnly: true,
   })
 })
 </script>


### PR DESCRIPTION
### 🔗 Linked issue

n/a

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<table>
<tr>
 <th>before</th>
 <th>after</th>
 </tr>
<tr>
 <td>
<img width="772" height="319" alt="image" src="https://github.com/user-attachments/assets/a49f1f80-5781-4d2e-b9e1-27a6bb952ea2" />
</td>
 <td>
<img width="772" height="319" alt="image" src="https://github.com/user-attachments/assets/44be7acc-a695-4abd-aaa7-522bb52a66c4" />
</td>
</tr>
</table>

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

Updates the command on the connector modal for pnpm so that it's in line with the others

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
