### PR TITLE
feat: add a badge type for package likes

### DIFF
--- a/docs/content/2.guide/6.badges.md
+++ b/docs/content/2.guide/6.badges.md
@@ -28,6 +28,7 @@ npmx.dev offers many different SVG badges with stats about any package via its A
 - **maintainers**: Displays the total count of package maintainers. :img{src="https://img.shields.io/badge/%2306b6d4-06b6d4" class="inline align-middle h-5 w-14"}
 - **deprecated**: Shows if the package is active or deprecated. :img{src="https://img.shields.io/badge/%2322c55e-22c55e" class="inline align-middle h-5 w-14"} / :img{src="https://img.shields.io/badge/%23ef4444-ef4444" class="inline align-middle h-5 w-14"}
 - **name**: Simple badge displaying the package name. :img{src="https://img.shields.io/badge/%2364748b-64748b" class="inline align-middle h-5 w-14"}
+- **likes**: Shows the total count of package likes on npmx.dev. :img{src="https://img.shields.io/badge/%233b82f6-3b82f6" class="inline align-middle h-5 w-14"}
 
 ## Examples
 

--- a/docs/content/2.guide/6.badges.md
+++ b/docs/content/2.guide/6.badges.md
@@ -28,7 +28,7 @@ npmx.dev offers many different SVG badges with stats about any package via its A
 - **maintainers**: Displays the total count of package maintainers. :img{src="https://img.shields.io/badge/%2306b6d4-06b6d4" class="inline align-middle h-5 w-14"}
 - **deprecated**: Shows if the package is active or deprecated. :img{src="https://img.shields.io/badge/%2322c55e-22c55e" class="inline align-middle h-5 w-14"} / :img{src="https://img.shields.io/badge/%23ef4444-ef4444" class="inline align-middle h-5 w-14"}
 - **name**: Simple badge displaying the package name. :img{src="https://img.shields.io/badge/%2364748b-64748b" class="inline align-middle h-5 w-14"}
-- **likes**: Shows the total count of likes of the package. :img{src="https://img.shields.io/badge/%233b82f6-3b82f6" class="inline align-middle h-5 w-14"}
+- **likes**: Shows the total count of package likes. :img{src="https://img.shields.io/badge/%233b82f6-3b82f6" class="inline align-middle h-5 w-14"}
 
 ## Examples
 

--- a/docs/content/2.guide/6.badges.md
+++ b/docs/content/2.guide/6.badges.md
@@ -28,7 +28,7 @@ npmx.dev offers many different SVG badges with stats about any package via its A
 - **maintainers**: Displays the total count of package maintainers. :img{src="https://img.shields.io/badge/%2306b6d4-06b6d4" class="inline align-middle h-5 w-14"}
 - **deprecated**: Shows if the package is active or deprecated. :img{src="https://img.shields.io/badge/%2322c55e-22c55e" class="inline align-middle h-5 w-14"} / :img{src="https://img.shields.io/badge/%23ef4444-ef4444" class="inline align-middle h-5 w-14"}
 - **name**: Simple badge displaying the package name. :img{src="https://img.shields.io/badge/%2364748b-64748b" class="inline align-middle h-5 w-14"}
-- **likes**: Shows the total count of package likes on npmx.dev. :img{src="https://img.shields.io/badge/%233b82f6-3b82f6" class="inline align-middle h-5 w-14"}
+- **likes**: Shows the total count of likes of the package. :img{src="https://img.shields.io/badge/%233b82f6-3b82f6" class="inline align-middle h-5 w-14"}
 
 ## Examples
 

--- a/docs/content/2.guide/6.badges.md
+++ b/docs/content/2.guide/6.badges.md
@@ -28,7 +28,7 @@ npmx.dev offers many different SVG badges with stats about any package via its A
 - **maintainers**: Displays the total count of package maintainers. :img{src="https://img.shields.io/badge/%2306b6d4-06b6d4" class="inline align-middle h-5 w-14"}
 - **deprecated**: Shows if the package is active or deprecated. :img{src="https://img.shields.io/badge/%2322c55e-22c55e" class="inline align-middle h-5 w-14"} / :img{src="https://img.shields.io/badge/%23ef4444-ef4444" class="inline align-middle h-5 w-14"}
 - **name**: Simple badge displaying the package name. :img{src="https://img.shields.io/badge/%2364748b-64748b" class="inline align-middle h-5 w-14"}
-- **likes**: Shows the total count of package likes. :img{src="https://img.shields.io/badge/%233b82f6-3b82f6" class="inline align-middle h-5 w-14"}
+- **likes**: Shows the total count of package likes. :img{src="https://img.shields.io/badge/%23ef4444-ef4444" class="inline align-middle h-5 w-14"}
 
 ## Examples
 

--- a/docs/shared/utils/badges.ts
+++ b/docs/shared/utils/badges.ts
@@ -16,6 +16,7 @@ export const BADGE_TYPES = Object.freeze([
   'maintainers',
   'deprecated',
   'name',
+  'likes',
 ] as const)
 
 export type BadgeType = (typeof BADGE_TYPES)[number]

--- a/server/api/registry/badge/[type]/[...pkg].get.ts
+++ b/server/api/registry/badge/[type]/[...pkg].get.ts
@@ -496,6 +496,13 @@ const badgeStrategies = {
       color: isDeprecated ? COLORS.red : COLORS.green,
     }
   },
+
+  'likes': async (pkgData: globalThis.Packument) => {
+    const likesUtil = new PackageLikesUtils()
+    const { totalLikes } = await likesUtil.getLikes(pkgData.name)
+
+    return { label: 'likes', value: String(totalLikes ?? 10), color: COLORS.blue }
+  },
 }
 
 const BadgeTypeSchema = v.picklist(Object.keys(badgeStrategies) as [string, ...string[]])

--- a/server/api/registry/badge/[type]/[...pkg].get.ts
+++ b/server/api/registry/badge/[type]/[...pkg].get.ts
@@ -501,7 +501,7 @@ const badgeStrategies = {
     const likesUtil = new PackageLikesUtils()
     const { totalLikes } = await likesUtil.getLikes(pkgData.name)
 
-    return { label: 'likes', value: String(totalLikes ?? 0), color: COLORS.blue }
+    return { label: 'likes', value: String(totalLikes ?? 0), color: COLORS.red }
   },
 }
 

--- a/server/api/registry/badge/[type]/[...pkg].get.ts
+++ b/server/api/registry/badge/[type]/[...pkg].get.ts
@@ -501,7 +501,7 @@ const badgeStrategies = {
     const likesUtil = new PackageLikesUtils()
     const { totalLikes } = await likesUtil.getLikes(pkgData.name)
 
-    return { label: 'likes', value: String(totalLikes ?? 10), color: COLORS.blue }
+    return { label: 'likes', value: String(totalLikes ?? 0), color: COLORS.blue }
   },
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Resolves #2412

### 🧭 Context

<!-- Brief background and why this change is needed -->
In #2412, it was requested to have a badge variant that shows the likes a specific package has on npmx.dev.

<!-- High-level summary of what changed -->
This PR introduces a `likes`-type badge.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
This PR adds a badge type called `likes` and integrates the logic of the `https://npmx.dev/api/social/likes/[pkg]` endpoint into it.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
