### PR TITLE
feat(ui): support Vite+ `vp` package manager commands

### DIFF
--- a/app/components/Package/ManagerSelect.vue
+++ b/app/components/Package/ManagerSelect.vue
@@ -191,7 +191,8 @@ function handleKeydown(event: KeyboardEvent) {
 :root[data-pm='yarn'] [data-pm-select='yarn'],
 :root[data-pm='bun'] [data-pm-select='bun'],
 :root[data-pm='deno'] [data-pm-select='deno'],
-:root[data-pm='vlt'] [data-pm-select='vlt'] {
+:root[data-pm='vlt'] [data-pm-select='vlt'],
+:root[data-pm='vp'] [data-pm-select='vp'] {
   display: inline-block;
 }
 

--- a/app/components/Terminal/Execute.vue
+++ b/app/components/Terminal/Execute.vue
@@ -94,7 +94,8 @@ const copyExecuteCommand = () => copyExecute(getFullExecuteCommand())
 :root[data-pm='yarn'] [data-pm-cmd='yarn'],
 :root[data-pm='bun'] [data-pm-cmd='bun'],
 :root[data-pm='deno'] [data-pm-cmd='deno'],
-:root[data-pm='vlt'] [data-pm-cmd='vlt'] {
+:root[data-pm='vlt'] [data-pm-cmd='vlt'],
+:root[data-pm='vp'] [data-pm-cmd='vp'] {
   display: flex;
 }
 

--- a/app/components/Terminal/Install.vue
+++ b/app/components/Terminal/Install.vue
@@ -412,7 +412,8 @@ useCommandPaletteContextCommands(
 :root[data-pm='yarn'] [data-pm-cmd='yarn'],
 :root[data-pm='bun'] [data-pm-cmd='bun'],
 :root[data-pm='deno'] [data-pm-cmd='deno'],
-:root[data-pm='vlt'] [data-pm-cmd='vlt'] {
+:root[data-pm='vlt'] [data-pm-cmd='vlt'],
+:root[data-pm='vp'] [data-pm-cmd='vp'] {
   display: flex;
 }
 

--- a/app/utils/install-command.ts
+++ b/app/utils/install-command.ts
@@ -59,6 +59,15 @@ export const packageManagers = [
     create: 'vlx',
     icon: 'i-custom-vlt',
   },
+  {
+    id: 'vp',
+    label: 'vp',
+    action: 'add',
+    executeLocal: 'vp exec',
+    executeRemote: 'vp dlx',
+    create: 'vp create',
+    icon: 'i-simple-icons:vite',
+  },
 ] as const
 
 export type PackageManagerId = (typeof packageManagers)[number]['id']

--- a/app/utils/prehydrate.ts
+++ b/app/utils/prehydrate.ts
@@ -21,7 +21,7 @@ export function initPreferencesOnPrehydrate() {
     ] satisfies typeof ACCENT_COLOR_IDS)
 
     // Valid package manager IDs
-    const validPMs = new Set(['npm', 'pnpm', 'yarn', 'bun', 'deno', 'vlt'])
+    const validPMs = new Set(['npm', 'pnpm', 'yarn', 'bun', 'deno', 'vlt', 'vp'])
 
     // Read settings from localStorage
     const settings = JSON.parse(

--- a/test/unit/app/utils/install-command.spec.ts
+++ b/test/unit/app/utils/install-command.spec.ts
@@ -35,6 +35,7 @@ describe('install command generation', () => {
         ['bun', 'lodash'],
         ['deno', 'npm:lodash'],
         ['vlt', 'lodash'],
+        ['vp', 'lodash'],
       ] as const)('%s → %s', (pm, expected) => {
         expect(
           getPackageSpecifier({
@@ -54,6 +55,7 @@ describe('install command generation', () => {
         ['bun', '@trpc/server'],
         ['deno', 'jsr:@trpc/server'], // Native JSR specifier preferred
         ['vlt', '@trpc/server'],
+        ['vp', '@trpc/server'],
       ] as const)('%s → %s', (pm, expected) => {
         expect(
           getPackageSpecifier({
@@ -73,6 +75,7 @@ describe('install command generation', () => {
         ['bun', '@vue/shared'],
         ['deno', 'npm:@vue/shared'], // Falls back to npm: compat
         ['vlt', '@vue/shared'],
+        ['vp', '@vue/shared'],
       ] as const)('%s → %s', (pm, expected) => {
         expect(
           getPackageSpecifier({
@@ -94,6 +97,7 @@ describe('install command generation', () => {
         ['bun', 'bun add lodash'],
         ['deno', 'deno add npm:lodash'],
         ['vlt', 'vlt install lodash'],
+        ['vp', 'vp add lodash'],
       ] as const)('%s → %s', (pm, expected) => {
         expect(
           getInstallCommand({
@@ -113,6 +117,7 @@ describe('install command generation', () => {
         ['bun', 'bun add lodash@4.17.21'],
         ['deno', 'deno add npm:lodash@4.17.21'],
         ['vlt', 'vlt install lodash@4.17.21'],
+        ['vp', 'vp add lodash@4.17.21'],
       ] as const)('%s → %s', (pm, expected) => {
         expect(
           getInstallCommand({
@@ -133,6 +138,7 @@ describe('install command generation', () => {
         ['bun', 'bun add -d eslint'],
         ['deno', 'deno add -D npm:eslint'],
         ['vlt', 'vlt install -D eslint'],
+        ['vp', 'vp add -D eslint'],
       ] as const)('%s → %s', (pm, expected) => {
         expect(
           getInstallCommand({
@@ -153,6 +159,7 @@ describe('install command generation', () => {
         ['bun', 'bun add @trpc/server'],
         ['deno', 'deno add jsr:@trpc/server'], // Native JSR preferred
         ['vlt', 'vlt install @trpc/server'],
+        ['vp', 'vp add @trpc/server'],
       ] as const)('%s → %s', (pm, expected) => {
         expect(
           getInstallCommand({
@@ -172,6 +179,7 @@ describe('install command generation', () => {
         ['bun', 'bun add @trpc/server@10.0.0'],
         ['deno', 'deno add jsr:@trpc/server@10.0.0'], // Native JSR with version
         ['vlt', 'vlt install @trpc/server@10.0.0'],
+        ['vp', 'vp add @trpc/server@10.0.0'],
       ] as const)('%s → %s', (pm, expected) => {
         expect(
           getInstallCommand({
@@ -192,6 +200,7 @@ describe('install command generation', () => {
         ['bun', 'bun add @vue/shared'],
         ['deno', 'deno add npm:@vue/shared'], // Falls back to npm: compat
         ['vlt', 'vlt install @vue/shared'],
+        ['vp', 'vp add @vue/shared'],
       ] as const)('%s → %s', (pm, expected) => {
         expect(
           getInstallCommand({
@@ -345,6 +354,7 @@ describe('install command generation', () => {
         ['bun', ['bunx', 'eslint']],
         ['deno', ['deno', 'run', 'npm:eslint']],
         ['vlt', ['vlx', 'eslint']],
+        ['vp', ['vp', 'exec', 'eslint']],
       ] as const)('%s → %s', (pm, expected) => {
         expect(
           getExecuteCommandParts({
@@ -364,6 +374,7 @@ describe('install command generation', () => {
         ['bun', ['bunx', 'degit']],
         ['deno', ['deno', 'run', 'npm:degit']],
         ['vlt', ['vlx', 'degit']],
+        ['vp', ['vp', 'dlx', 'degit']],
       ] as const)('%s → %s', (pm, expected) => {
         expect(
           getExecuteCommandParts({
@@ -383,6 +394,7 @@ describe('install command generation', () => {
         ['bun', ['bun', 'create', 'vite']],
         ['deno', ['deno', 'create', 'npm:vite']],
         ['vlt', ['vlx', 'vite']],
+        ['vp', ['vp', 'create', 'vite']],
       ] as const)('%s → %s', (pm, expected) => {
         expect(
           getExecuteCommandParts({


### PR DESCRIPTION
### 🔗 Linked issue

resolves #2418

### 🧭 Context

Add [viteplus](https://viteplus.dev/guide/) as a package manager

<!-- High-level summary of what changed -->

### 📚 Description

add viteplus command

> Since no Viteplus icon was found, the [Vite icon](https://icones.js.org/collection/simple-icons?s=vite&icon=simple-icons:vite) was used instead.

Thank you for your guidance. Please point out any shortcomings in the testing.
