### PR TITLE
fix(docs): update links to community projects in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ We welcome contributions &ndash; please do feel free to explore the project and 
 
 ## Related projects
 
-- [npmx-replace-extension](https://github.com/tylersayshi/npmx-replace-extension) &ndash; Browser extension to redirect npmjs.com to npmx.dev (Chrome only for now)
+- [npmx-redirect](https://github.com/iaverages/npmx-redirect) &ndash; Browser extension that automatically redirects npmjs.com URLs to npmx.dev.
 - [JSR](https://jsr.io/) &ndash; The open-source package registry for modern JavaScript and TypeScript
 - [npm-userscript](https://github.com/bluwy/npm-userscript) &ndash; Browser userscript with various improvements and fixes for npmjs.com
 - [npm-alt](https://npm.willow.sh/) &ndash; An alternative npm package browser
@@ -158,7 +158,6 @@ We welcome contributions &ndash; please do feel free to explore the project and 
 - [nxjt](https://nxjt.netlify.app) &ndash; npmx Jump To: Quickly navigate to npmx common webpages.
 - [npmx-weekly](https://npmx-weekly.trueberryless.org/) &ndash; A weekly newsletter for the npmx ecosystem. Add your own content via suggestions in the weekly PR on [GitHub](https://github.com/trueberryless-org/npmx-weekly/pulls?q=is%3Aopen+is%3Apr+label%3A%22%F0%9F%95%94+weekly+post%22).
 - [npmx-digest](https://npmx-digest.trueberryless.org/) &ndash; An automated news aggregation website that summarizes npmx activity from GitHub and Bluesky every 8 hours.
-- [npmx-redirect](https://github.com/iaverages/npmx-redirect) &ndash; Browser extension that automatically redirects npmjs.com URLs to npmx.dev.
 - [npmx-badge](https://npmx-badge.vercel.app/) &ndash; A playground to help you create custom badges quickly.
 
 If you're building something cool, let us know! 🙏


### PR DESCRIPTION
### 🧭 Context

the first redirect extension seems to be archived since March 19, 2026 and therefore, I would advise to link to the new extension which is already published in Chrome and Firefox as the first element in the last
