### PR TITLE
fix(ui): preserve root dir state when sibling dir is expanded

### DIFF
--- a/app/components/Code/FileTree.vue
+++ b/app/components/Code/FileTree.vue
@@ -39,7 +39,7 @@ const { toggleDir, isExpanded, autoExpandAncestors } = useFileTreeState(props.ba
 watch(
   () => props.currentPath,
   path => {
-    if (path) {
+    if (depth.value === 0 && path) {
       autoExpandAncestors(path)
     }
   },

--- a/app/composables/useFileTreeState.ts
+++ b/app/composables/useFileTreeState.ts
@@ -7,7 +7,6 @@ export function useFileTreeState(baseUrl: string) {
     } else {
       expanded.value.add(path)
     }
-    expanded.value = new Set(expanded.value)
   }
 
   function isExpanded(path: string) {
@@ -22,7 +21,6 @@ export function useFileTreeState(baseUrl: string) {
       prefix = prefix ? `${prefix}/${part}` : part
       expanded.value.add(prefix)
     }
-    expanded.value = new Set(expanded.value)
   }
 
   return {

--- a/app/composables/useFileTreeState.ts
+++ b/app/composables/useFileTreeState.ts
@@ -7,6 +7,7 @@ export function useFileTreeState(baseUrl: string) {
     } else {
       expanded.value.add(path)
     }
+    expanded.value = new Set(expanded.value)
   }
 
   function isExpanded(path: string) {
@@ -21,6 +22,7 @@ export function useFileTreeState(baseUrl: string) {
       prefix = prefix ? `${prefix}/${part}` : part
       expanded.value.add(prefix)
     }
+    expanded.value = new Set(expanded.value)
   }
 
   return {

--- a/test/nuxt/components/CodeFileTree.spec.ts
+++ b/test/nuxt/components/CodeFileTree.spec.ts
@@ -1,0 +1,89 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it, vi } from 'vitest'
+import CodeFileTree from '~/components/Code/FileTree.vue'
+
+const mockTree: PackageFileTree[] = [
+  {
+    name: 'distribution',
+    type: 'directory',
+    path: 'distribution',
+    children: [
+      {
+        name: 'core',
+        type: 'directory',
+        path: 'distribution/core',
+        children: [
+          {
+            name: 'constants.d.ts',
+            type: 'file',
+            path: 'distribution/core/constants.d.ts',
+          },
+        ],
+      },
+      {
+        name: 'types',
+        type: 'directory',
+        path: 'distribution/types',
+        children: [
+          {
+            name: 'common.d.ts',
+            type: 'file',
+            path: 'distribution/types/common.d.ts',
+          },
+        ],
+      },
+    ],
+  },
+]
+
+function findDirButton(wrapper: Awaited<ReturnType<typeof mountCodeFileTree>>, name: string) {
+  return wrapper.findAll('button').find(button => button.text().trim() === name)
+}
+
+async function mountCodeFileTree() {
+  return mountSuspended(CodeFileTree, {
+    attachTo: document.body,
+    props: {
+      tree: mockTree,
+      currentPath: 'distribution/core/constants.d.ts',
+      baseUrl: '/package-code/ky/v/1.14.3/distribution/core/constants.d.ts?test=tree',
+      baseRoute: {
+        params: {
+          packageName: 'ky',
+          version: '1.14.3',
+          filePath: '',
+        },
+      },
+    },
+  })
+}
+
+describe('CodeFileTree', () => {
+  it('keeps a collapsed sibling directory closed when another sibling expands', async () => {
+    const wrapper = await mountCodeFileTree()
+
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain('constants.d.ts')
+      expect(wrapper.text()).not.toContain('common.d.ts')
+    })
+
+    const coreButton = findDirButton(wrapper, 'core')
+    expect(coreButton).toBeDefined()
+    await coreButton!.trigger('click')
+
+    await vi.waitFor(() => {
+      expect(wrapper.text()).not.toContain('constants.d.ts')
+    })
+
+    const typesButton = findDirButton(wrapper, 'types')
+    expect(typesButton).toBeDefined()
+    await typesButton!.trigger('click')
+
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain('common.d.ts')
+      expect(wrapper.text()).not.toContain('constants.d.ts')
+    })
+
+    wrapper.unmount()
+  })
+})

