### PR TITLE
fix: highlight scatter axes on facet inputs focus

### DIFF
--- a/app/components/Compare/FacetScatterChart.vue
+++ b/app/components/Compare/FacetScatterChart.vue
@@ -323,7 +323,7 @@ function toggleAxisHighlight(state: AxisHighlight) {
           block
           @change="step += 1"
           @mouseenter="toggleAxisHighlight('y')"
-          @focus="toggleAxisHighlight('y')"
+          @mouseleave="toggleAxisHighlight(null)"
           @focusin="toggleAxisHighlight('y')"
           @focusout="toggleAxisHighlight(null)"
         />

--- a/app/components/Compare/FacetScatterChart.vue
+++ b/app/components/Compare/FacetScatterChart.vue
@@ -310,7 +310,8 @@ function toggleAxisHighlight(state: AxisHighlight) {
           @change="step += 1"
           @mouseenter="toggleAxisHighlight('x')"
           @mouseleave="toggleAxisHighlight(null)"
-          @blur="toggleAxisHighlight(null)"
+          @focusin="toggleAxisHighlight('x')"
+          @focusout="toggleAxisHighlight(null)"
         />
         <SelectField
           class="w-full"
@@ -322,8 +323,9 @@ function toggleAxisHighlight(state: AxisHighlight) {
           block
           @change="step += 1"
           @mouseenter="toggleAxisHighlight('y')"
-          @mouseleave="toggleAxisHighlight(null)"
-          @blur="toggleAxisHighlight(null)"
+          @focus="toggleAxisHighlight('y')"
+          @focusin="toggleAxisHighlight('y')"
+          @focusout="toggleAxisHighlight(null)"
         />
       </div>
 


### PR DESCRIPTION
Resolves #2483

(Forgot to push a commit on #2472)

This also highlights the related scatter axis when accessing facet inputs via keyboard.