### PR TITLE
refactor: add missing IconClass type to icon props

### DIFF
--- a/app/components/CollapsibleSection.vue
+++ b/app/components/CollapsibleSection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { shallowRef, computed } from 'vue'
 import { LinkBase } from '#components'
-import type { IconClass } from '../types/icon'
+import type { IconClass } from '~/types/icon'
 
 interface Props {
   title: string

--- a/app/components/CollapsibleSection.vue
+++ b/app/components/CollapsibleSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { shallowRef, computed } from 'vue'
 import { LinkBase } from '#components'
+import type { IconClass } from '../types/icon'
 
 interface Props {
   title: string
@@ -8,7 +9,7 @@ interface Props {
   isLoading?: boolean
   headingLevel?: `h${number}`
   id: string
-  icon?: string
+  icon?: IconClass
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/app/components/Diff/SidebarPanel.vue
+++ b/app/components/Diff/SidebarPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { packageRoute } from '~/utils/router'
+import type { IconClass } from '../../types/icon'
 
 const props = defineProps<{
   compare: CompareResponse
@@ -19,7 +20,7 @@ const fileFilter = defineModel<'all' | 'added' | 'removed' | 'modified'>('fileFi
 
 const sectionOrder = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']
 const { t } = useI18n()
-const sectionMeta = computed<Record<string, { label: string; icon: string }>>(() => ({
+const sectionMeta = computed<Record<string, { label: string; icon: IconClass }>>(() => ({
   dependencies: { label: t('compare.dependencies'), icon: 'i-lucide:box' },
   devDependencies: { label: t('compare.dev_dependencies'), icon: 'i-lucide:wrench' },
   peerDependencies: { label: t('compare.peer_dependencies'), icon: 'i-lucide:users' },

--- a/app/components/Diff/SidebarPanel.vue
+++ b/app/components/Diff/SidebarPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { packageRoute } from '~/utils/router'
-import type { IconClass } from '../../types/icon'
+import type { IconClass } from '~/types/icon'
 
 const props = defineProps<{
   compare: CompareResponse


### PR DESCRIPTION
### 🔗 Linked issue
Partially resolves #1256

### 🧭 Context
The codebase already had an `IconClass` type defined in `~/types/icon` 
for Iconify icon class strings (e.g. `i-lucide:home`). However, some 
component props that accept icon classes were still typed as plain `string`, 
missing out on type safety.

### 📚 Description
Applied the existing `IconClass` type to props that accept Iconify icon 
class strings in two components:

- `app/components/CollapsibleSection.vue`: `icon?: string` → `icon?: IconClass`
- `Diff/SidebarPanel.vue`: `icon: string` → `icon: IconClass` inside 
  the `sectionMeta` computed record

Full resolution of #1256 would require a dedicated icon component that 
enforces `IconClass` usage across the whole codebase, as noted by maintainers.