### PR TITLE
feat: enable turning off code ligatures

### DIFF
--- a/app/assets/main.css
+++ b/app/assets/main.css
@@ -287,6 +287,11 @@ html.light .shiki {
   }
 }
 
+/* Settings-based configuration for code ligatures. On by default. */
+:root[data-code-ligatures='false'] code {
+  font-variant-ligatures: none;
+}
+
 /* Inline code in package descriptions */
 p > span > code,
 .line-clamp-2 code {

--- a/app/composables/useSettings.ts
+++ b/app/composables/useSettings.ts
@@ -257,7 +257,7 @@ export function useCodeContainer() {
   }
 }
 
-export function useCodeLigatures() {
+export const useCodeLigatures = createSharedComposable(function useCodeLigatures() {
   const { settings } = useSettings()
 
   const codeLigatures = computed(() => settings.value.codeLigatures)
@@ -285,4 +285,4 @@ export function useCodeLigatures() {
     codeLigatures,
     toggleCodeLigatures,
   }
-}
+})

--- a/app/composables/useSettings.ts
+++ b/app/composables/useSettings.ts
@@ -39,6 +39,8 @@ export interface AppSettings {
     autoOpenURL: boolean
   }
   codeContainerFull: boolean
+  /** Enable/disable ligatures in code */
+  codeLigatures: boolean
   sidebar: {
     collapsed: string[]
   }
@@ -65,6 +67,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     autoOpenURL: false,
   },
   codeContainerFull: false,
+  codeLigatures: true,
   sidebar: {
     collapsed: [],
   },
@@ -251,5 +254,35 @@ export function useCodeContainer() {
   return {
     codeContainerFull,
     toggleCodeContainer,
+  }
+}
+
+export function useCodeLigatures() {
+  const { settings } = useSettings()
+
+  const codeLigatures = computed(() => settings.value.codeLigatures)
+
+  if (import.meta.client) {
+    // Sync the data attribute on root to the setting
+    watch(
+      codeLigatures,
+      value => {
+        if (value) {
+          delete document.documentElement.dataset.codeLigatures
+        } else {
+          document.documentElement.dataset.codeLigatures = 'false'
+        }
+      },
+      { immediate: true },
+    )
+  }
+
+  function toggleCodeLigatures() {
+    settings.value.codeLigatures = !settings.value.codeLigatures
+  }
+
+  return {
+    codeLigatures,
+    toggleCodeLigatures,
   }
 }

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -5,6 +5,7 @@ const { locale: currentLocale, locales, setLocale: setNuxti18nLocale } = useI18n
 const colorMode = useColorMode()
 const { currentLocaleStatus, isSourceLocale } = useI18nStatus()
 const keyboardShortcutsEnabled = useKeyboardShortcuts()
+const { toggleCodeLigatures } = useCodeLigatures()
 
 // Escape to go back (but not when focused on form elements or modal is open)
 onKeyStroke(
@@ -142,6 +143,16 @@ const setLocale: typeof setNuxti18nLocale = newLocale => {
               :label="$t('settings.enable_graph_pulse_loop')"
               :description="$t('settings.enable_graph_pulse_loop_description')"
               v-model="settings.enableGraphPulseLooping"
+            />
+
+            <!-- Divider -->
+            <div class="border-t border-border my-4" />
+
+            <!-- Code ligatures toggle -->
+            <SettingsToggle
+              :label="$t('settings.enable_code_ligatures')"
+              :modelValue="settings.codeLigatures"
+              @update:modelValue="() => toggleCodeLigatures()"
             />
           </div>
         </section>

--- a/app/utils/prehydrate.ts
+++ b/app/utils/prehydrate.ts
@@ -66,5 +66,10 @@ export function initPreferencesOnPrehydrate() {
     if (settings.keyboardShortcuts === false) {
       document.documentElement.dataset.kbdShortcuts = 'false'
     }
+
+    // Code font ligatures (default: true)
+    if (settings.codeLigatures === false) {
+      document.documentElement.dataset.codeLigatures = 'false'
+    }
   })
 }

--- a/i18n/locales/cs-CZ.json
+++ b/i18n/locales/cs-CZ.json
@@ -280,7 +280,8 @@
       "black": "Černá"
     },
     "keyboard_shortcuts_enabled": "Povolit klávesové zkratky",
-    "keyboard_shortcuts_enabled_description": "Klávesové zkratky lze zakázat, pokud se střetávají s jinými zkratkami prohlížeče nebo systému"
+    "keyboard_shortcuts_enabled_description": "Klávesové zkratky lze zakázat, pokud se střetávají s jinými zkratkami prohlížeče nebo systému",
+    "enable_code_ligatures": "Zapnout ligatury v kódu"
   },
   "i18n": {
     "missing_keys": "{count} chybějící překlad | {count} chybějící překlady | {count} chybějících překladů",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -280,7 +280,8 @@
       "black": "Black"
     },
     "keyboard_shortcuts_enabled": "Enable keyboard shortcuts",
-    "keyboard_shortcuts_enabled_description": "Keyboard shortcuts can be disabled if they conflict with other browser or system shortcuts"
+    "keyboard_shortcuts_enabled_description": "Keyboard shortcuts can be disabled if they conflict with other browser or system shortcuts",
+    "enable_code_ligatures": "Enable ligatures in code"
   },
   "i18n": {
     "missing_keys": "{count} missing translation | {count} missing translations",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -846,6 +846,9 @@
         },
         "keyboard_shortcuts_enabled_description": {
           "type": "string"
+        },
+        "enable_code_ligatures": {
+          "type": "string"
         }
       },
       "additionalProperties": false

--- a/test/nuxt/composables/use-settings.spec.ts
+++ b/test/nuxt/composables/use-settings.spec.ts
@@ -46,3 +46,31 @@ describe('useSettings - keyboardShortcuts', () => {
     })
   })
 })
+
+describe('useSettings - codeLigatures', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('has a default value of true', async () => {
+    const { useSettings } = await import('~/composables/useSettings')
+    const codeLigatures = useSettings().settings.value.codeLigatures
+    expect(codeLigatures).toBe(true)
+  })
+
+  describe('useCodeLigatures', () => {
+    it('has a default value of true', async () => {
+      const { useCodeLigatures } = await import('~/composables/useSettings')
+      const codeLigatures = useCodeLigatures().codeLigatures
+      expect(codeLigatures.value).toBe(true)
+    })
+
+    it('updates after toggle', async () => {
+      const { useCodeLigatures } = await import('~/composables/useSettings')
+      const { codeLigatures, toggleCodeLigatures } = useCodeLigatures()
+      expect(codeLigatures.value).toBe(true)
+      toggleCodeLigatures()
+      expect(codeLigatures.value).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Closes #2423

Adds a new setting that controls whether ligatures are used in code. The setting sets a data attribute on the root, which is picked up by a selector in global styles.

I opted to have changes in the setting call the `toggleCodeLigatures` function rather than using `v-model`. This is needed because we need to run the side effect of updating the data attribute, which happens inside a `watch` is registered in `useCodeLigatures`. I still don't really like this, because the attribute update is dependent on `useCodeLigatures` being called, even though you can access and update the setting itself on `settings`. Other settings work like this as well though (e.g. the data attribute for `keyboardShortcuts` gets updated only if `useKeyboardShortcuts` is called), so for the time being, I've kept it this way. I'd be interested in revisiting this in the future, perhaps updating the `useSettings` composable to handle side effects on changes of individual settings. Please let me know if that makes sense to you.

I've provided translations for the new setting's label in English and Czech (my native language).

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
