### PR TITLE
ci: update Discord link to builders server

### DIFF
--- a/.github/workflows/welcome-close.yml
+++ b/.github/workflows/welcome-close.yml
@@ -39,7 +39,7 @@ jobs:
             const body = [
               `Thanks for your first contribution, @${author}! ${emoji}`,
               '',
-              `We'd love to welcome you to the npmx community. Come and say hi on [Discord](https://chat.npmx.dev)! And once you've joined, visit [npmx.wamellow.com](https://npmx.wamellow.com/) to claim the **contributor** role.`,
+              `We'd love to welcome you to the npmx community. Come and say hi on [Discord](https://build.npmx.dev)! And once you've joined, visit [npmx.wamellow.com](https://npmx.wamellow.com/) to claim the **contributor** role.`,
             ].join('\n');
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
### 🧭 Context

The workflow for welcoming a contributor via comment on PR merge points to the chat.npmx.dev discord and mentions claiming a contributor role via wamellow. Wamellow is setup to handle role assignment on the build.npmx.dev discord not chat.

e.g. https://github.com/npmx-dev/npmx.dev/pull/1494#issuecomment-3901978562
### 📚 Description

Update the link to point the `build.npmx.dev` discord
