### PR TITLE
feat: add npmjs.dev to playground links (#2314)

### DIFF
--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -63,20 +63,33 @@ const { data: readmeData } = useLazyFetch<ReadmeResponse>(
   },
 )
 
-const playgroundLinks = computed(() => [
-  ...readmeData.value.playgroundLinks,
+const playgroundLinks = computed(() => {
+  const links = [...readmeData.value.playgroundLinks]
+
+  const packageData = pkg.value
+  if (!packageData) {
+    return links
+  }
+
   // Libraries with a storybook field in package.json contain a link to their deployed playground
-  ...(pkg.value?.storybook?.url
-    ? [
-        {
-          url: pkg.value.storybook.url,
-          provider: 'storybook',
-          providerName: 'Storybook',
-          label: 'Storybook',
-        },
-      ]
-    : []),
-])
+  if (packageData.storybook?.url) {
+    links.push({
+      url: packageData.storybook.url,
+      provider: 'storybook',
+      providerName: 'Storybook',
+      label: 'Storybook',
+    })
+  }
+
+  links.push({
+    url: `https://npmjs.dev/${packageData.name}`,
+    provider: 'npmjs.dev',
+    providerName: 'npmjs.dev',
+    label: 'npmjs.dev',
+  })
+
+  return links
+})
 
 const {
   data: readmeMarkdownData,


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2314.

### 🧭 Context

Simple solution to provide "Try on RunKit" alternative by linking to `https://npmjs.dev/{packageName]` and keep "how to run package in browser" out of npmx.dev scope.

### 📚 Description

Adds "npmjs.dev" to collapsible "Try it out" section in package sidebar. This PR makes a change to always add link to ad-hoc playground on `npmjs.dev`. Link is added last to the list and will always appear after official playgrounds, e.g. CodeSandbox or Storybook. 

I originally considered to add this link to `ExternalLinks.vue` but "Playgrounds" seems to be a perfect fit for it. Downside of this solution is that "Try it out" section is now always present, which pushes Versions section down. 

Open to hear feedback and iterate on this solution.