### PR TITLE
fix: add ignore attributes for password managers to input fields

### DIFF
--- a/app/components/CommandPalette.client.vue
+++ b/app/components/CommandPalette.client.vue
@@ -324,6 +324,7 @@ useEventListener(document, 'keydown', handleGlobalKeydown)
             type="text"
             :placeholder="viewMeta.placeholder"
             no-correct
+            no-password-manager
             size="lg"
             class="w-full"
             :aria-describedby="inputDescribedBy"

--- a/app/components/Input/Base.vue
+++ b/app/components/Input/Base.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { noCorrect } from '~/utils/input'
+import { noCorrect, noPasswordManager } from '~/utils/input'
 
 const model = defineModel<string>({ default: '' })
 
@@ -16,6 +16,12 @@ const props = withDefaults(
     noCorrect?: boolean
     /** Keyboard shortcut hint */
     ariaKeyshortcuts?: string
+    /**
+     * Prevents most common password managers from recognizing the input as a password field.
+     * Note: This is not a standard HTML attribute but vendor-specific data-* attributes.
+     * @default false
+     */
+    noPasswordManager?: boolean
   }>(),
   {
     size: 'md',
@@ -36,13 +42,18 @@ defineExpose({
   focus: () => el.value?.focus(),
   blur: () => el.value?.blur(),
 })
+
+const inputAttrs = computed(() => ({
+  ...(props.noCorrect ? noCorrect : {}),
+  ...(props.noPasswordManager ? noPasswordManager : {}),
+}))
 </script>
 
 <template>
   <input
     ref="el"
     v-model="model"
-    v-bind="props.noCorrect ? noCorrect : undefined"
+    v-bind="inputAttrs"
     @focus="emit('focus', $event)"
     @blur="emit('blur', $event)"
     class="appearance-none bg-bg-subtle border border-border font-mono text-fg placeholder:text-fg-subtle transition-[border-color,outline-color] duration-300 hover:border-fg-subtle outline-2 outline-transparent outline-offset-2 focus:border-accent focus-visible:outline-accent/70 disabled:(opacity-50 cursor-not-allowed)"

--- a/app/utils/input.ts
+++ b/app/utils/input.ts
@@ -28,3 +28,15 @@ export function isKeyWithoutModifiers(event: KeyboardEvent, key: string): boolea
 }
 
 export const DATE_INPUT_MAX = '9999-12-31'
+
+/** Attributes to prevent password managers from recognizing an input as a password field. */
+export const noPasswordManager = {
+  /* ProtonPass, https://stackoverflow.com/a/51272839 */
+  ['data-protonpass-ignore']: 'true',
+  /* LastPass, https://stackoverflow.com/a/51272839 */
+  ['data-lpignore']: 'true',
+  /* 1Password, https://stackoverflow.com/a/51272839 */
+  ['data-1p-ignore']: 'true',
+  /* Bitwarden, https://stackoverflow.com/questions/41945535/html-disable-password-manager#comment139327111_51272839 */
+  ['data-bwignore']: 'true',
+} as const


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Resolves #2465

### 🧭 Context

<!-- Brief background and why this change is needed -->
Currently, the Proton Pass extension (and potentially other password managers) is being triggered by the `CommandPalette.client.vue` component on `/package/<package>` pages.
This introduces a minor visual disturbance for users with those extensions installed.
As outlined in https://stackoverflow.com/a/51272839, password managers are notorious for ignoring hints such as `autocomplete` and `autocorrect`. 

<!-- High-level summary of what changed -->
Added the property `no-password-manager` to prevent password managers from auto-filling input fields that don't require it.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
To fix this issue, I introduced (similar to the existing `noCorrect` object export in `~/utils/input`) a `noPasswordManager` object with a collection of `data-x` attributes to silence password managers.
This object is conditionally bound to `~/components/Input/Base.vue` based on the added attribute

```ts
    //...
    /**
     * Prevents most common password managers from recognizing the input as a password field.
     * Note: This is not a standard HTML attribute but vendor-specific data-* attributes.
     * @default false
     */
    noPasswordManager?: boolean
    // ...
```
and then activated for `CommandPalette.client.vue` by default by passing `no-password-manager` to it.

I'm unsure if a "workaround" like this would qualify to be merged, but I guessed that it (hopefully) won't hurt to submit a PR to potentially fix this.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
