### PR TITLE
ci: add e18e dependency diff workflow

### DIFF
--- a/.github/workflows/dependency-diff-comment.yml
+++ b/.github/workflows/dependency-diff-comment.yml
@@ -1,0 +1,31 @@
+name: dependency-diff-comment
+
+on:
+  workflow_run:
+    workflows: ['dependency-diff']
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  dependency-diff-comment:
+    name: 💬 Dependency diff comment
+    runs-on: ubuntu-slim
+    if: github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: e18e-diff-result
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 💬 Post comment
+        uses: e18e/action-dependency-diff@d995338f3b229fe7b2cd82048df5da930f70c7c3 # v1.4.4
+        with:
+          mode: comment-from-artifact
+          artifact-path: e18e-diff-result.json

--- a/.github/workflows/dependency-diff.yml
+++ b/.github/workflows/dependency-diff.yml
@@ -18,7 +18,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   dependency-diff:
@@ -31,9 +30,18 @@ jobs:
           fetch-depth: 0
 
       - name: 🔎 Compare dependencies
+        id: analyze
         uses: e18e/action-dependency-diff@d995338f3b229fe7b2cd82048df5da930f70c7c3 # v1.4.4
         with:
+          mode: artifact
           detect-replacements: 'true'
           duplicate-threshold: '4'
           dependency-threshold: '15'
           size-threshold: '200000'
+
+      - name: 📤 Upload artifact
+        if: steps.analyze.outputs.artifact-path
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e18e-diff-result
+          path: ${{ steps.analyze.outputs.artifact-path }}

--- a/.github/workflows/dependency-diff.yml
+++ b/.github/workflows/dependency-diff.yml
@@ -1,0 +1,39 @@
+name: dependency-diff
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release
+    paths:
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - docs/package.json
+      - cli/package.json
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-diff:
+    name: 🔎 Dependency diff
+    runs-on: ubuntu-slim
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: 🔎 Compare dependencies
+        uses: e18e/action-dependency-diff@d995338f3b229fe7b2cd82048df5da930f70c7c3 # v1.4.4
+        with:
+          detect-replacements: 'true'
+          duplicate-threshold: '4'
+          dependency-threshold: '15'
+          size-threshold: '200000'


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

See https://github.com/e18e/action-dependency-diff.

### 📚 Description

This configures the e18e/action-dependency-diff workflow. I've tried to tune it to avoid being noisy, but we may have to iterate a bit on it once merged.

Note that the action doesn't have sophisticated monorepo handling, so it won't report the base app + cli + docs separately, since they share a lockfile.