### PR TITLE
perf: replace ISR with CDN cache for versioned code and docs routes

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -167,8 +167,12 @@ export default defineNuxtConfig({
     '/package/:org/:name/_payload.json': getISRConfig(60, { fallback: 'json' }),
     '/package/:org/:name/v/:version/_payload.json': getISRConfig(60, { fallback: 'json' }),
     // infinite cache (versioned - doesn't change)
-    '/package-code/**': { isr: true, cache: { maxAge: 365 * 24 * 60 * 60 } },
-    '/package-docs/**': { isr: true, cache: { maxAge: 365 * 24 * 60 * 60 } },
+    '/package-code/**': {
+      headers: { 'Cache-Control': 'public, s-maxage=31536000, stale-while-revalidate=31536000' },
+    },
+    '/package-docs/**': {
+      headers: { 'Cache-Control': 'public, s-maxage=31536000, stale-while-revalidate=31536000' },
+    },
     // static pages
     '/': { prerender: true },
     '/200.html': { prerender: true },


### PR DESCRIPTION
- Replace `isr: true` with `s-maxage` CDN cache headers on `/package-code/**` and `/package-docs/**`
- These routes serve immutable, versioned content (e.g. `/package-code/vue/v/3.4.0/src/index.ts`)
- ISR cache data shows 145:1 write-to-read byte ratio — >99% of durable storage entries are never read
- `/package-code/` alone accounts for ~81% of all ISR write units (6.4M/7.9M per 12h)
- Vercel CDN caches (`s-maxage`) are free and equivalent for immutable content
- API handler caching (`defineCachedEventHandler`) is unaffected

Expected impact: **~80% reduction in ISR write volume**

## What's lost

| Feature lost | Why acceptable |
|---|---|
| ISR durable storage fallback | 145:1 write:read ratio — barely used. CDN eviction → function re-renders (714ms P75). |
| Request collapsing | Millions of unique URLs → concurrent requests to same file are extremely rare. |
| Cache persistence across deploys | <1% of writes are ever read — deploy cold-cache has negligible impact. |