### PR TITLE
refactor: use timers/promises setTimeout for async delays

### DIFF
--- a/server/api/github/contributors-evolution/[owner]/[repo].get.ts
+++ b/server/api/github/contributors-evolution/[owner]/[repo].get.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises'
 import { CACHE_MAX_AGE_ONE_DAY } from '#shared/utils/constants'
 
 type GitHubContributorWeek = {
@@ -11,8 +12,6 @@ type GitHubContributorStats = {
   total: number
   weeks: GitHubContributorWeek[]
 }
-
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 export default defineCachedEventHandler(
   async event => {
@@ -50,7 +49,7 @@ export default defineCachedEventHandler(
 
         if (status === 202) {
           if (attempt === maxAttempts - 1) return []
-          await sleep(delayMs)
+          await setTimeout(delayMs)
           delayMs = Math.min(delayMs * 2, 16_000)
           continue
         }

--- a/server/utils/atproto/lock.ts
+++ b/server/utils/atproto/lock.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises'
 import type { RuntimeLock } from '@atproto/oauth-client-node'
 import { requestLocalLock } from '@atproto/oauth-client-node'
 import { Redis } from '@upstash/redis'
@@ -22,7 +23,7 @@ function createUpstashLock(redis: Redis): RuntimeLock {
 
     if (!acquired) {
       // Another instance holds the lock, wait briefly and retry once
-      await new Promise(resolve => setTimeout(resolve, 100))
+      await setTimeout(100)
       const retryAcquired = await redis.set(lockKey, lockValue, {
         nx: true,
         ex: lockTTL,

--- a/test/unit/server/utils/atproto/lock.spec.ts
+++ b/test/unit/server/utils/atproto/lock.spec.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 const mockRedisSet = vi.fn()
@@ -145,7 +146,7 @@ describe('lock', () => {
 
     const lock = getUpstashLock()
     const result = await lock('async-key', async () => {
-      await new Promise(resolve => setTimeout(resolve, 10))
+      await setTimeout(10)
       return 'async-result'
     })
 

--- a/test/unit/shared/utils/async.spec.ts
+++ b/test/unit/shared/utils/async.spec.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises'
 import { describe, expect, it, vi } from 'vitest'
 import * as fc from 'fast-check'
 import { mapWithConcurrency } from '#shared/utils/async'
@@ -21,7 +22,7 @@ describe('mapWithConcurrency', () => {
       async () => {
         concurrent++
         maxConcurrent = Math.max(maxConcurrent, concurrent)
-        await new Promise(resolve => setTimeout(resolve, 10))
+        await setTimeout(10)
         concurrent--
       },
       3,
@@ -66,7 +67,7 @@ describe('mapWithConcurrency', () => {
     await mapWithConcurrency(items, async () => {
       concurrent++
       maxConcurrent = Math.max(maxConcurrent, concurrent)
-      await new Promise(resolve => setTimeout(resolve, 5))
+      await setTimeout(5)
       concurrent--
     })
 
@@ -84,7 +85,7 @@ describe('mapWithConcurrency', () => {
       async () => {
         concurrent++
         maxConcurrent = Math.max(maxConcurrent, concurrent)
-        await new Promise(resolve => setTimeout(resolve, 10))
+        await setTimeout(10)
         concurrent--
       },
       10,


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

This change replaces ad-hoc promise wrappers around `setTimeout` with Node’s promise-based timer API from `node:timers/promises`.

The goal is to remove repetitive delay boilerplate and make retry/wait paths easier to read without changing behavior.

### 📚 Description

Updated the async delay calls that were written as `new Promise(resolve => setTimeout(resolve, ms))` to use `setTimeout(ms)` from `node:timers/promises` instead.

This affects the GitHub contributors evolution retry logic, the Upstash OAuth lock retry path, and the related unit tests. The behavior is unchanged; this is a small refactor toward the standard Node API for promise-based timers.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
