### PR TITLE
feat: add logo to OAuth metadata

### DIFF
--- a/server/utils/atproto/oauth.ts
+++ b/server/utils/atproto/oauth.ts
@@ -41,11 +41,11 @@ export function getOauthClientMetadata(pkAlg: string | undefined = undefined): O
     ? webUriSchema.parse(`${clientUri}/.well-known/jwks.json`)
     : undefined
 
-  // If anything changes here, please make sure to also update /shared/schemas/oauth.ts to match
   return {
     client_name: 'npmx.dev',
     client_id,
     client_uri: clientUri,
+    logo_uri: webUriSchema.parse(`${clientUri}/logo-icon.svg`),
     scope,
     redirect_uris: [redirect_uri],
     grant_types: ['authorization_code', 'refresh_token'],


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

When I go in my PDS's account management and look at the connected apps, npmx.dev has no logo. For comparison, PDSls has one:
<img width="922" height="380" alt="image" src="https://github.com/user-attachments/assets/c8824b13-68b0-436d-bb96-4ec20f51fb82" />

(npmx is missing in the screenshot because right now I'm getting error 401 when trying to log in)

The difference seems to be that https://pdsls.dev/oauth-client-metadata.json links to a logo while https://npmx.dev/oauth-client-metadata.json does not.

### 📚 Description

This PR adds a logo_uri set to npmx.dev/logo.svg. I'm not 100% sure that SVG is a supported format and I don't know how to test it, I guess if we merge and it does not work then we switch to .ico like PDSls? :sweat_smile: 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
