### PR TITLE
fix(i18n): allow translations for the recharging/vacation page

### DIFF
--- a/scripts/compare-translations.ts
+++ b/scripts/compare-translations.ts
@@ -407,9 +407,6 @@ const run = async (): Promise<void> => {
     lang: 'en',
   })
 
-  // TODO: removing vacations entry key for temporal recharging page
-  delete referenceContent.vacations
-
   // $schema is a JSON Schema reference, not a translation key
   delete referenceContent.$schema
 


### PR DESCRIPTION
### 🧭 Context

I [noticed](https://github.com/npmx-dev/npmx.dev/pull/2246/changes/5511c196da22a4d2455577659132e62d5f83837d) that the autofix CI always deletes the `vacation` section for the recharging page because we thought that it probably be deleted before the launch again.

### 📚 Description

This PR removes this deletion part in the compare translation script as I think we [decided](https://github.com/npmx-dev/npmx.dev/pull/1682#issuecomment-3974062145) that the recharging page will stay, so we should probably also allow translators to translate it 👍 
