### PR TITLE
fix: change default sorting to downloads-week-desc as in parseSortOption

### DIFF
--- a/app/pages/org/[org].vue
+++ b/app/pages/org/[org].vue
@@ -112,7 +112,7 @@ const totalWeeklyDownloads = computed(() =>
 // Reset state when org changes
 watch(orgName, () => {
   clearAllFilters()
-  setSort('updated-desc')
+  setSort('downloads-week-desc')
   currentPage.value = 1
 })
 

--- a/app/pages/org/[org].vue
+++ b/app/pages/org/[org].vue
@@ -10,6 +10,8 @@ definePageMeta({
 const route = useRoute('org')
 const router = useRouter()
 
+const DEFAULT_SORT = 'downloads-week-desc' satisfies SortOption
+
 const orgName = computed(() => route.params.org.toLowerCase())
 
 const { isConnected } = useConnector()
@@ -57,7 +59,7 @@ const {
   setSort,
 } = useStructuredFilters({
   packages,
-  initialSort: (normalizeSearchParam(route.query.sort) as SortOption) ?? 'downloads-week-desc',
+  initialSort: (normalizeSearchParam(route.query.sort) as SortOption) ?? DEFAULT_SORT,
 })
 
 // Pagination state
@@ -86,7 +88,7 @@ const updateUrl = debounce((updates: { filter?: string; sort?: string }) => {
     query: {
       ...route.query,
       q: updates.filter || undefined,
-      sort: updates.sort && updates.sort !== 'downloads-week-desc' ? updates.sort : undefined,
+      sort: updates.sort && updates.sort !== DEFAULT_SORT ? updates.sort : undefined,
     },
   })
 }, 300)
@@ -112,7 +114,7 @@ const totalWeeklyDownloads = computed(() =>
 // Reset state when org changes
 watch(orgName, () => {
   clearAllFilters()
-  setSort('downloads-week-desc')
+  setSort(DEFAULT_SORT)
   currentPage.value = 1
 })
 

--- a/app/pages/org/[org].vue
+++ b/app/pages/org/[org].vue
@@ -57,7 +57,7 @@ const {
   setSort,
 } = useStructuredFilters({
   packages,
-  initialSort: (normalizeSearchParam(route.query.sort) as SortOption) ?? 'updated-desc',
+  initialSort: (normalizeSearchParam(route.query.sort) as SortOption) ?? 'downloads-week-desc',
 })
 
 // Pagination state
@@ -86,7 +86,7 @@ const updateUrl = debounce((updates: { filter?: string; sort?: string }) => {
     query: {
       ...route.query,
       q: updates.filter || undefined,
-      sort: updates.sort && updates.sort !== 'updated-desc' ? updates.sort : undefined,
+      sort: updates.sort && updates.sort !== 'downloads-week-desc' ? updates.sort : undefined,
     },
   })
 }, 300)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Resolves #2471

### 🧭 Context

<!-- Brief background and why this change is needed -->

### Describe the bug

- `https://npmx.dev/org/arnaud-barre` -> Sort dropdown is `Downloads/wk`
- Change to `Last published`, no URL change
- Change back to `Downloads/wk`, `?sort=downloads-week-desc` is append to the URL

The makes it annoying in the following flow:
- Change to last published, click the first one
- Navigate back, you don't get back the list order


<!-- High-level summary of what changed -->
Changed default sorting on `/org/` pages to match the default sorting method used in 

https://github.com/npmx-dev/npmx.dev/blob/016406444c35dbcb890b9eaf106f81c3a99b7d8b/shared/types/preferences.ts#L133-L149

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

`/org/[org]` pages used `updated-desc` as the default sorting method

https://github.com/npmx-dev/npmx.dev/blob/016406444c35dbcb890b9eaf106f81c3a99b7d8b/app/pages/org/%5Borg%5D.vue#L60

The `ListToolbar` component used on that page, relies on the fn `parseSortOption`, which uses `downloads-week-desc` as the default sorting method though, as defined in

https://github.com/npmx-dev/npmx.dev/blob/016406444c35dbcb890b9eaf106f81c3a99b7d8b/shared/types/preferences.ts#L133-L149

So when `/org/` used the default sorting method, it didn't save it in the URL query params. The `/org/` page thought that `updated-desc i` was used, but `ListToolbar` thought that `downloads-weeks-desc i` was used. This caused the desync as outlined in the issue.

I adjusted the default on the `/org/` page to align with the default set in `shared/types/preferences.ts`.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
