### PR TITLE
fix(a11y): use native checkboxes for compare facet selector

### DIFF
--- a/app/components/Compare/FacetSelector.vue
+++ b/app/components/Compare/FacetSelector.vue
@@ -23,6 +23,20 @@ function onFacetChange(facet: FacetInfoWithLabels) {
   toggleFacet(facet.id)
 }
 
+/** Visual variant for each facet chip (border/background/cursor). */
+function facetChipVariantClass(facet: FacetInfoWithLabels): string {
+  if (facet.comingSoon) {
+    return 'text-fg-subtle/50 bg-bg-subtle border-border-subtle cursor-not-allowed'
+  }
+  if (isFacetCheckboxDisabled(facet)) {
+    return 'text-fg-muted bg-bg-muted border-border opacity-90 cursor-not-allowed'
+  }
+  if (isFacetSelected(facet.id)) {
+    return 'text-fg-muted bg-bg-muted border-border cursor-pointer'
+  }
+  return 'text-fg-subtle bg-bg-subtle border-border-subtle hover:text-fg-muted hover:border-border cursor-pointer'
+}
+
 // Check if all non-comingSoon facets in a category are selected
 function isCategoryAllSelected(category: string): boolean {
   const facets = facetsByCategory.value[category] ?? []
@@ -84,15 +98,7 @@ function isCategoryNoneSelected(category: string): boolean {
           v-for="facet in facetsByCategory[category]"
           :key="facet.id"
           class="flex items-center gap-1.5 px-1.5 py-0.5 rounded border text-xs transition-colors focus-within:outline focus-within:outline-2 focus-within:outline-offset-1 focus-within:outline-accent/70"
-          :class="
-            facet.comingSoon
-              ? 'text-fg-subtle/50 bg-bg-subtle border-border-subtle cursor-not-allowed'
-              : isFacetCheckboxDisabled(facet)
-                ? 'text-fg-muted bg-bg-muted border-border opacity-90 cursor-not-allowed'
-                : isFacetSelected(facet.id)
-                  ? 'text-fg-muted bg-bg-muted border-border cursor-pointer'
-                  : 'text-fg-subtle bg-bg-subtle border-border-subtle hover:text-fg-muted hover:border-border cursor-pointer'
-          "
+          :class="facetChipVariantClass(facet)"
         >
           <input
             type="checkbox"

--- a/test/nuxt/components/compare/FacetSelector.spec.ts
+++ b/test/nuxt/components/compare/FacetSelector.spec.ts
@@ -41,7 +41,7 @@ const categoryLabels: Record<string, string> = {
   security: 'Security & Compliance',
 }
 
-const comingSoonFacetId = comingSoonFacets[0]
+const comingSoonFacetId: ComparisonFacet | undefined = comingSoonFacets.at(0)
 
 // Helper to build facet info with labels
 function buildFacetInfo(facet: ComparisonFacet) {
@@ -190,33 +190,35 @@ describe('FacetSelector', () => {
     })
   })
 
-  describe.runIf(hasComingSoonFacets)('comingSoon facets', () => {
-    it('disables comingSoon facets', async () => {
-      const component = await mountSuspended(FacetSelector)
+  describe.runIf(hasComingSoonFacets && comingSoonFacetId !== undefined)(
+    'comingSoon facets',
+    () => {
+      // runIf guarantees comingSoonFacetId is defined here
+      const facetId: ComparisonFacet = comingSoonFacetId!
 
-      const comingSoonInput = component.find(
-        `input[type="checkbox"][data-facet-id="${comingSoonFacetId}"]`,
-      )
-      expect(comingSoonInput.attributes('disabled')).toBeDefined()
-    })
+      it('disables comingSoon facets', async () => {
+        const component = await mountSuspended(FacetSelector)
 
-    it('shows coming soon text for comingSoon facets', async () => {
-      const component = await mountSuspended(FacetSelector)
+        const comingSoonInput = component.find(`input[type="checkbox"][data-facet-id="${facetId}"]`)
+        expect(comingSoonInput.attributes('disabled')).toBeDefined()
+      })
 
-      expect(component.text().toLowerCase()).toContain('coming soon')
-    })
+      it('shows coming soon text for comingSoon facets', async () => {
+        const component = await mountSuspended(FacetSelector)
 
-    it('does not call toggleFacet when comingSoon checkbox change is triggered', async () => {
-      const component = await mountSuspended(FacetSelector)
+        expect(component.text().toLowerCase()).toContain('coming soon')
+      })
 
-      const comingSoonInput = component.find(
-        `input[type="checkbox"][data-facet-id="${comingSoonFacetId}"]`,
-      )
-      await comingSoonInput.trigger('change')
+      it('does not call toggleFacet when comingSoon checkbox change is triggered', async () => {
+        const component = await mountSuspended(FacetSelector)
 
-      expect(mockToggleFacet).not.toHaveBeenCalledWith(comingSoonFacetId)
-    })
-  })
+        const comingSoonInput = component.find(`input[type="checkbox"][data-facet-id="${facetId}"]`)
+        await comingSoonInput.trigger('change')
+
+        expect(mockToggleFacet).not.toHaveBeenCalledWith(facetId)
+      })
+    },
+  )
 
   describe('category all/none buttons', () => {
     it('calls selectCategory when all button is clicked', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

No Issue Number , This PR was constructed to address a TODO comment in FacetSelector.vue

### 🧭 Context

On /compare, users choose which metrics appear in the table using the facet strip at the top. That strip was implemented as buttons with aria-pressed, which behaves like a custom toggle rather than a standard control. Screen readers and keyboard users generally get clearer, more predictable behavior from real checkboxes (with an associated label). The component already called this out in TODOs. This change implements those controls as native checkboxes while leaving selection logic, URL syncing, and rules unchanged (e.g. at least one facet must stay on, and “coming soon” options stay off).

### High Level Summary of Changes

Replaced facet row ButtonBase chips with a <label> + checkbox per metric, including disabled state when a facet is “coming soon” or when it’s the only selected facet (so the “≥ one metric” rule still holds).

Preserved existing category All / None actions and styling intent (chip-like borders/backgrounds, focus styles).
Updated FacetSelector.spec.ts to assert on checkboxes (data-facet-id, checked/disabled, change → toggleFacet) and removed an unused test helper.
Added aria-label on each category’s facet role="group" so the subgroup is named in the accessibility tree.


### 📚 Description

The facet strip on the compare page was using ButtonBase with aria-pressed to let users toggle metrics on and off. The visual design implied a checkbox group, but the semantics didn't back that up — screen readers and other assistive tech treat push-buttons differently from form controls, so the experience wasn't matching the mental model of "pick which rows to show."

- Swapped those out for a real <label> + <input type="checkbox"> per metric. The underlying behavior is all the same: 
(ex. useFacetSelection is untouched, selections still sync to the facets query param, etc...)

Tests are updated to reflect the new markup — data-facet-id, checked/disabled state, change handling — so any regressions in selection behavior will surface.

Better semantics, same behavior.

### Screenshot: Before/After UI Change:
Current Comparison UI:
<img width="870" height="1376" alt="Current UI" src="https://github.com/user-attachments/assets/346c4a33-d694-4a69-a737-bae81e6eaa72" />
After Selection Boxes Implemented:
<img width="906" height="1373" alt="SelectionBoxes" src="https://github.com/user-attachments/assets/6d345ec7-8880-4527-b21e-b2c8d399e8cd" />


<!----------------------------------------------------------------------
TODO: 
Scope: Only the per-facet controls were changed to native checkboxes. Category All / None are still ButtonBase with aria-pressed; the file still has a TODO about radios vs buttons there—that’s a possible follow-up, not part of this PR.

Visuals: Styling was kept close to the old chips (borders, backgrounds, focus ring). If design wants pixel-perfect parity or a denser row, that can be tweaked in a follow-up.
----------------------------------------------------------------------->
