### PR TITLE
fix: source profile data from npm

### DIFF
--- a/app/composables/npm/useUserPackages.ts
+++ b/app/composables/npm/useUserPackages.ts
@@ -1,22 +1,9 @@
-/** Default page size for incremental loading (npm registry path) */
-const PAGE_SIZE = 50 as const
-
-/** npm search API practical limit for maintainer queries */
-const MAX_RESULTS = 250
-
 /**
- * Fetch packages for a given npm user/maintainer.
+ * Fetch all packages for a given npm user.
  *
- * The composable handles all loading strategy internally based on the active
- * search provider. Consumers get a uniform interface regardless of provider:
- *
- * - **Algolia**: Fetches all packages at once via `owner.name` filter (fast).
- * - **npm**: Incrementally paginates through `maintainer:` search results.
- *
- * @example
- * ```ts
- * const { data, status, hasMore, isLoadingMore, loadMore } = useUserPackages(username)
- * ```
+ * Mirrors {@link useOrgPackages} — both use the same npm registry endpoint
+ * (`/-/org/<name>/package`) which accepts usernames and org names alike.
+ * The only difference: unknown users return an empty list instead of a 404.
  */
 export function useUserPackages(username: MaybeRefOrGetter<string>) {
   const route = useRoute()
@@ -26,24 +13,7 @@ export function useUserPackages(username: MaybeRefOrGetter<string>) {
     if (p === 'npm' || searchProvider.value === 'npm') return 'npm'
     return 'algolia'
   })
