### PR TITLE
chore: bump vue-data-ui from 3.16.0 to 3.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "vite-plugin-pwa": "1.2.0",
     "vite-plus": "0.1.12",
     "vue": "3.5.30",
-    "vue-data-ui": "3.16.0"
+    "vue-data-ui": "3.16.1"
   },
   "devDependencies": {
     "@e18e/eslint-plugin": "0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,8 +235,8 @@ importers:
         specifier: 3.5.30
         version: 3.5.30(typescript@6.0.2)
       vue-data-ui:
-        specifier: 3.16.0
-        version: 3.16.0(vue@3.5.30(typescript@6.0.2))
+        specifier: 3.16.1
+        version: 3.16.1(vue@3.5.30(typescript@6.0.2))
     devDependencies:
       '@e18e/eslint-plugin':
         specifier: 0.3.0
@@ -10590,8 +10590,8 @@ packages:
   vue-component-type-helpers@3.2.6:
     resolution: {integrity: sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==}
 
-  vue-data-ui@3.16.0:
-    resolution: {integrity: sha512-5f9mJi5vkC/48ntfBwxVG8AjuyZBf7nK9dzQDcL8L9xEFlRHuIrXB1YMt1qDQEWimcPSmWZ051KUQm/cSS3U5g==}
+  vue-data-ui@3.16.1:
+    resolution: {integrity: sha512-abJC3lSyikfD2y7sY61ZqKE2x5gPDtfsu/89oVndyVbk0ZaFQ4L6SCgPVlCPpFrNdfLRYM7KIYP+rseU5LHbYA==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -23380,7 +23380,7 @@ snapshots:
 
   vue-component-type-helpers@3.2.6: {}
 
-  vue-data-ui@3.16.0(vue@3.5.30(typescript@6.0.2)):
+  vue-data-ui@3.16.1(vue@3.5.30(typescript@6.0.2)):
     dependencies:
       vue: 3.5.30(typescript@6.0.2)
 


### PR DESCRIPTION
Resolves #2258 

- Bump vue-data-ui to 3.16.1 ([release notes](https://github.com/graphieros/vue-data-ui/releases/tag/v3.16.1))
  - Keyboard navigation on chart areas now initialises from the currently hovered datapoint instead of defaulting to the first index, which makes keyboard navigation more natural by continuing from where the user is already focused, when transitioning from mouse to keyboard.
  - Improve keyboard navigation of the built-in chart annotator's context menu and color picker