### PR TITLE
perf(ui): parallelize chunked chart download fetches

### DIFF
--- a/app/composables/useCharts.ts
+++ b/app/composables/useCharts.ts
@@ -6,6 +6,7 @@ import type {
   WeeklyDataPoint,
   YearlyDataPoint,
 } from '~/types/chart'
+import { mapWithConcurrency } from '#shared/utils/async'
 import { fetchNpmDownloadsRange } from '~/utils/npm/api'
 
 export type PackumentLikeForTime = {
@@ -256,12 +257,12 @@ async function fetchDailyRangeChunked(packageName: string, startIso: string, end
     return fetchDailyRangeCached(packageName, startIso, endIso)
   }
 
-  const all: DailyRawPoint[] = []
-
-  for (const range of ranges) {
-    const part = await fetchDailyRangeCached(packageName, range.startIso, range.endIso)
-    all.push(...part)
-  }
+  const parts = await mapWithConcurrency(
+    ranges,
+    range => fetchDailyRangeCached(packageName, range.startIso, range.endIso),
+    10,
+  )
+  const all = parts.flat()
 
   return mergeDailyPoints(all)
 }


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Longer date ranges and multi-package comparisons pay avoidable network round-trip time because each chunk waits for the previous one to finish. Parallelizing those chunk requests reduces end-to-end chart load time without changing the returned data shape.

### 📚 Description

This improves chart loading for large npm download date ranges by parallelizing chunked range fetches in `useCharts`.

Previously, requests larger than the npm downloads API window were split into multiple chunks and fetched sequentially, which made total latency roughly additive across chunks. This change keeps the existing chunking behavior but fetches chunks with bounded concurrency, then merges the results as before.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
