### PR TITLE
fix: retry replacement suggestions after transient fetch failures

### DIFF
--- a/app/composables/useCompareReplacements.ts
+++ b/app/composables/useCompareReplacements.ts
@@ -42,15 +42,18 @@ export function useCompareReplacements(packageNames: MaybeRefOrGetter<string[]>)
         namesToCheck.map(async name => {
           try {
             const replacement = await $fetch<ModuleReplacement | null>(`/api/replacements/${name}`)
-            return { name, replacement }
+            return { name, replacement, failed: false as const }
           } catch {
-            return { name, replacement: null }
+            return { name, failed: true as const }
           }
         }),
       )
 
       const newReplacements = new Map(replacements.value)
-      for (const { name, replacement } of results) {
+      for (const result of results) {
+        if (result.failed) continue
+
+        const { name, replacement } = result
         newReplacements.set(name, replacement)
       }
       replacements.value = newReplacements

--- a/app/composables/useCompareReplacements.ts
+++ b/app/composables/useCompareReplacements.ts
@@ -52,9 +52,7 @@ export function useCompareReplacements(packageNames: MaybeRefOrGetter<string[]>)
       const newReplacements = new Map(replacements.value)
       for (const result of results) {
         if (result.failed) continue
-
-        const { name, replacement } = result
-        newReplacements.set(name, replacement)
+        newReplacements.set(result.name, result.replacement)
       }
       replacements.value = newReplacements
     } finally {

--- a/test/nuxt/composables/use-compare-replacements.spec.ts
+++ b/test/nuxt/composables/use-compare-replacements.spec.ts
@@ -6,7 +6,9 @@ import type { ReplacementSuggestion } from '~/composables/useCompareReplacements
 /**
  * Helper to test useCompareReplacements by wrapping it in a component.
  */
-async function useCompareReplacementsInComponent(packageNames: string[]) {
+async function useCompareReplacementsInComponent(
+  packageNames: Parameters<typeof useCompareReplacements>[0],
+) {
   const capturedNoDepSuggestions = ref<ReplacementSuggestion[]>([])
   const capturedInfoSuggestions = ref<ReplacementSuggestion[]>([])
   const capturedLoading = ref(false)
@@ -212,27 +214,82 @@ describe('useCompareReplacements', () => {
     })
 
     it('handles fetch errors gracefully', async () => {
-      vi.stubGlobal(
-        '$fetch',
-        vi.fn().mockImplementation(() => {
-          return Promise.reject(new Error('Network error'))
-        }),
-      )
+      const fetchMock = vi.fn().mockImplementation(() => {
+        return Promise.reject(new Error('Network error'))
+      })
+
+      vi.stubGlobal('$fetch', fetchMock)
 
       const { noDepSuggestions, infoSuggestions, replacements } =
         await useCompareReplacementsInComponent(['some-package'])
 
       await vi.waitFor(() => {
-        expect(replacements.value.has('some-package')).toBe(true)
+        expect(fetchMock).toHaveBeenCalledTimes(1)
       })
 
-      expect(replacements.value.get('some-package')).toBeNull()
+      expect(replacements.value.has('some-package')).toBe(false)
       expect(noDepSuggestions.value).toHaveLength(0)
       expect(infoSuggestions.value).toHaveLength(0)
     })
   })
 
   describe('caching', () => {
+    it('retries a package after a transient fetch failure', async () => {
+      const packageNames = ref(['is-even'])
+      const fetchMock = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('Temporary network error'))
+        .mockResolvedValueOnce({
+          type: 'simple',
+          moduleName: 'is-even',
+          replacement: 'Use (n % 2) === 0',
+          category: 'micro-utilities',
+        } satisfies ModuleReplacement)
+
+      vi.stubGlobal('$fetch', fetchMock)
+
+      const { noDepSuggestions, replacements } =
+        await useCompareReplacementsInComponent(packageNames)
+
+      await vi.waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+      })
+
+      expect(replacements.value.has('is-even')).toBe(false)
+
+      packageNames.value = []
+      await nextTick()
+      packageNames.value = ['is-even']
+
+      await vi.waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+        expect(noDepSuggestions.value).toHaveLength(1)
+      })
+
+      expect(replacements.value.get('is-even')?.type).toBe('simple')
+    })
+
+    it('caches successful null replacement data and does not refetch', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(null)
+
+      vi.stubGlobal('$fetch', fetchMock)
+
+      const packageNames = ref(['react'])
+      const { replacements } = await useCompareReplacementsInComponent(packageNames)
+
+      await vi.waitFor(() => {
+        expect(replacements.value.has('react')).toBe(true)
+      })
+
+      packageNames.value = []
+      await nextTick()
+      packageNames.value = ['react']
+
+      await vi.waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+      })
+    })
+
     it('caches replacement data and does not refetch', async () => {
       const fetchMock = vi.fn().mockImplementation((url: string) => {
         if (url.includes('/api/replacements/is-even')) {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

The compare page caches replacement lookups per package in `useCompareReplacements`. That cache treated transient fetch failures the same as a real “no replacement” response by storing `null` for both cases. Once that happened, the package was considered already checked and would never be fetched again for the rest of the session.

In practice, a temporary API failure, offline blip, or server 500 could permanently suppress replacement suggestions until the app was reloaded.

### 📚 Description

This PR changes compare-page replacement caching so only successful fetch results are persisted.

Successful `null` responses are still cached, which preserves the existing optimization for packages that truly have no replacement suggestion. Thrown fetch errors are no longer written into the cache, which allows the package to be retried on a later watch cycle instead of being suppressed for the rest of the session.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