--- a/test/nuxt/components/CodeFileTree.spec.ts
+++ b/test/nuxt/components/CodeFileTree.spec.ts
@@ -59,7 +59,7 @@ async function mountCodeFileTree() {
 }
 
 describe('CodeFileTree', () => {
-  it('keeps a collapsed sibling directory closed when another sibling expands', async () => {
+  it('expands and collapses a directory when clicked', async () => {
     const wrapper = await mountCodeFileTree()
 
     await vi.waitFor(() => {
@@ -73,6 +73,7 @@ describe('CodeFileTree', () => {
 
     await vi.waitFor(() => {
       expect(wrapper.text()).not.toContain('constants.d.ts')
+      expect(wrapper.text()).not.toContain('common.d.ts')
     })
 
     const typesButton = findDirButton(wrapper, 'types')

--- a/test/nuxt/components/CodeFileTree.spec.ts
+++ b/test/nuxt/components/CodeFileTree.spec.ts
@@ -61,30 +61,31 @@ async function mountCodeFileTree() {
 describe('CodeFileTree', () => {
   it('expands and collapses a directory when clicked', async () => {
     const wrapper = await mountCodeFileTree()
+    try {
+      await vi.waitFor(() => {
+        expect(wrapper.text()).toContain('constants.d.ts')
+        expect(wrapper.text()).not.toContain('common.d.ts')
+      })
 
-    await vi.waitFor(() => {
-      expect(wrapper.text()).toContain('constants.d.ts')
-      expect(wrapper.text()).not.toContain('common.d.ts')
-    })
+      const coreButton = findDirButton(wrapper, 'core')
+      expect(coreButton).toBeDefined()
+      await coreButton!.trigger('click')
 
-    const coreButton = findDirButton(wrapper, 'core')
-    expect(coreButton).toBeDefined()
-    await coreButton!.trigger('click')
+      await vi.waitFor(() => {
+        expect(wrapper.text()).not.toContain('constants.d.ts')
+        expect(wrapper.text()).not.toContain('common.d.ts')
+      })
 
-    await vi.waitFor(() => {
-      expect(wrapper.text()).not.toContain('constants.d.ts')
-      expect(wrapper.text()).not.toContain('common.d.ts')
-    })
+      const typesButton = findDirButton(wrapper, 'types')
+      expect(typesButton).toBeDefined()
+      await typesButton!.trigger('click')
 
-    const typesButton = findDirButton(wrapper, 'types')
-    expect(typesButton).toBeDefined()
-    await typesButton!.trigger('click')
-
-    await vi.waitFor(() => {
-      expect(wrapper.text()).toContain('common.d.ts')
-      expect(wrapper.text()).not.toContain('constants.d.ts')
-    })
-
-    wrapper.unmount()
+      await vi.waitFor(() => {
+        expect(wrapper.text()).toContain('common.d.ts')
+        expect(wrapper.text()).not.toContain('constants.d.ts')
+      })
+    } finally {
+      wrapper.unmount()
+    }
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/npmx-dev/npmx.dev/issues/2363

### 🧭 Context

The package code sidebar was re-expanding a collapsed sibling directory when another directory in the same tree was opened. On `ky@1.14.3`, collapsing `core/` and then expanding `types/` caused both directories to appear expanded again.

This change fixes the tree expansion logic so only the intended directory opens, and adds coverage for the regression.

### 📚 Description

The root cause was that the code tree auto-expanded the current file path from recursive `CodeFileTree` instances, not just from the root tree. That meant a subtree remount could re-apply ancestor expansion and reopen a directory the user had just collapsed.

This PR:
- limits auto-expansion of the current file path to the root file tree instance
- keeps file tree expansion state updates explicit by replacing the stored `Set` after mutations
- adds a Nuxt regression test covering the sibling-directory case from the issue

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
