### PR TITLE
style: subtle color and size adjustment for <details> in the readme

### DIFF
--- a/app/components/Readme.vue
+++ b/app/components/Readme.vue
@@ -60,13 +60,19 @@ function handleClick(event: MouseEvent) {
 </script>
 
 <template>
-  <article class="readme max-w-[70ch] lg:max-w-none px-1" dir="auto" v-html="html" :style="{
-    '--i18n-note': '\'' + $t('package.readme.callout.note') + '\'',
-    '--i18n-tip': '\'' + $t('package.readme.callout.tip') + '\'',
-    '--i18n-important': '\'' + $t('package.readme.callout.important') + '\'',
-    '--i18n-warning': '\'' + $t('package.readme.callout.warning') + '\'',
-    '--i18n-caution': '\'' + $t('package.readme.callout.caution') + '\'',
-  }" @click="handleClick" />
+  <article
+    class="readme max-w-[70ch] lg:max-w-none px-1"
+    dir="auto"
+    v-html="html"
+    :style="{
+      '--i18n-note': '\'' + $t('package.readme.callout.note') + '\'',
+      '--i18n-tip': '\'' + $t('package.readme.callout.tip') + '\'',
+      '--i18n-important': '\'' + $t('package.readme.callout.important') + '\'',
+      '--i18n-warning': '\'' + $t('package.readme.callout.warning') + '\'',
+      '--i18n-caution': '\'' + $t('package.readme.callout.caution') + '\'',
+    }"
+    @click="handleClick"
+  />
 </template>
 
 <style scoped>


### PR DESCRIPTION
### 🔗 Linked issue
resolves #2391 

### 🧭 Context

Hello, sorry if I went ahead and fixed this one without discussion first of the issue 😆. It's a small one. This PR will implement a subtle difference in `<details>` content. 

### 📚 Description

The PR applies a change in how `<details>` on the readme of a package is rendered. The `<summary>` content remains unchanged, while the content hidden/shown when toggling are smaller and subtler. More description on the issue #2391 

### See screenshots

The following are screenshots for the [readme of `@ayo-run/mnswpr`](https://npmx.dev/package/@ayo-run/mnswpr#readme)

| npmjs.com | npmx.dev (before) | npmx.dev (after) |
| --- | --- | --- |
| <img width="371" height="545" alt="Screenshot from 2026-04-05 16-59-46" src="https://github.com/user-attachments/assets/dedb6c88-ba89-4235-a5a4-acc0ace2a3f2" /> | <img width="376" height="597" alt="Screenshot from 2026-04-05 17-14-26" src="https://github.com/user-attachments/assets/e45e7e65-e372-4d0e-b89a-c7200ae16ef4" /> | <img width="376" height="597" alt="Screenshot from 2026-04-05 17-14-15" src="https://github.com/user-attachments/assets/1a5ee470-d9d8-43d8-b0ba-c763a0553e1f" /> |
