### PR TITLE
feat: add package access/collaborators page

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ What npmx offers:
 - **Version range resolution** &ndash; dependency ranges (e.g., `^1.0.0`) resolve to actual installed versions
 - **Claim new packages** &ndash; register new package names directly from search results (via local connector)
 - **Clickable version tags** &ndash; navigate directly to any version from the versions list
+- **Package access management** &ndash; view and manage team/collaborator access for scoped packages (via local connector)
 
 ### User & org pages
 
@@ -91,7 +92,7 @@ What npmx offers:
 | Multi-provider repo support    |    ❌     |    ✅    |
 | Version range resolution       |    ❌     |    ✅    |
 | Dependents list                |    ✅     |    🚧    |
-| Package admin (access/owners)  |    ✅     |    🚧    |
+| Package admin (access/owners)  |    ✅     |    ✅    |
 | Org/team management            |    ✅     |    🚧    |
 | 2FA/account settings           |    ✅     |    ❌    |
 | Claim new package names        |    ✅     |    ✅    |
@@ -118,8 +119,6 @@ npmx.dev supports npm permalinks &ndash; just replace `npmjs.com` with `npmx.dev
 
 #### Not yet supported
 
-- `/package/<name>/access` &ndash; package access settings
-- `/package/<name>/dependents` &ndash; dependent packages list
 - `/settings/*` &ndash; account settings pages
 
 ### Simpler URLs

--- a/app/components/Package/Header.vue
+++ b/app/components/Package/Header.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
   latestVersion?: SlimVersion | null
   provenanceData?: ProvenanceDetails | null
   provenanceStatus?: string | null
-  page: 'main' | 'docs' | 'code' | 'diff'
+  page: 'main' | 'docs' | 'code' | 'diff' | 'access'
   versionUrlPattern: string
 }>()
 
@@ -106,6 +106,18 @@ const mainLink = computed((): RouteLocationRaw | null => {
     return null
   }
   return packageRoute(props.pkg.name, props.resolvedVersion)
+})
+
+const accessLink = computed((): RouteLocationRaw | null => {
+  if (props.pkg == null) return null
+  const split = props.pkg.name.split('/')
+  return {
+    name: 'package-access',
+    params: {
+      org: split.length === 2 ? split[0] : undefined,
+      name: split.length === 2 ? split[1]! : split[0]!,
+    },
+  }
 })
 
 const diffLink = computed((): RouteLocationRaw | null => {
@@ -342,6 +354,14 @@ const fundingUrl = computed(() => {
           :class="page === 'diff' ? 'border-accent text-accent!' : 'border-transparent'"
         >
           {{ $t('compare.compare_versions') }}
+        </LinkBase>
+        <LinkBase
+          v-if="accessLink"
+          :to="accessLink"
+          class="decoration-none border-b-2 p-1 hover:border-accent/50 focus-visible:[outline-offset:-2px]!"
+          :class="page === 'access' ? 'border-accent text-accent!' : 'border-transparent'"
+        >
+          {{ $t('package.links.access') }}
         </LinkBase>
       </nav>
     </div>

--- a/app/pages/package/[[org]]/[name]/access.vue
+++ b/app/pages/package/[[org]]/[name]/access.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+definePageMeta({
+  name: 'package-access',
+  scrollMargin: 200,
+})
+
+const route = useRoute('package-access')
+
+const packageName = computed(() => {
+  const { org, name } = route.params
+  return org ? `${org}/${name}` : name
+})
+
+const { data: pkg } = usePackage(packageName)
+
+const resolvedVersion = computed(() => {
+  const latest = pkg.value?.['dist-tags']?.latest
+  if (!latest) return null
+  return latest
+})
+
+const displayVersion = computed(() => pkg.value?.requestedVersion ?? null)
+
+const latestVersion = computed(() => {
+  if (!pkg.value) return null
+  const latestTag = pkg.value['dist-tags']?.latest
+  if (!latestTag) return null
+  return pkg.value.versions[latestTag] ?? null
+})
+
+const versionUrlPattern = computed(() => {
+  const split = packageName.value.split('/')
+  if (split.length === 2) {
+    return `/package/${split[0]}/${split[1]}/v/{version}`
+  }
+  return `/package/${packageName.value}/v/{version}`
+})
+
+const { isConnected } = useConnector()
+const connectorModal = import.meta.client ? useModal('connector-modal') : null
+
+useSeoMeta({
+  title: () => `Access - ${packageName.value} - npmx`,
+  description: () => `Manage access and collaborators for ${packageName.value}`,
+})
+</script>
+
+<template>
+  <main class="flex-1 pb-8">
+    <PackageHeader
+      :pkg="pkg ?? null"
+      :resolved-version="resolvedVersion"
+      :display-version="displayVersion"
+      :latest-version="latestVersion"
+      :version-url-pattern="versionUrlPattern"
+      page="access"
+    />
+
+    <div class="container py-6">
+      <h1 class="font-mono text-xl font-semibold mb-1">
+        {{ $t('package.access.page_title') }}
+      </h1>
+      <p class="text-sm text-fg-muted mb-6">
+        {{ $t('package.access.page_subtitle', { name: packageName }) }}
+      </p>
+
+      <ClientOnly>
+        <template v-if="isConnected">
+          <PackageAccessControls :package-name="packageName" />
+        </template>
+        <template v-else>
+          <div class="py-12 text-center">
+            <span class="i-lucide:lock w-12 h-12 mx-auto mb-4 text-fg-subtle block" />
+            <p class="text-fg-muted mb-2 font-medium">
+              {{ $t('package.access.connect_required') }}
+            </p>
+            <p class="text-sm text-fg-subtle mb-6">
+              {{ $t('package.access.connect_hint') }}
+            </p>
+            <ButtonBase variant="primary" @click="connectorModal?.open()">
+              {{ $t('connector.modal.connect') }}
+            </ButtonBase>
+          </div>
+        </template>
+        <template #fallback>
+          <div class="space-y-4">
+            <SkeletonInline v-for="i in 4" :key="i" class="h-12 w-full rounded-md" />
+          </div>
+        </template>
+      </ClientOnly>
+    </div>
+  </main>
+</template>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -318,7 +318,8 @@
       "docs": "docs",
       "fund": "fund",
       "compare": "compare",
-      "compare_this_package": "compare this package"
+      "compare_this_package": "compare this package",
+      "access": "access"
     },
     "likes": {
       "like": "Like this package",
@@ -587,6 +588,10 @@
       "show_all": "show {count} deprecated package | show all {count} deprecated packages"
     },
     "access": {
+      "page_title": "Access & Collaborators",
+      "page_subtitle": "Manage team and collaborator access for {name}",
+      "connect_required": "Connect your npm CLI to manage access",
+      "connect_hint": "Use the local connector to view and manage package collaborators and team access.",
       "title": "Team Access",
       "refresh": "Refresh team access",
       "list_label": "Team access list",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -960,6 +960,9 @@
             },
             "compare_this_package": {
               "type": "string"
+            },
+            "access": {
+              "type": "string"
             }
           },
           "additionalProperties": false
@@ -1765,6 +1768,18 @@
         "access": {
           "type": "object",
           "properties": {
+            "page_title": {
+              "type": "string"
+            },
+            "page_subtitle": {
+              "type": "string"
+            },
+            "connect_required": {
+              "type": "string"
+            },
+            "connect_hint": {
+              "type": "string"
+            },
             "title": {
               "type": "string"
             },


### PR DESCRIPTION
Adds a dedicated `/package/<name>/access` page for managing team and collaborator access.

Previously the `AccessControls` component was only reachable via the sidebar on the main package page. This gives it a proper URL, tab in the nav, and a connect prompt for users who haven't set up the local connector yet.

## What changed

- **Page** — `app/pages/package/[[org]]/[name]/access.vue` wrapping the existing `PackageAccessControls` component
- **Header tab** — "access" tab added to the package navigation bar
- **Connect prompt** — shown when the npm connector isn't running, with a button to open the connector modal
- **i18n** — page title, subtitle, and connect prompt strings
- **README** — package admin marked as implemented, removed from "Not yet supported" URL list

## Test

Visit `/package/@nuxt/kit/access` with the local connector running — should show current collaborators and team access. Without the connector, shows a prompt to connect.