### PR TITLE
fix: skip emoji conversion inside code blocks

### DIFF
--- a/shared/utils/emoji.ts
+++ b/shared/utils/emoji.ts
@@ -1905,15 +1905,16 @@ const emojis = {
   'wales': '🏴󠁧󠁢󠁷󠁬󠁳󠁿',
 }
 
-const emojisKeysRegex = new RegExp(
-  Object.keys(emojis)
-    .map(key => `:${key}:`)
-    .join('|'),
-  'g',
-)
-export function convertToEmoji(text: string): string {
-  return text.replace(emojisKeysRegex, match => {
-    const key = match.slice(1, -1) as keyof typeof emojis
-    return emojis[key] || match
-  })
+export function convertToEmoji(html: string): string {
+  return html.replace(
+    /(<code[\s>][\s\S]*?<\/code>|<pre[\s>][\s\S]*?<\/pre>)|(:[\w+-]+:)/gi,
+    (match, codeBlock: string | undefined, shortcode: string | undefined) => {
+      if (codeBlock) return codeBlock
+      if (shortcode) {
+        const key = shortcode.slice(1, -1) as keyof typeof emojis
+        return emojis[key] || shortcode
+      }
+      return match
+    },
+  )
 }


### PR DESCRIPTION
### 🔗 Linked issue
Fixes #2364

### 🧭 Context
Emoji shortcodes like `:1234:` were being converted even inside code blocks in package READMEs.

### 📚 Description
`convertToEmoji` was running against the full HTML string, so `:1234:` in IPv6 addresses inside `<code>` and `<pre>` tags got turned into 🔢. Updated the function to match code/pre blocks first and skip them, only converting shortcodes in the rest of the content. Removed the now-unused `emojisKeysRegex` variable.