### PR TITLE
fix: show dependencies section even when empty

### DIFF
--- a/app/components/Package/Dependencies.vue
+++ b/app/components/Package/Dependencies.vue
@@ -94,10 +94,13 @@ const numberFormatter = useNumberFormatter()
 
 <template>
   <div class="space-y-8">
-
-   <!-- Empty state -->
+    <!-- Empty state -->
     <p
-      v-if="!sortedDependencies.length && !sortedPeerDependencies.length && !sortedOptionalDependencies.length"
+      v-if="
+        !sortedDependencies.length &&
+        !sortedPeerDependencies.length &&
+        !sortedOptionalDependencies.length
+      "
       class="text-sm text-fg-subtle italic"
     >
       {{ $t('package.dependencies.none') }}

--- a/i18n/locales/ar-EG.json
+++ b/i18n/locales/ar-EG.json
@@ -166,7 +166,6 @@
     "dependencies": {
       "vulnerabilities_count": "{count} ثغرات | ثغرة أمنية واحدة | ثغرتان أمنيتان | {count} ثغرات أمنية | {count} ثغرة أمنية | {count} ثغرات أمنية",
       "none": "No dependencies"
-
     },
     "maintainers": {
       "maintainer_template": "المشرف {name}"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -455,8 +455,6 @@
       "has_replacement": "This dependency has suggested replacements",
       "vulnerabilities_count": "{count} vulnerability | {count} vulnerabilities",
       "none": "No dependencies"
-
-
     },
     "peer_dependencies": {
       "title": "Peer Dependency ({count}) | Peer Dependencies ({count})",


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2168

### 🧭 Context

The dependencies section in the sidebar was only rendered when a package had at least one dependency. This meant users had to look in different places depending on whether a package had deps or not, which was inconsistent.

### 📚 Description

- Removed hasDependencies && from the v-if on PackageDependencies in [name].vue so the section always renders when a version is resolved
- Added an empty state message inside PackageDependencies.vue that shows when all three dependency lists are empty
- Added the package.dependencies.none i18n key to en.json
- Added the package.dependencies.none i18n key to ar-EG.json

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
