### PR TITLE
fix(i18n): add missing russian translations

### DIFF
--- a/i18n/locales/ru-RU.json
+++ b/i18n/locales/ru-RU.json
@@ -455,7 +455,7 @@
       "outdated_minor": "{count} минорная версия позади (последняя: {latest}) | {count} минорные версии позади (последняя: {latest}) | {count} минорных версий позади (последняя: {latest})",
       "outdated_patch": "Доступно патч-обновление (последняя: {latest})",
       "has_replacement": "Для этой зависимости есть рекомендуемые замены",
-      "vulnerabilities_count": "{count} уязвимость | {count} уязвимостей"
+      "vulnerabilities_count": "{count} уязвимость | {count} уязвимости | {count} уязвимостей"
     },
     "peer_dependencies": {
       "title": "Peer-зависимости ({count})",


### PR DESCRIPTION
### 🔗 Linked issue

None — this is a standalone localization sync (no open issue).

### 🧭 Context

`ru-RU.json` was missing many keys that already exist in `en.json`. Without them, the Russian UI could show untranslated keys or fall back to English for new surfaces (settings, package pages, shortcuts, docs, version history, forge links, accessibility strings, etc.).

### 📚 Description

- Adds Russian translations for newly introduced keys: navigation (`brand`), keyboard shortcuts (`open_main`, `open_diff`), settings (graph pulse loop, accent color names, background theme names, translation status), blog (`no_posts`), expanded `view_on.*` for additional forges, `collapse` / `expand`, package docs and link labels, version UI (filters, grouping help, page titles), dependency vulnerability plurals, maintainer template, trends chart assistive text, and related copy.
- Keeps placeholders and pluralization patterns aligned with the English source where applicable.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->