### PR TITLE
fix: add spacing between tab toggle and comparison table

### DIFF
--- a/app/pages/compare.vue
+++ b/app/pages/compare.vue
@@ -295,7 +295,7 @@ useSeoMeta({
             <!-- Data table -->
             <TabPanel value="table" panel-id="comparison-panel-table">
               <!-- Desktop: Grid layout -->
-              <div class="hidden md:block overflow-x-auto">
+              <div class="hidden md:block overflow-x-auto mt-4">
                 <CompareComparisonGrid
                   :columns="gridColumns"
                   :show-no-dependency="showNoDependency"
@@ -315,7 +315,7 @@ useSeoMeta({
               </div>
 
               <!-- Mobile: Card-based layout -->
-              <div class="md:hidden space-y-3">
+              <div class="md:hidden space-y-3 mt-4">
                 <CompareFacetCard
                   v-for="facet in selectedFacets"
                   :key="facet.id"


### PR DESCRIPTION
<table>
<tr>
 <td>Before</td>
 <td>After</td>
<tr>
 <td><img width="836" height="545" alt="before" src="https://github.com/user-attachments/assets/95c90f1f-780b-4296-a515-42666e634420" /></td>
 <td><img width="836" height="545" alt="after" src="https://github.com/user-attachments/assets/e863e894-022a-4458-8198-d87682c8f586" /></td>
</table>
