### PR TITLE
fix(i18n): actually use i18n `ctrl_key` consistently

### DIFF
--- a/app/composables/usePlatformModifierKey.ts
+++ b/app/composables/usePlatformModifierKey.ts
@@ -16,7 +16,9 @@ function detectApplePlatform() {
 }
 
 export function usePlatformModifierKey() {
+  const { t } = useI18n()
   const isApplePlatform = useState('platform:is-apple', detectApplePlatform)
+  const ctrlKeyLabel = computed(() => t('shortcuts.ctrl_key'))
 
   if (import.meta.client) {
     onMounted(() => {
@@ -26,7 +28,9 @@ export function usePlatformModifierKey() {
 
   return {
     isApplePlatform: computed(() => isApplePlatform.value),
-    primaryModifierKeyLabel: computed(() => (isApplePlatform.value ? '⌘' : 'Ctrl')),
-    commandPaletteShortcutLabel: computed(() => (isApplePlatform.value ? '⌘ K' : 'Ctrl+K')),
+    primaryModifierKeyLabel: computed(() => (isApplePlatform.value ? '⌘' : ctrlKeyLabel.value)),
+    commandPaletteShortcutLabel: computed(() =>
+      isApplePlatform.value ? '⌘ K' : `${ctrlKeyLabel.value}+K`,
+    ),
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

The i18n key already exists, we just weren't using it everywhere.

### 📚 Description

Replace hardcoded `Ctrl` with translations.