### PR TITLE
feat: add link to `socket.dev`

### DIFF
--- a/app/components/Package/ExternalLinks.vue
+++ b/app/components/Package/ExternalLinks.vue
@@ -177,6 +177,7 @@ useCommandPaletteContextCommands(
       <LinkBase
         :to="`https://socket.dev/npm/package/${pkg.name}`"
         :title="$t('common.view_on.socket_dev')"
+        classicon="i-simple-icons:socket"
       >
         socket.dev
       </LinkBase>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -336,6 +336,7 @@
       "gitea": "View on Gitea",
       "gitee": "View on Gitee",
       "radicle": "View on Radicle",
+      "socket_dev": "view on socket.dev",
       "sourcehut": "View on SourceHut",
       "tangled": "View on Tangled"
     },

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -1012,6 +1012,9 @@
             "radicle": {
               "type": "string"
             },
+            "socket_dev": {
+              "type": "string"
+            },
             "sourcehut": {
               "type": "string"
             },


### PR DESCRIPTION
### 🔗 Linked issue

Closes #2369 


### 🧭 Context

Similar to what `npmjs` has

<img width="385" height="55" alt="image" src="https://github.com/user-attachments/assets/9ad5d71f-3728-4d45-a163-7dec6e9ae2ed" />


### 📚 Description

Adds link to `socket.dev`
