### PR TITLE
fix: set `codeContainerFull` to `true` by default

### DIFF
--- a/app/composables/useSettings.ts
+++ b/app/composables/useSettings.ts
@@ -38,7 +38,8 @@ export interface AppSettings {
     /** Automatically open the web auth page in the browser */
     autoOpenURL: boolean
   }
-  codeContainerFull: boolean
+  /** Container width on code page */
+  codeContainerFull: true
   sidebar: {
     collapsed: string[]
   }

--- a/app/composables/useSettings.ts
+++ b/app/composables/useSettings.ts
@@ -39,7 +39,7 @@ export interface AppSettings {
     autoOpenURL: boolean
   }
   /** Container width on code page */
-  codeContainerFull: true
+  codeContainerFull: boolean
   sidebar: {
     collapsed: string[]
   }
@@ -65,7 +65,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   connector: {
     autoOpenURL: false,
   },
-  codeContainerFull: false,
+  codeContainerFull: true,
   sidebar: {
     collapsed: [],
   },

--- a/app/pages/package-code/[[org]]/[packageName]/v/[version]/[...filePath].vue
+++ b/app/pages/package-code/[[org]]/[packageName]/v/[version]/[...filePath].vue
@@ -292,7 +292,7 @@ onPrehydrate(el => {
   const settingsSaved = JSON.parse(localStorage.getItem('npmx-settings') || '{}')
   const container = el.querySelector('#code-page-container')
 
-  if (settingsSaved?.codeContainerFull === true && container) {
+  if (settingsSaved?.codeContainerFull !== false && container) {
     container.classList.add('container-full')
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->


### 🧭 Context

I think most who look at code page often would prefer the container to have full width


### 📚 Description

set `codeContainerFull` to `true` by default
