### PR TITLE
feat(ui): flag git and https dependencies

### DIFF
--- a/app/components/Package/Dependencies.vue
+++ b/app/components/Package/Dependencies.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { SEVERITY_TEXT_COLORS, getHighestSeverity } from '#shared/utils/severity'
+import { isUrlDependency } from '#shared/utils/version-source'
 import { getOutdatedTooltip, getVersionClass } from '~/utils/npm/outdated-dependencies'
 
 const { t } = useI18n()
@@ -168,6 +169,19 @@ const numberFormatter = useNumberFormatter()
             >
               <span class="sr-only">{{ $t('package.deprecated.label') }}</span>
             </LinkBase>
+            <TooltipApp
+              v-if="isUrlDependency(version)"
+              class="shrink-0 text-amber-700 dark:text-amber-500"
+              :text="$t('package.dependencies.url_dependency')"
+            >
+              <button
+                type="button"
+                class="inline-flex items-center justify-center p-2 -m-2"
+                :aria-label="$t('package.dependencies.url_dependency')"
+              >
+                <span class="i-lucide:unlink w-3 h-3" aria-hidden="true" />
+              </button>
+            </TooltipApp>
             <LinkBase
               :to="packageRoute(dep, version)"
               class="block truncate"
@@ -234,14 +248,29 @@ const numberFormatter = useNumberFormatter()
               {{ $t('package.dependencies.optional') }}
             </TagStatic>
           </div>
-          <LinkBase
-            :to="packageRoute(peer.name, peer.version)"
-            class="block truncate max-w-[30%]"
-            :title="peer.version"
-            dir="ltr"
-          >
-            {{ peer.version }}
-          </LinkBase>
+          <span class="flex items-center gap-1 max-w-[30%]" dir="ltr">
+            <TooltipApp
+              v-if="isUrlDependency(peer.version)"
+              class="shrink-0 text-amber-700 dark:text-amber-500"
+              :text="$t('package.dependencies.url_dependency')"
+            >
+              <button
+                type="button"
+                class="inline-flex items-center justify-center p-2 -m-2"
+                :aria-label="$t('package.dependencies.url_dependency')"
+              >
+                <span class="i-lucide:unlink w-3 h-3" aria-hidden="true" />
+              </button>
+            </TooltipApp>
+            <LinkBase
+              :to="packageRoute(peer.name, peer.version)"
+              class="block truncate"
+              :title="peer.version"
+              dir="ltr"
+            >
+              {{ peer.version }}
+            </LinkBase>
+          </span>
         </li>
       </ul>
       <button
@@ -291,14 +320,29 @@ const numberFormatter = useNumberFormatter()
           <LinkBase :to="packageRoute(dep)" class="block max-w-[80%] break-words" dir="ltr">
             {{ dep }}
           </LinkBase>
-          <LinkBase
-            :to="packageRoute(dep, version)"
-            class="block truncate"
-            :title="version"
-            dir="ltr"
-          >
-            {{ version }}
-          </LinkBase>
+          <span class="flex items-center gap-1" dir="ltr">
+            <TooltipApp
+              v-if="isUrlDependency(version)"
+              class="shrink-0 text-amber-700 dark:text-amber-500"
+              :text="$t('package.dependencies.url_dependency')"
+            >
+              <button
+                type="button"
+                class="inline-flex items-center justify-center p-2 -m-2"
+                :aria-label="$t('package.dependencies.url_dependency')"
+              >
+                <span class="i-lucide:unlink w-3 h-3" aria-hidden="true" />
+              </button>
+            </TooltipApp>
+            <LinkBase
+              :to="packageRoute(dep, version)"
+              class="block truncate"
+              :title="version"
+              dir="ltr"
+            >
+              {{ version }}
+            </LinkBase>
+          </span>
         </li>
       </ul>
       <button

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -454,6 +454,7 @@
       "outdated_minor": "{count} minor version behind (latest: {latest}) | {count} minor versions behind (latest: {latest})",
       "outdated_patch": "Patch update available (latest: {latest})",
       "has_replacement": "This dependency has suggested replacements",
