### PR TITLE
fix: set longer ttl for ungh

### DIFF
--- a/app/composables/useRepoMeta.ts
+++ b/app/composables/useRepoMeta.ts
@@ -3,6 +3,8 @@ import { parseRepoUrl, GITLAB_HOSTS } from '#shared/utils/git-providers'
 
 // TTL for git repo metadata (10 minutes - repo stats don't change frequently)
 const REPO_META_TTL = 60 * 10
+// Other TTLs for known sources
+const UNGH_REPO_META_TTL = 60 * 60 * 3 // 3 hours (ungh caches 6 hours server-side, but we run it half more frequently)
 
 export type RepoMetaLinks = {
   repo: string
@@ -134,7 +136,7 @@ const githubAdapter: ProviderAdapter = {
       const { data } = await cachedFetch<UnghRepoResponse>(
         `https://ungh.cc/repos/${ref.owner}/${ref.repo}`,
         { headers: { 'User-Agent': 'npmx', ...options.headers }, ...options },
-        REPO_META_TTL,
+        UNGH_REPO_META_TTL,
       )
       res = data
     } catch {


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### 🧭 Context

I talked with @pi0 recently and he mentioned having server load issues on ungh side, so maybe this PR helps

### 📚 Description

Currently, all repo metadata are fetched with a 10min cache from any sources. Since ungh caches server-side for 6 hours (actually 24 hours now temporarily but I'll take it as 6 for now), refetching every 10min is a bit unnecessary.

Taking 6 hours, I set to cache it for 3 hours so it at least has fresh-ish data when requested in between cache invalidation. I'm happy to change it to any number that we decide.

---

NOTE: Initially I wanted to update `cachedFetch` to respect `Cache-Control` etc, but it feels like a larger and complex task, so I'm doing this for now.