-  // this is only used in npm path, but we need to extract it when the composable runs
-  const { $npmRegistry } = useNuxtApp()
-  const { searchByOwner } = useAlgoliaSearch()
-
-  // --- Incremental loading state (npm path) ---
-  const currentPage = shallowRef(1)
-
-  /** Tracks which provider actually served the current data (may differ from
-   *  searchProvider when Algolia returns empty and we fall through to npm) */
-  const activeProvider = shallowRef<'npm' | 'algolia'>(searchProviderValue.value)
-
-  const cache = shallowRef<{
-    username: string
-    objects: NpmSearchResult[]
-    total: number
-  } | null>(null)
-
-  const isLoadingMore = shallowRef(false)
+  const { getPackagesByName } = useAlgoliaSearch()
 
   const asyncData = useLazyAsyncData(
     () => `user-packages:${searchProviderValue.value}:${toValue(username)}`,
@@ -53,197 +23,72 @@ export function useUserPackages(username: MaybeRefOrGetter<string>) {
         return emptySearchResponse()
       }
 
-      const provider = searchProviderValue.value
-
-      // --- Algolia: fetch all at once ---
-      if (provider === 'algolia') {
-        try {
-          const response = await searchByOwner(user)
-
-          // Guard against stale response (user/provider changed during await)
-          if (user !== toValue(username) || provider !== searchProviderValue.value) {
-            return emptySearchResponse()
-          }
-
-          // If Algolia returns results, use them. If empty, fall through to npm
-          // registry which uses `maintainer:` search (matches all maintainers,
-          // not just the primary owner that Algolia's owner.name indexes).
-          if (response.objects.length > 0) {
-            activeProvider.value = 'algolia'
-            cache.value = {
-              username: user,
-              objects: response.objects,
-              total: response.total,
-            }
-            return response
-          }
-        } catch {
-          // Fall through to npm registry path on Algolia failure
-        }
-      }
-
-      // --- npm registry: initial page (or Algolia fallback) ---
-      activeProvider.value = 'npm'
-      cache.value = null
-      currentPage.value = 1
-
-      const params = new URLSearchParams()
-      params.set('text', `maintainer:${user}`)
-      params.set('size', String(PAGE_SIZE))
-
-      const { data: response, isStale } = await $npmRegistry<NpmSearchResponse>(
-        `/-/v1/search?${params.toString()}`,
-        { signal },
-        60,
-      )
-
-      // Guard against stale response (user/provider changed during await)
-      if (user !== toValue(username) || provider !== searchProviderValue.value) {
+      let packageNames: string[]
+      try {
+        const { packages } = await $fetch<{ packages: string[]; count: number }>(
+          `/api/registry/org/${encodeURIComponent(user)}/packages`,
+          { signal },
+        )
+        packageNames = packages
+      } catch {
+        // Unknown user or network error — show empty state, not a 404
         return emptySearchResponse()
       }
 
-      cache.value = {
-        username: user,
-        objects: response.objects,
-        total: response.total,
+      if (user !== toValue(username)) {
+        return emptySearchResponse()
       }
 
-      return { ...response, isStale }
+      if (packageNames.length === 0) {
+        return emptySearchResponse()
+      }
+
+      if (searchProviderValue.value === 'algolia') {
+        try {
+          const response = await getPackagesByName(packageNames)
+          if (user !== toValue(username)) {
+            return emptySearchResponse()
+          }
+          if (response.objects.length > 0) {
+            return response
+          }
+        } catch {
+          // Fall through to npm registry path
+        }
+      }
+
+      const metaResults = await mapWithConcurrency(
+        packageNames,
+        async name => {
+          try {
+            return await $fetch<PackageMetaResponse>(
+              `/api/registry/package-meta/${encodePackageName(name)}`,
+              { signal },
+            )
+          } catch {
+            return null
+          }
+        },
+        10,
+      )
+
+      if (user !== toValue(username)) {
+        return emptySearchResponse()
+      }
+
+      const results: NpmSearchResult[] = metaResults
+        .filter((meta): meta is PackageMetaResponse => meta !== null)
+        .map(metaToSearchResult)
+
+      return {
+        isStale: false,
+        objects: results,
+        total: results.length,
+        time: new Date().toISOString(),
+      } satisfies NpmSearchResponse
     },
     { default: emptySearchResponse },
   )
-  // --- Fetch more (npm path only) ---
-  /**
-   * Fetch the next page of results from npm registry.
-   * @param manageLoadingState - When false, caller manages isLoadingMore (used by loadAll to prevent flicker)
-   */
-  async function fetchMore(manageLoadingState = true): Promise<void> {
-    const user = toValue(username)
-    // Use activeProvider: if Algolia fell through to npm, we still need pagination
-    if (!user || activeProvider.value !== 'npm') return
 
-    if (cache.value && cache.value.username !== user) {
-      cache.value = null
-      await asyncData.refresh()
-      return
-    }
-
-    const currentCount = cache.value?.objects.length ?? 0
-    const total = Math.min(cache.value?.total ?? Infinity, MAX_RESULTS)
-
-    if (currentCount >= total) return
-
-    if (manageLoadingState) isLoadingMore.value = true
-
-    try {
-      const from = currentCount
-      const size = Math.min(PAGE_SIZE, total - currentCount)
-
-      const params = new URLSearchParams()
-      params.set('text', `maintainer:${user}`)
-      params.set('size', String(size))
-      params.set('from', String(from))
-
-      const { data: response } = await $npmRegistry<NpmSearchResponse>(
-        `/-/v1/search?${params.toString()}`,
-        {},
-        60,
-      )
-
-      // Guard against stale response
-      if (user !== toValue(username) || activeProvider.value !== 'npm') return
-
-      if (cache.value && cache.value.username === user) {
-        const existingNames = new Set(cache.value.objects.map(obj => obj.package.name))
-        const newObjects = response.objects.filter(obj => !existingNames.has(obj.package.name))
-        cache.value = {
-          username: user,
-          objects: [...cache.value.objects, ...newObjects],
-          total: response.total,
-        }
-      } else {
-        cache.value = {
-          username: user,
-          objects: response.objects,
-          total: response.total,
-        }
-      }
-    } finally {
-      if (manageLoadingState) isLoadingMore.value = false
-    }
-  }
-
-  /** Load the next page of results (no-op if all loaded or using Algolia) */
-  async function loadMore(): Promise<void> {
-    if (isLoadingMore.value || !hasMore.value) return
-    currentPage.value++
-    await fetchMore()
-  }
-
-  /** Load all remaining results at once (e.g. when user starts filtering) */
-  async function loadAll(): Promise<void> {
-    if (!hasMore.value) return
-
-    isLoadingMore.value = true
-    try {
-      while (hasMore.value) {
-        await fetchMore(false)
-      }
-    } finally {
-      isLoadingMore.value = false
-    }
-  }
-
-  // asyncdata will automatically rerun due to key, but we need to reset cache/page
-  // when provider changes
-  watch(
-    () => searchProviderValue.value,
-    newProvider => {
-      cache.value = null
-      currentPage.value = 1
-      activeProvider.value = newProvider
-    },
-  )
-
-  // Computed data that uses cache (only if it belongs to the current username)
-  const data = computed<NpmSearchResponse | null>(() => {
-    const user = toValue(username)
-    if (cache.value && cache.value.username === user) {
-      return {
-        isStale: false,
-        objects: cache.value.objects,
-        total: cache.value.total,
-        time: new Date().toISOString(),
-      }
-    }
-    return asyncData.data.value
-  })
-
-  /** Whether there are more results available to load (npm path only) */
-  const hasMore = computed(() => {
-    if (!toValue(username)) return false
-    // Algolia fetches everything in one request; only npm needs pagination
-    if (activeProvider.value !== 'npm') return false
-    if (!cache.value) return true
-    // npm path: more available if we haven't hit the server total or our cap
-    const fetched = cache.value.objects.length
-    const available = cache.value.total
-    return fetched < available && fetched < MAX_RESULTS
-  })
-
-  return {
-    ...asyncData,
-    /** Reactive package results */
-    data,
-    /** Whether currently loading more results */
-    isLoadingMore,
-    /** Whether there are more results available */
-    hasMore,
-    /** Load next page of results */
-    loadMore,
-    /** Load all remaining results (for filter/sort) */
-    loadAll,
-    /** Default page size (for display) */
-    pageSize: PAGE_SIZE,
-  }
+  return asyncData
 }

