### PR TITLE
perf: increase ISR revalidation intervals for package and API routes

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -99,7 +99,7 @@ export default defineNuxtConfig({
 
   routeRules: {
     // API routes
-    '/api/**': { isr: 60 },
+    '/api/**': { isr: 300 },
     '/api/registry/badge/**': {
       isr: {
         expiration: 60 * 60 /* one hour */,
@@ -128,7 +128,7 @@ export default defineNuxtConfig({
     '/api/registry/package-meta/**': { isr: 300 },
     '/:pkg/.well-known/skills/**': { isr: 3600 },
     '/:scope/:pkg/.well-known/skills/**': { isr: 3600 },
-    '/__og-image__/**': getISRConfig(60),
+    '/__og-image__/**': getISRConfig(3600),
     '/_avatar/**': { isr: 3600, proxy: 'https://www.gravatar.com/avatar/**' },
     '/opensearch.xml': { isr: true },
     '/oauth-client-metadata.json': { prerender: true },
@@ -161,11 +161,11 @@ export default defineNuxtConfig({
       },
     },
     // pages
-    '/package/**': getISRConfig(60, { fallback: 'html' }),
-    '/package/:name/_payload.json': getISRConfig(60, { fallback: 'json' }),
-    '/package/:name/v/:version/_payload.json': getISRConfig(60, { fallback: 'json' }),
-    '/package/:org/:name/_payload.json': getISRConfig(60, { fallback: 'json' }),
-    '/package/:org/:name/v/:version/_payload.json': getISRConfig(60, { fallback: 'json' }),
+    '/package/**': getISRConfig(300, { fallback: 'html' }),
+    '/package/:name/_payload.json': getISRConfig(300, { fallback: 'json' }),
+    '/package/:name/v/:version/_payload.json': getISRConfig(300, { fallback: 'json' }),
+    '/package/:org/:name/_payload.json': getISRConfig(300, { fallback: 'json' }),
+    '/package/:org/:name/v/:version/_payload.json': getISRConfig(300, { fallback: 'json' }),
     // infinite cache (versioned - doesn't change)
     '/package-code/**': { isr: true, cache: { maxAge: 365 * 24 * 60 * 60 } },
     '/package-docs/**': { isr: true, cache: { maxAge: 365 * 24 * 60 * 60 } },


### PR DESCRIPTION
- `/api/**`: 60s → 300s
- `/__og-image__/**`: 60s → 3600s
- `/package/**` + payload routes: 60s → 300s

Current 60s ISR triggers background revalidation every minute for active URLs. Server-side data caches (package-meta: 300s, downloads: 3600s, files: 1y) outlive this — most revalidations produce identical HTML and the ISR write is skipped, but the function still executes on each cycle.

Aligning page ISR (300s) with the fastest handler cache eliminates redundant revalidation invocations. OG images set to 3600s (stable per package version). API catch-all set to 300s (explicit overrides unaffected).

Expected impact: **~80% fewer time-based revalidations, ~25-30% compute reduction**

## What the user experiences

Package page content may be up to 5 min stale (was 1 min). Since npm metadata changes on publish (typically days/weeks) and download counts aggregate daily, this is imperceptible.