### PR TITLE
ci: actually bump `e18e/action-dependency-diff` to v1.5.0

### DIFF
--- a/.github/workflows/dependency-diff-comment.yml
+++ b/.github/workflows/dependency-diff-comment.yml
@@ -25,7 +25,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 💬 Post comment
-        uses: e18e/action-dependency-diff@d995338f3b229fe7b2cd82048df5da930f70c7c3 # v1.4.4
+        uses: e18e/action-dependency-diff@f825d5b5c5ce0a42dc46c47ec20de24460affcd8 # v1.5.0
         with:
           mode: comment-from-artifact
           artifact-path: e18e-diff-result.json

--- a/.github/workflows/dependency-diff.yml
+++ b/.github/workflows/dependency-diff.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: 🔎 Compare dependencies
         id: analyze
-        uses: e18e/action-dependency-diff@d995338f3b229fe7b2cd82048df5da930f70c7c3 # v1.4.4
+        uses: e18e/action-dependency-diff@f825d5b5c5ce0a42dc46c47ec20de24460affcd8 # v1.5.0
         with:
           mode: artifact
           detect-replacements: 'true'


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

In https://github.com/npmx-dev/npmx.dev/pull/2435 we started using a feature that was added in https://github.com/e18e/action-dependency-diff/releases/tag/v1.5.0, but we forgot to bump it, so it's failing: https://github.com/npmx-dev/npmx.dev/actions/runs/24242462290/job/70780154550.

### 📚 Description

Bump it!