### PR TITLE
fix: compare quadrant penalise more stale packages

### DIFF
--- a/app/utils/compare-quadrant-chart.ts
+++ b/app/utils/compare-quadrant-chart.ts
@@ -40,8 +40,8 @@ export interface PackageQuadrantPoint {
 
 const WEIGHTS = {
   adoption: {
-    downloads: 0.75, // dominant signal because they best reflect real-world adoption (in the data we have through facets currently)
-    freshness: 0.15, // small correction so stale packages are slightly
+    downloads: 0.65, // dominant signal because they best reflect real-world adoption (in the data we have through facets currently)
+    freshness: 0.25, // penalising correction for stale packages
     likes: 0.1, // might be pumped up in the future when ./npmx likes are more mainstream
   },
   efficiency: {


### PR DESCRIPTION
Resolved #2446 

Redistribute 0.1 between freshness & downloads, to penalise more stale packages

- Increase freshness ratio from 0.15 -> 0.25
- Decrease  downloads ratio from 0.75 -> 0.65

| Before | After |
|-------|-------|
|<img width="400"  alt="image" src="https://github.com/user-attachments/assets/f625f7fd-03d5-499b-9132-438e5002315b" />|<img width="400" alt="image" src="https://github.com/user-attachments/assets/7d239749-75c3-4532-9b70-720d4933f8db" />|