### PR TITLE
fix: "copy as markdown" button appearing too eagerly

### DIFF
--- a/app/pages/compare.vue
+++ b/app/pages/compare.vue
@@ -75,10 +75,15 @@ function addNoDep() {
 // Get loading state for each column
 const columnLoading = computed(() => packages.value.map((_, i) => isColumnLoading(i)))
 
-// FIXME(serhalp): canCompare only checks package count, not whether data has loaded.
-// Copy-markdown and view-switching commands appear as soon as one package loads, even if
-// other packages are still loading. The UI copy button has the same issue.
+// Makes sense to compare if there's 2 or more packages
 const canCompare = computed(() => packages.value.length >= 2)
+
+// Allow copying only after all data is loaded
+const canCopyTable = computed(
+  () =>
+    packagesData.value.length >= 1 &&
+    packagesData.value.every(data => data !== null && data !== undefined),
+)
 
 const comparisonView = usePermalink<'table' | 'charts'>('view', 'table')
 const hasChartableFacets = computed(() => selectedFacets.value.some(facet => facet.chartable))
@@ -173,7 +178,7 @@ useCommandPaletteContextCommands(
       },
     ]
 
-    if (canCompare.value && packagesData.value && packagesData.value.some(p => p !== null)) {
+    if (canCompare.value && canCopyTable.value) {
       commands.push({
         id: 'compare-copy-markdown',
         group: 'actions',
@@ -335,7 +340,7 @@ useSeoMeta({
       <!-- Comparison grid -->
       <section v-if="canCompare" class="mt-10" aria-labelledby="comparison-heading">
         <CopyToClipboardButton
-          v-if="packagesData && packagesData.some(p => p !== null)"
+          v-if="canCopyTable"
           :copied="copied"
           :copy-text="$t('compare.packages.copy_as_markdown')"
           class="mb-4"

--- a/app/pages/compare.vue
+++ b/app/pages/compare.vue
@@ -80,9 +80,7 @@ const canCompare = computed(() => packages.value.length >= 2)
 
 // Allow copying only after all data is loaded
 const canCopyTable = computed(
-  () =>
-    packagesData.value.length >= 1 &&
-    packagesData.value.every(data => data !== null),
+  () => packagesData.value.length >= 1 && packagesData.value.every(data => data !== null),
 )
 
 const comparisonView = usePermalink<'table' | 'charts'>('view', 'table')

--- a/app/pages/compare.vue
+++ b/app/pages/compare.vue
@@ -82,7 +82,7 @@ const canCompare = computed(() => packages.value.length >= 2)
 const canCopyTable = computed(
   () =>
     packagesData.value.length >= 1 &&
-    packagesData.value.every(data => data !== null && data !== undefined),
+    packagesData.value.every(data => data !== null),
 )
 
 const comparisonView = usePermalink<'table' | 'charts'>('view', 'table')

--- a/test/nuxt/pages/ComparePage.spec.ts
+++ b/test/nuxt/pages/ComparePage.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 import type { PackageComparisonData } from '~/composables/usePackageComparison'
+import CopyToClipboardButtonComponent from '~/components/CopyToClipboardButton.vue'
 
 const mockPackagesData = ref<(PackageComparisonData | null)[]>([])
 const mockStatus = ref<'idle' | 'pending' | 'success' | 'error'>('idle')
@@ -80,6 +81,55 @@ describe('compare page command palette commands', () => {
 
     const allCommands = contextCommands.value.flatMap(entry => entry.commands)
     expect(allCommands.find(c => c.id === 'compare-copy-markdown')).toBeTruthy()
+
+    wrapper.unmount()
+  })
+})
+
+describe('compare page copy-as-markdown button', () => {
+  afterEach(() => {
+    mockPackagesData.value = []
+    mockStatus.value = 'idle'
+    const commandPalette = useCommandPalette()
+    commandPalette.close()
+    commandPalette.contextCommands.value = []
+  })
+
+  it('shows copy-as-markdown button when all packages have loaded data', async () => {
+    mockPackagesData.value = [makePackageData('react'), makePackageData('vue')]
+    mockStatus.value = 'success'
+
+    const wrapper = await mountComparePage('/compare?packages=react,vue')
+
+    expect(wrapper.findComponent(CopyToClipboardButtonComponent).exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('does not show copy-as-markdown button when only some packages have loaded data', async () => {
+    // Simulate a partial-load race: 2 packages in the URL but only the first has data yet.
+    mockPackagesData.value = [makePackageData('react'), null]
+    mockStatus.value = 'pending'
+
+    const wrapper = await mountComparePage('/compare?packages=react,vue')
+
+    // The button must not appear until every requested package has loaded its data.
+    expect(wrapper.findComponent(CopyToClipboardButtonComponent).exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('does not register copy-markdown command when only some packages have loaded data', async () => {
+    // Same race: 2 packages in the URL but only the first has data yet.
+    mockPackagesData.value = [makePackageData('react'), null]
+    mockStatus.value = 'pending'
+
+    const wrapper = await mountComparePage('/compare?packages=react,vue')
+    const { contextCommands } = useCommandPalette()
+
+    const allCommands = contextCommands.value.flatMap(entry => entry.commands)
+    // The command-palette entry must not appear until every requested package has loaded.
+    expect(allCommands.find(c => c.id === 'compare-copy-markdown')).toBeUndefined()
 
     wrapper.unmount()
   })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2390

### 🧭 Context

"Copy as markdown" button is currently showing and clickable when some of the packages' data is not loaded yet.

### 📚 Description

I've added a new computed ref to track when data can be copied as a Markdown table: When there's at least one package and all packages's data is loaded. This ref replaces previous conditions when

- adding commands to the command pallete, and
- conditionally rendering the "copy as markdown" button in the template

I originally changed the `canCompare` condition like the linked issue suggests, but I think that unnecessarily waits to show the comparison table until all data has loaded. Showing partially loaded data in the UI is okay imo, the only thing that needs to wait until data is loaded is the copying.

Claude wrote (and I tweaked and finished) tests that fail without this PR and succeed with it.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
