### PR TITLE
chore: add i18n redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -100,7 +100,7 @@
           "value": "i18n.npmx.dev"
         }
       ],
-      "destination": "https://npmx.dev/translation-status"
+      "destination": "https://main.npmx.dev/translation-status"
     }
   ]
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

this adds a redirect to our new i18n dashboard.

it won't do anything until we release to main, so I won't move the i18n.npmx.dev subdomain until then