### PR TITLE
fix: resolve lint errors and type check failures

### DIFF
--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -1645,7 +1645,7 @@ const isSparklineLayout = computed({
       id-prefix="chart-layout"
       class="mt-4 mb-8"
     >
-      <TabList :aria-label="$t('package.trends.chart_view_toggle')">
+      <TabList :ariaLabel="$t('package.trends.chart_view_toggle')">
         <TabItem value="combined" tab-id="combined-chart-layout-tab" icon="i-lucide:chart-line">
           {{ $t('package.trends.chart_view_combined') }}
         </TabItem>

--- a/app/pages/compare.vue
+++ b/app/pages/compare.vue
@@ -280,7 +280,7 @@ useSeoMeta({
             id-prefix="comparison"
             class="mt-4"
           >
-            <TabList :aria-label="$t('compare.packages.section_comparison')">
+            <TabList :ariaLabel="$t('compare.packages.section_comparison')">
               <TabItem value="table" tab-id="comparison-tab-table" icon="i-lucide:table">
                 {{ $t('compare.packages.table_view') }}
               </TabItem>

--- a/server/utils/readme.ts
+++ b/server/utils/readme.ts
@@ -458,6 +458,17 @@ function renderFrontmatterTable(data: Record<string, unknown>): string {
   return `<table><thead><tr><th>Key</th><th>Value</th></tr></thead><tbody>\n${rows}\n</tbody></table>\n`
 }
 
+// Extract and preserve allowed attributes from HTML heading tags
+function extractHeadingAttrs(attrsString: string): string {
+  if (!attrsString) return ''
+  const preserved: string[] = []
+  const alignMatch = /\balign=(["']?)([^"'\s>]+)\1/i.exec(attrsString)
+  if (alignMatch?.[2]) {
+    preserved.push(`align="${alignMatch[2]}"`)
+  }
+  return preserved.length > 0 ? ` ${preserved.join(' ')}` : ''
+}
+
 export async function renderReadmeHtml(
   content: string,
   packageName: string,
@@ -528,17 +539,6 @@ export async function renderReadmeHtml(
     const plainText = getHeadingPlainText(displayHtml)
     const slugSource = getHeadingSlugSource(displayHtml)
     return processHeading(depth, displayHtml, plainText, slugSource)
-  }
-
-  // Extract and preserve allowed attributes from HTML heading tags
-  function extractHeadingAttrs(attrsString: string): string {
-    if (!attrsString) return ''
-    const preserved: string[] = []
-    const alignMatch = /\balign=(["']?)([^"'\s>]+)\1/i.exec(attrsString)
-    if (alignMatch?.[2]) {
-      preserved.push(`align="${alignMatch[2]}"`)
-    }
-    return preserved.length > 0 ? ` ${preserved.join(' ')}` : ''
   }
 
   // Intercept HTML headings so they get id, TOC entry, and correct semantic level.

--- a/test/nuxt/components/Tab.spec.ts
+++ b/test/nuxt/components/Tab.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { defineComponent, h, nextTick } from 'vue'
+import { defineComponent, h } from 'vue'
 import { TabRoot, TabList, TabItem, TabPanel } from '#components'
 
 function createTabsWrapper(props: { modelValue: string; idPrefix?: string }) {

--- a/test/unit/app/utils/versions.spec.ts
+++ b/test/unit/app/utils/versions.spec.ts
@@ -425,10 +425,11 @@ describe('isSameVersionGroup', () => {
   })
 })
 
+function row(version: string, tags: string[]) {
+  return { id: `version:${version}`, primaryTag: tags[0]!, tags, version }
+}
+
 describe('compareTagRows', () => {
-  function row(version: string, tags: string[]) {
-    return { id: `version:${version}`, primaryTag: tags[0]!, tags, version }
-  }
 
   it('sorts by tag priority ascending (rc before beta)', () => {
     const rc = row('2.0.0-rc.1', ['rc'])


### PR DESCRIPTION
## Summary
- Remove unused `nextTick` import from Tab.spec.ts
- Use camelCase `ariaLabel` prop in TabList template bindings to satisfy vue-tsc
- Move `extractHeadingAttrs` and `row` helpers to outer scope (lint warnings)

Fixes failing CI checks on #2273.