### PR TITLE
refactor: replace fileURLToPath with import.meta.dirname

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,5 @@
 import process from 'node:process'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { defineConfig, devices } from '@playwright/test'
 import type { ConfigOptions } from '@nuxt/test-utils/playwright'
 
@@ -19,14 +19,14 @@ export default defineConfig<ConfigOptions>({
     timeout: 60_000,
   },
   // Start/stop mock connector server before/after all tests (teardown via returned closure)
-  globalSetup: fileURLToPath(new URL('./test/e2e/global-setup.ts', import.meta.url)),
+  globalSetup: join(import.meta.dirname, 'test/e2e/global-setup.ts'),
   // We currently only test on one browser on one platform
   snapshotPathTemplate: '{snapshotDir}/{testFileDir}/{testFileName}-snapshots/{arg}{ext}',
   use: {
     baseURL,
     trace: 'on-first-retry',
     nuxt: {
-      rootDir: fileURLToPath(new URL('.', import.meta.url)),
+      rootDir: import.meta.dirname,
       host: baseURL,
     },
   },

--- a/scripts/compare-translations.ts
+++ b/scripts/compare-translations.ts
@@ -3,12 +3,11 @@ import type { LocaleObject } from '@nuxtjs/i18n'
 import * as process from 'node:process'
 import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { basename, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { deepCopy } from '@intlify/shared'
 import { countryLocaleVariants, currentLocales } from '../config/i18n.ts'
 import { COLORS } from './utils.ts'
 
-const LOCALES_DIRECTORY = fileURLToPath(new URL('../i18n/locales', import.meta.url))
+const LOCALES_DIRECTORY = join(import.meta.dirname, '../i18n/locales')
 const REFERENCE_FILE_NAME = 'en.json'
 
 type NestedObject = { [key: string]: unknown }

--- a/scripts/find-invalid-translations.ts
+++ b/scripts/find-invalid-translations.ts
@@ -1,10 +1,9 @@
 /* eslint-disable no-console */
 import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { createI18NReport, type I18NItem } from 'vue-i18n-extract'
 import { colors } from './utils/colors.ts'
 
-const LOCALES_DIRECTORY = fileURLToPath(new URL('../i18n/locales', import.meta.url))
+const LOCALES_DIRECTORY = join(import.meta.dirname, '../i18n/locales')
 const REFERENCE_FILE_NAME = 'en.json'
 const VUE_FILES_GLOB = './app/**/*.?(vue|ts|js)'
 

--- a/scripts/generate-fixtures.ts
+++ b/scripts/generate-fixtures.ts
@@ -12,9 +12,8 @@
 
 import { writeFileSync, mkdirSync, existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 
-const FIXTURES_DIR = fileURLToPath(new URL('../test/fixtures', import.meta.url))
+const FIXTURES_DIR = join(import.meta.dirname, '../test/fixtures')
 
 const NPM_REGISTRY = 'https://registry.npmjs.org'
 const NPM_API = 'https://api.npmjs.org'

--- a/scripts/generate-i18n-schema.ts
+++ b/scripts/generate-i18n-schema.ts
@@ -1,10 +1,9 @@
 /* oxlint-disable no-console */
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { colors } from './utils/colors.ts'
 
-const I18N_DIRECTORY = fileURLToPath(new URL('../i18n', import.meta.url))
+const I18N_DIRECTORY = join(import.meta.dirname, '../i18n')
 const LOCALES_DIRECTORY = join(I18N_DIRECTORY, 'locales')
 const REFERENCE_FILE_NAME = 'en.json'
 const SCHEMA_FILE_NAME = 'schema.json'

--- a/scripts/remove-unused-translations.ts
+++ b/scripts/remove-unused-translations.ts
@@ -1,11 +1,10 @@
 /* eslint-disable no-console */
 import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { createI18NReport, type I18NItem } from 'vue-i18n-extract'
 import { colors } from './utils/colors.ts'
 import { readdir, readFile, writeFile } from 'node:fs/promises'
 
-const LOCALES_DIRECTORY = fileURLToPath(new URL('../i18n/locales', import.meta.url))
+const LOCALES_DIRECTORY = join(import.meta.dirname, '../i18n/locales')
 const REFERENCE_FILE_NAME = 'en.json'
 const VUE_FILES_GLOB = './app/**/*.?(vue|ts|js)'
 

--- a/scripts/unocss-checker.ts
+++ b/scripts/unocss-checker.ts
@@ -1,6 +1,5 @@
 import type { Dirent } from 'node:fs'
 import { glob, readFile } from 'node:fs/promises'
-import { fileURLToPath } from 'node:url'
 import { resolve } from 'node:path'
 import { createGenerator } from 'unocss'
 import { presetRtl } from '../uno-preset-rtl.ts'
@@ -9,7 +8,7 @@ import { COLORS } from './utils.ts'
 import { presetWind4 } from 'unocss'
 
 const argvFiles = process.argv.slice(2)
-const APP_DIRECTORY = fileURLToPath(new URL('../app', import.meta.url))
+const APP_DIRECTORY = resolve(import.meta.dirname, '../app')
 
 async function checkFile(path: Dirent): Promise<string | undefined> {
   if (path.isDirectory() || !path.name.endsWith('.vue')) {

--- a/test/unit/a11y-component-coverage.spec.ts
+++ b/test/unit/a11y-component-coverage.spec.ts
@@ -11,7 +11,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { assert, describe, it } from 'vitest'
-import { fileURLToPath } from 'node:url'
 
 /**
  * Components explicitly skipped from a11y testing with reasons.
@@ -152,9 +151,9 @@ function getTestedComponents(
 }
 
 describe('a11y component test coverage', () => {
-  const componentsDir = fileURLToPath(new URL('../../app/components', import.meta.url))
-  const componentsDtsPath = fileURLToPath(new URL('../../.nuxt/components.d.ts', import.meta.url))
-  const testFilePath = fileURLToPath(new URL('../nuxt/a11y.spec.ts', import.meta.url))
+  const componentsDir = path.join(import.meta.dirname, '../../app/components')
+  const componentsDtsPath = path.join(import.meta.dirname, '../../.nuxt/components.d.ts')
+  const testFilePath = path.join(import.meta.dirname, '../nuxt/a11y.spec.ts')
 
   it('should have accessibility tests for all components (or be explicitly skipped)', () => {
     // Get all Vue components

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,8 @@
-import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite-plus'
 import { defineVitestProject } from '@nuxt/test-utils/config'
 import { playwright } from 'vite-plus/test/browser-playwright'
 
-const rootDir = fileURLToPath(new URL('.', import.meta.url))
+const rootDir = import.meta.dirname
 
 export default defineConfig({
   run: {
@@ -187,7 +186,7 @@ export default defineConfig({
             environment: 'nuxt',
             environmentOptions: {
               nuxt: {
-                rootDir: fileURLToPath(new URL('.', import.meta.url)),
+                rootDir,
                 overrides: {
                   vue: {
                     runtimeCompiler: true,


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

The codebase still had several module-relative filesystem paths built with `fileURLToPath(new URL(..., import.meta.url))`. Since the project now targets Node.js 24.x, we can use `import.meta.dirname` directly for these filesystem path constants and simplify that pattern across scripts, config, and tests.

### 📚 Description

This PR replaces module-relative path constants based on `fileURLToPath(new URL(...))` with `import.meta.dirname`-based path construction where the code is resolving local filesystem paths.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
