### PR TITLE
fix: resolve semantic versioning issue

### DIFF
--- a/app/composables/npm/useResolvedVersion.ts
+++ b/app/composables/npm/useResolvedVersion.ts
@@ -1,4 +1,5 @@
 import type { PackageVersionsInfo, ResolvedPackageVersion } from 'fast-npm-meta'
+import semver from 'semver'
 
 export function useResolvedVersion(
   packageName: MaybeRefOrGetter<string>,
@@ -18,7 +19,7 @@ export function useResolvedVersion(
       // error (no publishedAt, no validation). When publishedAt is missing for
       // an exact version request, cross-check the versions list to confirm the
       // version actually exists in the registry.
-      if (version && /^\d/.test(version) && !data.publishedAt) {
+      if (version && semver.valid(version) && !data.publishedAt) {
         const versionsData = await $fetch<PackageVersionsInfo>(
           `https://npm.antfu.dev/versions/${name}`,
         )

--- a/test/nuxt/composables/use-resolved-version.spec.ts
+++ b/test/nuxt/composables/use-resolved-version.spec.ts
@@ -118,7 +118,7 @@ describe('useResolvedVersion', () => {
   })
 
   it('does not cross-check dist-tags against the versions list', async () => {
-    // Dist-tags start with a letter — the /^\d/ guard short-circuits the check
+    // Dist-tags start with a letter
     fetchSpy.mockResolvedValue(
       makeResolvedVersion({
         name: 'pkg-dist-tag-next',


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Fixes #2342
### 🧭 Context

Requesting a non-existent package version (e.g. `/package/axios/v/150.150.150`) returned HTTP 200 instead of 404. The page was silently showing content as if the version existed.

Added version validation in `useResolvedVersion` and unit tests to cover the fix.

### 📚 Description

The `npm.antfu.dev` API (fast-npm-meta) echoes back any version string without validating it against the registry. For non-existent versions it returns a 200 response but omits `publishedAt`. Because the fetch succeeded and returned a truthy version string, the existing 404 guards in the page never triggered.

The fix adds a check in `useResolvedVersion`: when an exact version is requested (starts with a digit) and the response has no `publishedAt`, a second request is made to the `/versions/` endpoint on the same API to confirm the version actually exists. If it does not, the composable returns `undefined`, which the existing 404 guards in [name].vue already handle correctly - both on the server (throwing a 404) and on the client (showing the error page).

Dist-tags (`latest`, `next`) and semver ranges start with a letter and skip this check since they resolve to a different version string by design.

**Files changed:**
- useResolvedVersion.ts - added registry validation when `publishedAt` is absent
- use-resolved-version.spec.ts - added unit tests covering valid versions, non-existent versions, old versions without `publishedAt`, dist-tags, and scoped packages