### PR TITLE
ci: auto-remove `needs review` label when PR is reviewed

### DIFF
--- a/.github/workflows/remove-needs-review-on-review.yml
+++ b/.github/workflows/remove-needs-review-on-review.yml
@@ -23,9 +23,21 @@ jobs:
             const review = context.payload.review;
             const LABEL = 'needs review';
             const reviewer = review?.user?.login;
+            const author = pr.user?.login;
+            const reviewerType = review?.user?.type;
 
             if (!reviewer) {
               console.log('No reviewer login found in payload, skipping.');
+              return;
+            }
+
+            if (reviewerType === 'Bot') {
+              console.log(`Skipping bot review from @${reviewer} on PR #${pr.number}.`);
+              return;
+            }
+
+            if (reviewer === author) {
+              console.log(`Skipping self-review from @${reviewer} on PR #${pr.number}.`);
               return;
             }
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

We've been using the `needs review` label on PRs that are not stale, desirable, meet our contribution guidelines, passing CI, haven't been reviewed yet or are ready for a re-review, etc.

But the label gets less valuable if you can't rely on it at a glance or to filter PRs. This can happen if we don't manually remove the label when submitting a PR review.

### 📚 Description

This PR adds a CI workflow that removes the `needs review` label from a PR, if present, when a PR review is submitted by a maintainer.

✅ Ignores "reviews" (some comments count as reviews) from the PR author:

```
Skipping self-review from @serhalp on PR #2402.
```

✅ Ignores reviews from bots like CodeRabbit:

```
Skipping bot review from @CodeRabbit on PR #2402.
```