### PR TITLE
fix: migrate live region to useAnnouncer 

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -136,6 +136,8 @@ if (import.meta.client) {
 
     <AppHeader :show-logo="!isHomepage" />
 
+    <NuxtAnnouncer />
+
     <NuxtRouteAnnouncer v-slot="{ message }">
       {{ route.name === 'search' ? `${$t('search.title_packages')} - npmx` : message }}
     </NuxtRouteAnnouncer>

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -283,6 +283,7 @@ async function loadMore() {
 }
 onBeforeUnmount(() => {
   updateUrlPage.cancel()
+  cancelPendingAnnouncements()
 })
 
 // Update URL when page changes from scrolling
@@ -584,94 +585,92 @@ defineOgImageComponent('Default', {
 })
 
 // -----------------------------------
-// Live region debouncing logic
+// Live region announcements
 // -----------------------------------
 const isMobile = useIsMobile()
+const { polite } = useAnnouncer()
 
-// Evaluate the text that should be announced to screen readers
-const rawLiveRegionMessage = computed(() => {
-  if (isRateLimited.value) {
-    return $t('search.rate_limited')
-  }
-
-  // If status is pending, no update phrase needed yet
-  if (status.value === 'pending') {
-    return ''
-  }
-
-  if (visibleResults.value && displayResults.value.length > 0) {
-    if (viewMode.value === 'table' || paginationMode.value === 'paginated') {
-      const pSize = Math.min(preferredPageSize.value, effectiveTotal.value)
-
-      return $t(
-        'filters.count.showing_paginated',
-        {
-          pageSize: pSize.toString(),
-          count: $n(effectiveTotal.value),
-        },
-        effectiveTotal.value,
-      )
-    }
-
-    if (isRelevanceSort.value) {
-      return $t(
-        'search.found_packages',
-        { count: $n(visibleResults.value.total) },
-        visibleResults.value.total,
-      )
-    }
-
-    return $t(
-      'search.found_packages_sorted',
-      { count: $n(effectiveTotal.value) },
-      effectiveTotal.value,
-    )
-  }
-
-  if (status.value === 'success' || status.value === 'error') {
-    if (displayResults.value.length === 0 && query.value) {
-      return $t('search.no_results', { query: query.value })
-    }
-  }
-
-  return ''
-})
-
-const debouncedLiveRegionMessage = ref('')
-
-const updateLiveRegionMobile = debounce((val: string) => {
-  debouncedLiveRegionMessage.value = val
-}, 700)
-
-const updateLiveRegionDesktop = debounce((val: string) => {
-  debouncedLiveRegionMessage.value = val
+const announcePoliteDesktop = debounce((message: string) => {
+  polite(message)
 }, 250)
 
+const announcePoliteMobile = debounce((message: string) => {
+  polite(message)
+}, 700)
+
+function announcePolite(message: string) {
+  if (isMobile.value) {
+    announcePoliteDesktop.cancel()
+    announcePoliteMobile(message)
+    return
+  }
+
+  announcePoliteMobile.cancel()
+  announcePoliteDesktop(message)
+}
+
+function cancelPendingAnnouncements() {
+  announcePoliteDesktop.cancel()
+  announcePoliteMobile.cancel()
+}
+
+// Announce search results changes to screen readers
 watch(
-  rawLiveRegionMessage,
-  newVal => {
-    if (!newVal) {
-      updateLiveRegionMobile.cancel()
-      updateLiveRegionDesktop.cancel()
-      debouncedLiveRegionMessage.value = ''
+  () => ({
+    rateLimited: isRateLimited.value,
+    searchStatus: status.value,
+    count: displayResults.value.length,
+    searchQuery: query.value,
+    mode: viewMode.value,
+    pagMode: paginationMode.value,
+    total: effectiveTotal.value,
+  }),
+  ({ rateLimited, searchStatus, count, searchQuery, mode, pagMode, total }) => {
+    if (rateLimited) {
+      announcePolite($t('search.rate_limited'))
       return
     }
 
-    if (isMobile.value) {
-      updateLiveRegionDesktop.cancel()
-      updateLiveRegionMobile(newVal)
-    } else {
-      updateLiveRegionMobile.cancel()
-      updateLiveRegionDesktop(newVal)
+    // Don't announce while searching
+    if (searchStatus === 'pending') {
+      cancelPendingAnnouncements()
+      return
+    }
+
+    if (count > 0) {
+      if (mode === 'table' || pagMode === 'paginated') {
+        const pSize = Math.min(preferredPageSize.value, total)
+
+        announcePolite(
+          $t(
+            'filters.count.showing_paginated',
+            {
+              pageSize: pSize.toString(),
+              count: $n(total),
+            },
+            total,
+          ),
+        )
+      } else if (isRelevanceSort.value) {
+        announcePolite(
+          $t(
+            'search.found_packages',
+            { count: $n(visibleResults.value?.total ?? 0) },
+            visibleResults.value?.total ?? 0,
+          ),
+        )
+      } else {
+        announcePolite($t('search.found_packages_sorted', { count: $n(total) }, total))
+      }
+    } else if (searchStatus === 'success' || searchStatus === 'error') {
+      if (searchQuery) {
+        announcePolite($t('search.no_results', { query: searchQuery }))
+      } else {
+        cancelPendingAnnouncements()
+      }
     }
   },
-  { immediate: true },
 )
-
-onBeforeUnmount(() => {
-  updateLiveRegionMobile.cancel()
-  updateLiveRegionDesktop.cancel()
-})
 </script>
 
 <template>
@@ -910,10 +909,6 @@ onBeforeUnmount(() => {
       :package-scope="packageScope"
       :can-publish-to-scope="canPublishToScope"
     />
-
-    <div role="status" class="sr-only">
-      {{ debouncedLiveRegionMessage }}
-    </div>
   </main>
 </template>
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

follow up #1812 

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->
https://github.com/nuxt/nuxt/pull/34318

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->

- Add `<NuxtAnnouncer />` global component 

#### Known issue: typed route type-checking after Nuxt 4.4 upgrade

After upgrading to Nuxt 4.4.2, `vue-tsc` reports many route param type errors (`string | string[] | undefined`) and typed-router related issues.

`@storybook-vue/nuxt@9.0.1` currently declares:
- peer `nuxt: ^3.13.0`
- dependency `vue-router: ^4.3.0`

while this repo is on:
- `nuxt: 4.4.2`
- `vue-router: 5.x` (typed pages enabled)

So the workspace ends up with mixed router majors (v4 + v5), which likely affects typed-router / volar behavior and amplifies route param typing issues.