+      "url_dependency": "This dependency uses a URL instead of the npm registry, bypassing integrity checks",
       "vulnerabilities_count": "{count} vulnerability | {count} vulnerabilities"
     },
     "peer_dependencies": {

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -1366,6 +1366,9 @@
             "has_replacement": {
               "type": "string"
             },
+            "url_dependency": {
+              "type": "string"
+            },
             "vulnerabilities_count": {
               "type": "string"
             }

--- a/shared/utils/version-source.ts
+++ b/shared/utils/version-source.ts
@@ -1,0 +1,21 @@
+/**
+ * Detect whether a dependency version specifier points to a URL or Git source
+ * rather than the npm registry.
+ *
+ * These bypass npm registry integrity checks and can be manipulated.
+ * @see https://docs.npmjs.com/cli/v11/configuring-npm/package-json#git-urls-as-dependencies
+ * @see https://docs.npmjs.com/cli/v11/configuring-npm/package-json#urls-as-dependencies
+ */
+export function isUrlDependency(version: string): boolean {
+  // npm: protocol aliases are safe (resolved from the registry)
+  if (version.startsWith('npm:')) return false
+
+  // Protocols: git:, git+https:, git+ssh:, git+http:, https:, http:, file:
+  if (/^[a-z][a-z+]*:/i.test(version)) return true
+
+  // GitHub shorthand: user/repo or user/repo#ref
+  // Also matches github:, gist:, bitbucket:, gitlab: (already caught above by protocol check)
+  if (/^[^@][^/]*\/[^/]+/.test(version)) return true
+
+  return false
+}

--- a/test/unit/shared/utils/version-source.spec.ts
+++ b/test/unit/shared/utils/version-source.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { isUrlDependency } from '#shared/utils/version-source'
+
+describe('version-source', () => {
+  describe('isUrlDependency', () => {
+    it('returns false for semver ranges', () => {
+      expect(isUrlDependency('^1.0.0')).toBe(false)
+      expect(isUrlDependency('~2.3.4')).toBe(false)
+      expect(isUrlDependency('>=1.0.0 <2.0.0')).toBe(false)
+      expect(isUrlDependency('*')).toBe(false)
+      expect(isUrlDependency('1.0.0')).toBe(false)
+      expect(isUrlDependency('2.0.0-beta.1')).toBe(false)
+    })
+
+    it('returns false for npm: protocol aliases', () => {
+      expect(isUrlDependency('npm:other-pkg@^1.0.0')).toBe(false)
+      expect(isUrlDependency('npm:@scope/pkg@2.0.0')).toBe(false)
+    })
+
+    it('returns true for git: protocol', () => {
+      expect(isUrlDependency('git://github.com/user/repo.git')).toBe(true)
+    })
+
+    it('returns true for git+https: protocol', () => {
+      expect(isUrlDependency('git+https://github.com/user/repo.git')).toBe(true)
+    })
+
+    it('returns true for git+ssh: protocol', () => {
+      expect(isUrlDependency('git+ssh://git@github.com:user/repo.git')).toBe(true)
+    })
+
+    it('returns true for git+http: protocol', () => {
+      expect(isUrlDependency('git+http://github.com/user/repo.git')).toBe(true)
+    })
+
+    it('returns true for https: URLs', () => {
+      expect(isUrlDependency('https://github.com/user/repo/tarball/main')).toBe(true)
+    })
+
+    it('returns true for http: URLs', () => {
+      expect(isUrlDependency('http://example.com/pkg.tgz')).toBe(true)
+    })
+
+    it('returns true for file: protocol', () => {
+      expect(isUrlDependency('file:../local-pkg')).toBe(true)
+      expect(isUrlDependency('file:./packages/my-lib')).toBe(true)
+    })
+
+    it('returns true for GitHub shorthand (user/repo)', () => {
+      expect(isUrlDependency('user/repo')).toBe(true)
+      expect(isUrlDependency('user/repo#branch')).toBe(true)
+      expect(isUrlDependency('user/repo#semver:^1.0.0')).toBe(true)
+    })
+
+    it('returns true for github: prefix', () => {
+      expect(isUrlDependency('github:user/repo')).toBe(true)
+    })
+
+    it('returns true for gist: prefix', () => {
+      expect(isUrlDependency('gist:11081aaa281')).toBe(true)
+    })
+
+    it('returns true for bitbucket: prefix', () => {
+      expect(isUrlDependency('bitbucket:user/repo')).toBe(true)
+    })
+
+    it('returns true for gitlab: prefix', () => {
+      expect(isUrlDependency('gitlab:user/repo')).toBe(true)
+    })
+
+    it('returns false for scoped packages in semver ranges', () => {
+      // Scoped packages start with @ so they won't match the user/repo pattern
+      expect(isUrlDependency('@scope/pkg')).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds visual warning flag (unlink icon + tooltip) next to dependencies that use URL-based version specifiers instead of the npm registry
- Detects `git:`, `git+https:`, `git+ssh:`, `http:`, `https:`, `file:`, `github:`, `gist:`, `bitbucket:`, `gitlab:`, and `user/repo` shorthand — everything except `npm:` aliases
- Flags shown in all three dependency sections (dependencies, peer dependencies, optional dependencies)
- All strings internationalized via i18n
- Unit tests with 100% coverage for the detection function

## Changes

- **`shared/utils/version-source.ts`** — new `isUrlDependency()` utility, pure frontend detection from the version specifier string
- **`app/components/Package/Dependencies.vue`** — warning icon with tooltip in all dependency list sections
- **`i18n/locales/en.json`** + **`i18n/schema.json`** — new `url_dependency` translation key
- **`test/unit/shared/utils/version-source.spec.ts`** — 15 test cases covering all formats

## Design decisions

- **Frontend-only detection** — the raw version specifiers are already available as props, so no server changes or extra API calls needed for direct deps
- **Broad detection** — covers all formats from [npm docs](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#git-urls-as-dependencies) including GitHub shorthand (`user/repo`)
- **`i-lucide:unlink` icon** — visually distinct from existing icons (circle-alert for outdated, lightbulb for replacement, shield-check for vulnerabilities, octagon-alert for deprecated)

## Live example

[react-native-gauge](https://npmx.dev/package/react-native-gauge) has a `github:` dependency that would be flagged.

## Test plan

- [ ] Verify warning icon appears on packages with URL dependencies (e.g. react-native-gauge)
- [ ] Verify tooltip text on hover
- [ ] Verify no icon appears for normal semver or npm: dependencies
- [ ] Verify icon appears in peer and optional dependency sections too
- [ ] Unit tests pass: `pnpm test -- --run test/unit/shared/utils/version-source.spec.ts`

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)