### PR TITLE
chore: bump vue-data-ui from 3.16.5 to 3.17.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "vite-plugin-pwa": "1.2.0",
     "vite-plus": "0.1.12",
     "vue": "3.5.30",
-    "vue-data-ui": "3.16.5"
+    "vue-data-ui": "3.17.1"
   },
   "devDependencies": {
     "@e18e/eslint-plugin": "0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,8 +235,8 @@ importers:
         specifier: 3.5.30
         version: 3.5.30(typescript@6.0.2)
       vue-data-ui:
-        specifier: 3.16.5
-        version: 3.16.5(vue@3.5.30(typescript@6.0.2))
+        specifier: 3.17.1
+        version: 3.17.1(vue@3.5.30(typescript@6.0.2))
     devDependencies:
       '@e18e/eslint-plugin':
         specifier: 0.3.0
@@ -10721,8 +10721,8 @@ packages:
   vue-component-type-helpers@3.2.6:
     resolution: {integrity: sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==}
 
-  vue-data-ui@3.16.5:
-    resolution: {integrity: sha512-m6q7vy/DWKZpiR1TOYbqNEYYTH1FEFkT0VgzZK3EZvJX7k+q3UMKMEO57lR5S6l9ETy+PDuJoR/7hg9SOcDJAw==}
+  vue-data-ui@3.17.1:
+    resolution: {integrity: sha512-MRSWzNXQQpfWQq5GMaxwNoOFYnHEj5sAui19HaA9rT5eHdgAAgwqJS1Gzx+7XBqNcYmW4MK/3qzX8KH0BbiiQQ==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -23600,7 +23600,7 @@ snapshots:
 
   vue-component-type-helpers@3.2.6: {}
 
-  vue-data-ui@3.16.5(vue@3.5.30(typescript@6.0.2)):
+  vue-data-ui@3.17.1(vue@3.5.30(typescript@6.0.2)):
     dependencies:
       vue: 3.5.30(typescript@6.0.2)
 


### PR DESCRIPTION
This update fixes an issue in the chart's minimap in Firefox (range handles were not draggable).
[Release notes](https://github.com/graphieros/vue-data-ui/releases/tag/v3.17.1)