### PR TITLE
fix: typo in chart config attribute

### DIFF
--- a/app/components/Compare/FacetBarChart.vue
+++ b/app/components/Compare/FacetBarChart.vue
@@ -131,7 +131,7 @@ const config = computed<VueUiHorizontalBarConfig>(() => {
         csv: false,
         altCopy: true,
       },
-      buttonTitle: {
+      buttonTitles: {
         img: $t('package.trends.download_file', { fileType: 'PNG' }),
         svg: $t('package.trends.download_file', { fileType: 'SVG' }),
         altCopy: $t('package.trends.copy_alt.button_label'),


### PR DESCRIPTION
Resolves #2327 

An attribute was misspelled in FacetBarChart.vue's configuration object, silently ignored because the type is very permissive.