### PR TITLE
fix: align dependency warning icons to middle

### DIFF
--- a/app/components/Package/Dependencies.vue
+++ b/app/components/Package/Dependencies.vue
@@ -126,7 +126,7 @@ const numberFormatter = useNumberFormatter()
             >
               <button
                 type="button"
-                class="p-2 -m-2"
+                class="inline-flex items-center justify-center p-2 -m-2"
                 :aria-label="getOutdatedTooltip(outdatedDeps[dep], $t)"
               >
                 <span class="i-lucide:circle-alert w-3 h-3" aria-hidden="true" />
@@ -139,7 +139,7 @@ const numberFormatter = useNumberFormatter()
             >
               <button
                 type="button"
-                class="p-2 -m-2"
+                class="inline-flex items-center justify-center p-2 -m-2"
                 :aria-label="$t('package.dependencies.has_replacement')"
               >
                 <span class="i-lucide:lightbulb w-3 h-3" aria-hidden="true" />


### PR DESCRIPTION
Before: 

<img width="673" height="222" alt="before-icon" src="https://github.com/user-attachments/assets/276c3b79-e1b9-45e6-8381-61ebcb000901" />

After: 

<img width="673" height="222" alt="after-icon" src="https://github.com/user-attachments/assets/d69e632a-0993-4a0d-b598-4a1201b9086a" />