--- a/app/pages/~[username]/index.vue
+++ b/app/pages/~[username]/index.vue
@@ -32,25 +32,14 @@ const debouncedUpdateUrl = debounce((filter: string, sort: string) => {
   updateUrl({ filter, sort })
 }, 300)
 
-// Load all results when user starts filtering/sorting (so client-side filter works on full set)
+// Update URL when filter/sort changes (debounced)
 watch([filterText, sortOption], ([filter, sort]) => {
-  if (filter !== '' || sort !== 'downloads') {
-    loadAll()
-  }
   debouncedUpdateUrl(filter, sort)
 })
 
-// Fetch packages (composable manages pagination & provider dispatch internally)
-const {
-  data: results,
-  status,
-  error,
-  isLoadingMore,
-  hasMore,
-  loadMore,
-  loadAll,
-  pageSize,
-} = useUserPackages(username)
+// Fetch packages from npm registry (same endpoint as org page, but
+// unknown users get empty results instead of a 404 error page)
+const { data: results, status, error } = useUserPackages(username)
 
 // Get initial page from URL (for scroll restoration on reload)
 const initialPage = computed(() => {
@@ -217,11 +206,7 @@ defineOgImageComponent('Default', {
       <PackageList
         v-else
         :results="filteredAndSortedPackages"
-        :has-more="hasMore"
-        :is-loading="isLoadingMore"
-        :page-size="pageSize"
         :initial-page="initialPage"
-        @load-more="loadMore"
         @page-change="handlePageChange"
       />
     </section>

--- a/app/pages/~[username]/index.vue
+++ b/app/pages/~[username]/index.vue
@@ -189,10 +189,7 @@ defineOgImageComponent('Default', {
         {{ $t('user.page.no_match', { query: filterText }) }}
       </p>
 
-      <PackageList
-        v-else
-        :results="filteredAndSortedPackages"
-      />
+      <PackageList v-else :results="filteredAndSortedPackages" />
     </section>
 
     <!-- Empty state (no packages found for user) -->

--- a/app/pages/~[username]/index.vue
+++ b/app/pages/~[username]/index.vue
@@ -7,12 +7,11 @@ const router = useRouter()
 
 const username = computed(() => route.params.username.toLowerCase())
 
-// Debounced URL update for page and filter/sort
-const updateUrl = debounce((updates: { page?: number; filter?: string; sort?: string }) => {
+// Debounced URL update for filter/sort
+const updateUrl = debounce((updates: { filter?: string; sort?: string }) => {
   router.replace({
     query: {
       ...route.query,
-      page: updates.page && updates.page > 1 ? updates.page : undefined,
       q: updates.filter || undefined,
       sort: updates.sort && updates.sort !== 'downloads' ? updates.sort : undefined,
     },
@@ -37,15 +36,7 @@ watch([filterText, sortOption], ([filter, sort]) => {
   debouncedUpdateUrl(filter, sort)
 })
 
-// Fetch packages from npm registry (same endpoint as org page, but
-// unknown users get empty results instead of a 404 error page)
 const { data: results, status, error } = useUserPackages(username)
-
-// Get initial page from URL (for scroll restoration on reload)
-const initialPage = computed(() => {
-  const p = Number.parseInt(normalizeSearchParam(route.query.page), 10)
-  return Number.isNaN(p) ? 1 : Math.max(1, p)
-})
 
 // Get the base packages list
 const packages = computed(() => results.value?.objects ?? [])
@@ -96,11 +87,6 @@ const filteredCount = computed(() => filteredAndSortedPackages.value.length)
 const totalWeeklyDownloads = computed(() =>
   filteredAndSortedPackages.value.reduce((sum, pkg) => sum + (pkg.downloads?.weekly ?? 0), 0),
 )
-
-// Update URL when page changes from scrolling
-function handlePageChange(page: number) {
-  updateUrl({ page, filter: filterText.value, sort: sortOption.value })
-}
 
 // Reset state when username changes
 watch(username, () => {
@@ -206,8 +192,6 @@ defineOgImageComponent('Default', {
       <PackageList
         v-else
         :results="filteredAndSortedPackages"
-        :initial-page="initialPage"
-        @page-change="handlePageChange"
       />
     </section>
 


### PR DESCRIPTION
fixes #2504 

This PR reuses the org code to power the `useUserPackages.ts` hook.

Why? well the endpoint to get packages for orgs also works for users, by design. So we can reuse the API w/o any loss of accuracy. 

~It's a dirty lil hack rn, just reuse that same hook. I spent enough time root causing this bug, so this is the short term fix that I prefer and prefer to have reviewed.~ Seeing the red checks made me come back and try to do this slightly cleaner lol. Now im jsut duplicatng the logic of the org hook whereas before I was using the org hook itself. It's messy.

There is an existing bug btw on the Org pages, which is present in this PR as well. The org logic is limited to fetching 1k packages at once from npm, but there is no limit or pagination currently. See https://www.npmx.dev/~sindresorhus , on an empty cache that makes requests for every single one of his 1690 packages to fetch metadata as a fallback after the 400. Issue for that is #2507



## Before 📸 
<img width="1124" height="599" alt="Screenshot 2026-04-13 at 5 40 06 PM" src="https://github.com/user-attachments/assets/284c70f8-3db5-4658-bb5d-c0e385403578" />


## After 📸 
<img width="1124" height="599" alt="Screenshot 2026-04-13 at 5 39 58 PM" src="https://github.com/user-attachments/assets/974379b1-4a19-45cc-9cdb-b16a5d8785ec" />