### PR TITLE
feat: add `socket.dev` link into package command palette

### DIFF
--- a/app/components/Package/ExternalLinks.vue
+++ b/app/components/Package/ExternalLinks.vue
@@ -118,6 +118,15 @@ useCommandPaletteContextCommands(
     }
 
     commands.push({
+      id: 'package-link-socket.dev',
+      group: 'links',
+      label: 'socket.dev',
+      keywords: [...packageKeywords, 'socket.dev'],
+      iconClass: 'i-simple-icons:socket',
+      href: `https://socket.dev/npm/package/${props.pkg.name}`,
+    })
+
+    commands.push({
       id: 'package-link-npm',
       group: 'links',
       label: 'npm',


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2480.

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

Link to `socket.dev` was missing in package command palette (Cmd/Ctrl+K) menu. 

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description
Simple change to ensure link is added to `commands` array and thus visible in command palette. 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
