### PR TITLE
perf(ui): cache search keyboard navigation targets

### DIFF
--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -408,29 +408,62 @@ const exactMatchType = computed<'package' | 'org' | 'user' | null>(() => {
 const suggestionCount = computed(() => validatedSuggestions.value.length)
 const totalSelectableCount = computed(() => suggestionCount.value + resultCount.value)
 
+const resultsContainerRef = useTemplateRef<HTMLElement>('resultsContainerRef')
 const isVisible = (el: HTMLElement) => el.getClientRects().length > 0
+const focusableElements = shallowRef<HTMLElement[]>([])
+let focusableElementsObserver: MutationObserver | null = null
+let refreshFocusableElementsFrame: number | null = null
 
 /**
- * Get all focusable result elements in DOM order (suggestions first, then packages)
+ * Cache all keyboard-focusable result elements in DOM order.
+ * DOM order already matches our navigation order: suggestions first, then packages.
  */
-function getFocusableElements(): HTMLElement[] {
-  const suggestions = Array.from(document.querySelectorAll<HTMLElement>('[data-suggestion-index]'))
-    .filter(isVisible)
-    .sort((a, b) => {
-      const aIdx = Number.parseInt(a.dataset.suggestionIndex ?? '0', 10)
-      const bIdx = Number.parseInt(b.dataset.suggestionIndex ?? '0', 10)
-      return aIdx - bIdx
-    })
+function refreshFocusableElements() {
+  const root = resultsContainerRef.value
+  if (!root) {
+    focusableElements.value = []
+    return
+  }
 
-  const packages = Array.from(document.querySelectorAll<HTMLElement>('[data-result-index]'))
-    .filter(isVisible)
-    .sort((a, b) => {
-      const aIdx = Number.parseInt(a.dataset.resultIndex ?? '0', 10)
-      const bIdx = Number.parseInt(b.dataset.resultIndex ?? '0', 10)
-      return aIdx - bIdx
-    })
+  focusableElements.value = Array.from(
+    root.querySelectorAll<HTMLElement>('[data-suggestion-index], [data-result-index]'),
+  ).filter(isVisible)
+}
 
-  return [...suggestions, ...packages]
+function scheduleFocusableElementsRefresh() {
+  if (!import.meta.client) return
+  if (refreshFocusableElementsFrame != null) return
+
+  refreshFocusableElementsFrame = window.requestAnimationFrame(() => {
+    refreshFocusableElementsFrame = null
+    refreshFocusableElements()
+  })
+}
+
+function stopObservingFocusableElements() {
+  focusableElementsObserver?.disconnect()
+  focusableElementsObserver = null
+  focusableElements.value = []
+}
+
+function startObservingFocusableElements() {
+  stopObservingFocusableElements()
+
+  const root = resultsContainerRef.value
+  if (!root || !import.meta.client) return
+
+  focusableElementsObserver = new MutationObserver(() => {
+    scheduleFocusableElementsRefresh()
+  })
+
+  focusableElementsObserver.observe(root, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['class', 'style', 'hidden', 'aria-hidden'],
+  })
+
+  scheduleFocusableElementsRefresh()
 }
 
 /**
@@ -472,6 +505,29 @@ watch(displayResults, newResults => {
   }
 })
 
+watch(resultsContainerRef, () => {
+  startObservingFocusableElements()
+})
+
+watch(
+  [
+    suggestionCount,
+    resultCount,
+    viewMode,
+    paginationMode,
+    currentPage,
+    showSelectionView,
+    isRateLimited,
+    committedQuery,
+  ],
+  () => {
+    nextTick(() => {
+      scheduleFocusableElementsRefresh()
+    })
+  },
+  { flush: 'post' },
+)
+
 /**
  * Focus the header search input
  */
@@ -511,7 +567,7 @@ function handleResultsKeydown(e: KeyboardEvent) {
 
   if (totalSelectableCount.value <= 0) return
 
-  const elements = getFocusableElements()
+  const elements = focusableElements.value
   if (elements.length === 0) return
 
   const currentIndex = elements.findIndex(el => el === document.activeElement)
@@ -551,6 +607,10 @@ function handleResultsKeydown(e: KeyboardEvent) {
 }
 
 onKeyDown(['ArrowDown', 'ArrowUp', 'Enter'], handleResultsKeydown)
+
+onMounted(() => {
+  startObservingFocusableElements()
+})
 
 useSeoMeta({
   title: () =>
@@ -669,6 +729,11 @@ watch(
 )
 
 onBeforeUnmount(() => {
+  stopObservingFocusableElements()
+  if (refreshFocusableElementsFrame != null) {
+    window.cancelAnimationFrame(refreshFocusableElementsFrame)
+    refreshFocusableElementsFrame = null
+  }
   updateLiveRegionMobile.cancel()
   updateLiveRegionDesktop.cancel()
 })
@@ -701,7 +766,7 @@ onBeforeUnmount(() => {
         :view-mode="viewMode"
       />
 
-      <section v-else-if="committedQuery" class="results-layout">
+      <section v-else-if="committedQuery" ref="resultsContainerRef" class="results-layout">
         <LoadingSpinner v-if="showSearching" :text="$t('search.searching')" />
 
         <div

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -470,7 +470,6 @@ function startObservingFocusableElements() {
   // Perform an initial synchronous refresh so focusableElements is populated
   // before any immediate key handling (ArrowUp/ArrowDown) occurs.
   refreshFocusableElements()
-  scheduleFocusableElementsRefresh()
 }
 
 /**

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -740,10 +740,6 @@ watch(
 
 onBeforeUnmount(() => {
   stopObservingFocusableElements()
-  if (refreshFocusableElementsFrame != null) {
-    window.cancelAnimationFrame(refreshFocusableElementsFrame)
-    refreshFocusableElementsFrame = null
-  }
   updateLiveRegionMobile.cancel()
   updateLiveRegionDesktop.cancel()
 })

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -443,6 +443,10 @@ function scheduleFocusableElementsRefresh() {
 function stopObservingFocusableElements() {
   focusableElementsObserver?.disconnect()
   focusableElementsObserver = null
+  if (refreshFocusableElementsFrame != null) {
+    window.cancelAnimationFrame(refreshFocusableElementsFrame)
+    refreshFocusableElementsFrame = null
+  }
   focusableElements.value = []
 }
 
@@ -463,6 +467,9 @@ function startObservingFocusableElements() {
     attributeFilter: ['class', 'style', 'hidden', 'aria-hidden'],
   })
 
+  // Perform an initial synchronous refresh so focusableElements is populated
+  // before any immediate key handling (ArrowUp/ArrowDown) occurs.
+  refreshFocusableElements()
   scheduleFocusableElementsRefresh()
 }
 

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -529,6 +529,9 @@ watch(
   ],
   () => {
     nextTick(() => {
+      if (!resultsContainerRef.value) {
+        return
+      }
       scheduleFocusableElementsRefresh()
     })
   },


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

The search page supports keyboard navigation across suggestions and package results with `ArrowUp`, `ArrowDown`, and `Enter`.

That navigation path was doing repeated DOM queries and per-key sorting to rebuild the list of selectable elements on every key press. On larger result sets, that adds unnecessary work to a hot interaction path and can make keyboard movement through results feel sluggish.

While optimizing that path, a follow-up issue showed up: the cached focus targets were being populated on the next animation frame, which left a brief window where results were visible but keyboard navigation had no cached targets yet. In practice, if a user pressed an arrow key immediately after results rendered, nothing could happen. There was also a teardown gap where a pending animation frame could refill the cache after observation had stopped.

### 📚 Description

This change updates search keyboard navigation to cache focusable result elements instead of querying and sorting the DOM on every key press.

It introduces a scoped results container ref, maintains the cached focus target list with a `MutationObserver`, and refreshes that cache when relevant search UI state changes. This keeps navigation work lightweight while preserving the existing DOM-order behavior of suggestions first, then package results.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
