### PR TITLE
perf: avoid creating Date objects when parsing timestamps

### DIFF
--- a/app/composables/npm/usePackage.ts
+++ b/app/composables/npm/usePackage.ts
@@ -37,7 +37,7 @@ export function transformPackument(
       const timeA = pkg.time[a]
       const timeB = pkg.time[b]
       if (!timeA || !timeB) return 0
-      return new Date(timeB).getTime() - new Date(timeA).getTime()
+      return Date.parse(timeB) - Date.parse(timeA)
     })
     .slice(0, RECENT_VERSIONS_COUNT)
 

--- a/app/composables/useStructuredFilters.ts
+++ b/app/composables/useStructuredFilters.ts
@@ -327,7 +327,7 @@ export function useStructuredFilters(options: UseStructuredFiltersOptions) {
         diff = (a.downloads?.weekly ?? 0) - (b.downloads?.weekly ?? 0)
         break
       case 'updated':
-        diff = new Date(a.package.date).getTime() - new Date(b.package.date).getTime()
+        diff = Date.parse(a.package.date) - Date.parse(b.package.date)
         break
       case 'name':
         diff = a.package.name.localeCompare(b.package.name)

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -234,7 +234,7 @@ const displayResults = computed(() => {
         diff = (a.downloads?.weekly ?? 0) - (b.downloads?.weekly ?? 0)
         break
       case 'updated':
-        diff = new Date(a.package.date).getTime() - new Date(b.package.date).getTime()
+        diff = Date.parse(a.package.date) - Date.parse(b.package.date)
         break
       case 'name':
         diff = a.package.name.localeCompare(b.package.name)

--- a/modules/blog.ts
+++ b/modules/blog.ts
@@ -138,7 +138,7 @@ async function loadBlogPosts(blogDir: string, imagesDir: string): Promise<BlogPo
   }
 
   // Sort newest first
-  posts.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+  posts.sort((a, b) => Date.parse(b.date) - Date.parse(a.date))
   return posts
 }
 

--- a/scripts/generate-fixtures.ts
+++ b/scripts/generate-fixtures.ts
@@ -183,7 +183,7 @@ function slimPackument(pkg: Record<string, unknown>): Record<string, unknown> {
       const timeA = time[a]
       const timeB = time[b]
       if (!timeA || !timeB) return 0
-      return new Date(timeB).getTime() - new Date(timeA).getTime()
+      return Date.parse(timeB) - Date.parse(timeA)
     })
     .slice(0, RECENT_VERSIONS_COUNT)
 

--- a/server/api/atproto/bluesky-comments.get.ts
+++ b/server/api/atproto/bluesky-comments.get.ts
@@ -132,7 +132,7 @@ function parseThread(
         if (parsed) replies.push(parsed)
       }
     }
-    replies.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+    replies.sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt))
   }
 
   return {

--- a/shared/utils/atproto.ts
+++ b/shared/utils/atproto.ts
@@ -15,7 +15,7 @@ const simpleHash = (str: string): number => {
 
 // Parse date from frontmatter, add slug-path entropy for same-date collision resolution
 export const generateBlogTID = (dateString: string, slug: string): string => {
-  let timestamp = new Date(dateString).getTime()
+  let timestamp = Date.parse(dateString)
 
   if (timestamp % ONE_DAY_MILLISECONDS === 0) {
     const offset = simpleHash(slug) % 1000000
@@ -28,4 +28,4 @@ export const generateBlogTID = (dateString: string, slug: string): string => {
 
 // Using our release date as the tid for the publication
 export const npmxPublicationRkey = () =>
-  TID.create(new Date('2026-03-03').getTime() * MS_TO_MICROSECONDS, TID_CLOCK_ID)
+  TID.create(Date.parse('2026-03-03') * MS_TO_MICROSECONDS, TID_CLOCK_ID)

--- a/test/nuxt/composables/use-package-comparison.spec.ts
+++ b/test/nuxt/composables/use-package-comparison.spec.ts
@@ -89,7 +89,7 @@ describe('usePackageComparison', () => {
 
       // Should use version-specific timestamp, NOT time.modified
       expect(values[0]!.display).toBe('2024-06-15T00:00:00.000Z')
-      expect(values[0]!.raw).toBe(new Date('2024-06-15T00:00:00.000Z').getTime())
+      expect(values[0]!.raw).toBe(Date.parse('2024-06-15T00:00:00.000Z'))
     })
 
     it('stores version-specific time in metadata', async () => {

--- a/test/unit/app/utils/download-anomalies.spec.ts
+++ b/test/unit/app/utils/download-anomalies.spec.ts
@@ -22,7 +22,7 @@ function month(monthStr: string, value: number): MonthlyDataPoint {
   return {
     value,
     month: monthStr,
-    timestamp: new Date(`${monthStr}-01T00:00:00Z`).getTime(),
+    timestamp: Date.parse(`${monthStr}-01T00:00:00Z`),
   }
 }
 
@@ -30,7 +30,7 @@ function year(yearStr: string, value: number): YearlyDataPoint {
   return {
     value,
     year: yearStr,
-    timestamp: new Date(`${yearStr}-01-01T00:00:00Z`).getTime(),
+    timestamp: Date.parse(`${yearStr}-01-01T00:00:00Z`),
   }
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Uses `Date.parse(...)` instead of `new Date(...).getTime()` when converting date strings to timestamps.

### 📚 Description

Uses `Date.parse(...)` instead of `new Date(...).getTime()` when converting date strings to timestamps. This avoids creating unnecessary Date objects while keeping the behavior the same for string-based parsing paths used in sorting, TID generation, and related tests.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
