### PR TITLE
fix: relax devtools-specific security headers in dev

### DIFF
--- a/modules/security-headers.ts
+++ b/modules/security-headers.ts
@@ -24,10 +24,10 @@ export default defineNuxtModule({
     const devtools = nuxt.options.devtools
 
     const isDevtoolsRuntime =
-      nuxt.options.dev
-      && devtools !== false
-      && (devtools == null || typeof devtools !== 'object' || devtools.enabled !== false)
-      && !process.env.TEST
+      nuxt.options.dev &&
+      devtools !== false &&
+      (devtools == null || typeof devtools !== 'object' || devtools.enabled !== false) &&
+      !process.env.TEST
 
     // These assets are embedded directly on blog pages and should not affect image-proxy trust.
     const cspOnlyImgOrigins = ['https://api.star-history.com', 'https://cdn.bsky.app']
@@ -99,8 +99,7 @@ export default defineNuxtModule({
       },
     }
 
-    if (!isDevtoolsRuntime)
-      return
+    if (!isDevtoolsRuntime) return
 
     const devtoolsRule = nuxt.options.routeRules['/__nuxt_devtools__/**']
     nuxt.options.routeRules['/__nuxt_devtools__/**'] = {

--- a/test/unit/modules/security-headers.spec.ts
+++ b/test/unit/modules/security-headers.spec.ts
@@ -42,9 +42,8 @@ function createNuxt(options: Partial<MockNuxt['options']> = {}): MockNuxt {
 }
 
 function getCsp(nuxt: MockNuxt) {
-  return nuxt.options.app.head?.meta?.find(
-    meta => meta['http-equiv'] === 'Content-Security-Policy',
-  )?.content
+  return nuxt.options.app.head?.meta?.find(meta => meta['http-equiv'] === 'Content-Security-Policy')
+    ?.content
 }
 
 describe('security headers module', () => {
@@ -79,12 +78,14 @@ describe('security headers module', () => {
 
     expect(csp).toContain('ws://localhost:*')
     expect(csp).toContain("frame-src https://bsky.app https://pdsmoover.com 'self'")
-    expect(nuxt.options.routeRules['/**']?.headers).toEqual(expect.objectContaining({
-      'Permissions-Policy': 'camera=()',
-      'Referrer-Policy': 'strict-origin-when-cross-origin',
-      'X-Content-Type-Options': 'nosniff',
-      'X-Frame-Options': 'DENY',
-    }))
+    expect(nuxt.options.routeRules['/**']?.headers).toEqual(
+      expect.objectContaining({
+        'Permissions-Policy': 'camera=()',
+        'Referrer-Policy': 'strict-origin-when-cross-origin',
+        'X-Content-Type-Options': 'nosniff',
+        'X-Frame-Options': 'DENY',
+      }),
+    )
     expect(nuxt.options.routeRules['/__nuxt_devtools__/**']).toEqual({
       headers: {
         'Cache-Control': 'no-store',


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

Nuxt DevTools relies on a same-origin iframe and dev-only runtime connections, which were being blocked by our CSP and frame restrictions during development.

Instead of disabling `security-headers` entirely in dev, this change keeps the existing security headers in place and only relaxes the DevTools-specific parts needed for the local dev runtime.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->

This PR updates `security-headers` so that:

- DevTools-only CSP requirements are allowed in dev
- the DevTools route uses `SAMEORIGIN` instead of `DENY`
- DevTools-specific relaxations are not applied when DevTools is explicitly disabled
