### PR TITLE
fix: encode username in constructed gravatar URL

### DIFF
--- a/app/components/User/Avatar.vue
+++ b/app/components/User/Avatar.vue
@@ -31,7 +31,7 @@ const textClass = computed(() => {
   }
 })
 
-const { data: gravatarUrl } = useLazyFetch(() => `/api/gravatar/${props.username}`, {
+const { data: gravatarUrl } = useLazyFetch(() => `/api/gravatar/${encodeURIComponent(props.username)}`, {
   transform: res => (res.hash ? `/_avatar/${res.hash}?s=128&d=404` : null),
   getCachedData(key, nuxtApp) {
     return nuxtApp.static.data[key] ?? nuxtApp.payload.data[key]

--- a/app/components/User/Avatar.vue
+++ b/app/components/User/Avatar.vue
@@ -31,12 +31,15 @@ const textClass = computed(() => {
   }
 })
 
-const { data: gravatarUrl } = useLazyFetch(() => `/api/gravatar/${encodeURIComponent(props.username)}`, {
-  transform: res => (res.hash ? `/_avatar/${res.hash}?s=128&d=404` : null),
-  getCachedData(key, nuxtApp) {
-    return nuxtApp.static.data[key] ?? nuxtApp.payload.data[key]
+const { data: gravatarUrl } = useLazyFetch(
+  () => `/api/gravatar/${encodeURIComponent(props.username)}`,
+  {
+    transform: res => (res.hash ? `/_avatar/${res.hash}?s=128&d=404` : null),
+    getCachedData(key, nuxtApp) {
+      return nuxtApp.static.data[key] ?? nuxtApp.payload.data[key]
+    },
   },
-})
+)
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

Security: Unencoded username in API route construction

## Problem

**Severity**: `Medium` | **File**: `app/components/User/Avatar.vue:L30`

The username is inserted directly into `/api/gravatar/${props.username}`. A crafted username containing path separators or reserved URL characters can change the effective request path and potentially hit unintended endpoints.

## Solution

Wrap the username with `encodeURIComponent(props.username)` when constructing the URL path.

## Changes

- `app/components/User/Avatar.vue` (modified)