### PR TITLE
fix(i18n): add missing French translations

### DIFF
--- a/i18n/locales/fr-FR.json
+++ b/i18n/locales/fr-FR.json
@@ -312,6 +312,8 @@
     "warnings": "Avertissements :",
     "go_back_home": "Retour à l'accueil",
     "per_week": "/ semaine",
+    "yes": "Oui",
+    "no": "Non",
     "vanity_downloads_hint": "Métrique de vanité : aucun paquet affiché | Métrique de vanité : pour le paquet affiché | Métrique de vanité : somme des {count} paquets affichés",
     "sort": {
       "name": "nom",
@@ -334,6 +336,7 @@
       "gitea": "Voir sur Gitea",
       "gitee": "Voir sur Gitee",
       "radicle": "Voir sur Radicle",
+      "socket_dev": "Voir sur socket.dev",
       "sourcehut": "Voir sur SourceHut",
       "tangled": "Voir sur Tangled"
     },
@@ -937,8 +940,11 @@
     "lines": "{count} lignes",
     "toggle_tree": "Basculer l'arborescence",
     "close_tree": "Fermer l'arborescence",
+    "copy_content": "Copier le contenu du fichier",
     "copy_link": "Copier le lien",
     "view_raw": "Voir le fichier brut",
+    "toggle_container": "Changer la largeur du conteneur",
+    "open_raw_file": "Ouvrir le fichier brut",
     "file_too_large": "Fichier trop volumineux pour l'aperçu",
     "file_size_warning": "{size} dépasse la limite de 500 Ko pour la coloration syntaxique",
     "failed_to_load": "Échec du chargement du fichier",


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue

### 🧭 Context

French translations for the following keys are missing:

```
common.yes
common.no
common.view_on.socket_dev
code.copy_content
code.toggle_container
code.open_raw_file
```

This PR adds translations for those keys.

### 📚 Description

French translations have been added for the keys listed above.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
