### PR TITLE
fix: add missing token to first-time contributor welcome workflow

### DIFF
--- a/.github/workflows/welcome-open.yml
+++ b/.github/workflows/welcome-open.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: zephyrproject-rtos/action-first-interaction@58853996b1ac504b8e0f6964301f369d2bb22e5c
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           pr-opened-message: |
             Hello! Thank you for opening your **first PR** to npmx, @${{ github.event.pull_request.user.login }}! 🚀
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A — discovered from a failing CI job on #2262

### 🧭 Context

The "Greet First-Time Contributors" workflow (added in #2236) fails on every new contributor's PR because a required action input is missing.

### 📚 Description

The `zephyrproject-rtos/action-first-interaction` action requires a `repo-token` input to authenticate with the GitHub API, but it wasn't being supplied. This adds `repo-token: ${{ secrets.GITHUB_TOKEN }}` to the workflow. The workflow already has `permissions: pull-requests: write` so no additional permission changes are needed.

Failing job: https://github.com/npmx-dev/npmx.dev/actions/runs/23489827599/job/68354800411?pr=2262