### PR TITLE
revert: revert "fix: consistent and likely safer regex escaping"

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@iconify-json/svg-spinners": "1.2.4",
     "@iconify-json/vscode-icons": "1.2.45",
     "@intlify/shared": "11.3.0",
-    "@li/regexp-escape-polyfill": "jsr:0.3.4",
     "@lunariajs/core": "https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@904b935",
     "@napi-rs/canvas": "0.1.97",
     "@nuxt/a11y": "1.0.0-alpha.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ importers:
       '@intlify/shared':
         specifier: 11.3.0
         version: 11.3.0
-      '@li/regexp-escape-polyfill':
-        specifier: jsr:0.3.4
-        version: '@jsr/li__regexp-escape-polyfill@0.3.4'
       '@lunariajs/core':
         specifier: https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@904b935
         version: https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@904b935
@@ -1958,9 +1955,6 @@ packages:
 
   '@jsr/deno__graph@0.86.9':
     resolution: {integrity: sha512-+qrrma5/bL+hcG20mfaEeC8SLopqoyd1RjcKFMRu++3SAXyrTKuvuIjBJCn/NyN7X+kV+QrJG67BCHX38Rzw+g==, tarball: https://npm.jsr.io/~/11/@jsr/deno__graph/0.86.9.tgz}
-
-  '@jsr/li__regexp-escape-polyfill@0.3.4':
-    resolution: {integrity: sha512-UGHzM9zAlRt0DUQIgsXAuXBd9jdzJ3t1v+fHsIcIj2fbUKplO9A8v2FE/w9KZo8hs79n5IamuBvqCTndGADM2Q==, tarball: https://npm.jsr.io/~/11/@jsr/li__regexp-escape-polyfill/0.3.4.tgz}
 
   '@jsr/std__bytes@1.0.6':
     resolution: {integrity: sha512-St6yKggjFGhxS52IFLJWvkchRFbAKg2Xh8UxA4S1EGz7GJ2Ui+ssDDldj/w2c8vCxvl6qgR0HaYbKeFJNqujmA==, tarball: https://npm.jsr.io/~/11/@jsr/std__bytes/1.0.6.tgz}
@@ -12709,8 +12703,6 @@ snapshots:
   '@jsr/deno__graph@0.100.1': {}
 
   '@jsr/deno__graph@0.86.9': {}
-
-  '@jsr/li__regexp-escape-polyfill@0.3.4': {}
 
   '@jsr/std__bytes@1.0.6': {}
 

--- a/shared/utils/dev-dependency.ts
+++ b/shared/utils/dev-dependency.ts
@@ -1,5 +1,3 @@
-import { regExpEscape } from '@li/regexp-escape-polyfill'
-
 export type DevDependencySuggestionReason = 'known-package' | 'readme-hint'
 
 export interface DevDependencySuggestion {
@@ -61,11 +59,15 @@ function isKnownDevDependencyPackage(packageName: string): boolean {
   )
 }
 
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 function hasReadmeDevInstallHint(packageName: string, readmeContent?: string | null): boolean {
   if (!readmeContent) return false
 
-  const escapedName = regExpEscape(packageName)
-  const escapedNpmName = regExpEscape(`npm:${packageName}`)
+  const escapedName = escapeRegExp(packageName)
+  const escapedNpmName = escapeRegExp(`npm:${packageName}`)
   const packageSpec = `(?:${escapedName}|${escapedNpmName})(?:@[\\w.-]+)?`
 
   const patterns = [

--- a/shared/utils/emoji.ts
+++ b/shared/utils/emoji.ts
@@ -1,5 +1,3 @@
-import { regExpEscape } from '@li/regexp-escape-polyfill'
-
 // copied from https://github.com/markdown-it/markdown-it-emoji/blob/master/lib/data/full.mjs
 const emojis = {
   '100': '💯',
@@ -1909,7 +1907,7 @@ const emojis = {
 
 const emojisKeysRegex = new RegExp(
   Object.keys(emojis)
-    .map(key => `:${regExpEscape(key)}:`)
+    .map(key => `:${key}:`)
     .join('|'),
   'g',
 )


### PR DESCRIPTION
Reverts npmx-dev/npmx.dev#1439

main.npmx.dev and all new previews are broken at the moment. I bisected all the commits on main (https://github.com/npmx-dev/npmx.dev/pull/2354/commits) and this was unambiguously the culprit.

See also https://discord.com/channels/1464542801676206113/1490833925759701235.

I don't have access to the server logs, so I'm running blind here. Just reverting for now.

#### Repro 1

Visit `/astro`, see Vercel 500 crash page.

<img width="543" height="466" alt="image" src="https://github.com/user-attachments/assets/7b9e2225-0a94-4dfe-9025-ea2489586224" />

#### Repro 2

Visit `/package/astro`, see a dozen pieces of data "degrade gracefully".

<img width="905" height="869" alt="Screenshot 2026-04-06 at 18 51 54" src="https://github.com/user-attachments/assets/1ed5cd1c-fde7-4b9e-8329-e9576fa7ad2f" />