### PR TITLE
fix: use owners.name facet for user profile pkgs

### DIFF
--- a/app/composables/npm/useAlgoliaSearch.ts
+++ b/app/composables/npm/useAlgoliaSearch.ts
@@ -161,8 +161,8 @@ export function useAlgoliaSearch() {
     }
   }
 
-  /** Fetch all packages for an owner using `owner.name` filter with pagination. */
-  async function searchByOwner(
+  /** Fetch all packages for a maintainer using `owners.name` filter with pagination. */
+  async function searchByMaintainer(
     ownerName: string,
     options: { maxResults?: number } = {},
   ): Promise<NpmSearchResponse> {
@@ -185,7 +185,7 @@ export function useAlgoliaSearch() {
             query: '',
             offset,
             length,
-            filters: `owner.name:${ownerName}`,
+            filters: `owners.name:${ownerName}`,
             analyticsTags: ['npmx.dev'],
             attributesToRetrieve: ATTRIBUTES_TO_RETRIEVE,
             attributesToHighlight: [],
@@ -286,7 +286,7 @@ export function useAlgoliaSearch() {
       requests.push({
         indexName,
         query: '',
-        filters: `owner.name:${checks.name}`,
+        filters: `owners.name:${checks.name}`,
         length: 1,
         analyticsTags: ['npmx.dev'],
         attributesToRetrieve: EXISTENCE_CHECK_ATTRS,
@@ -347,7 +347,7 @@ export function useAlgoliaSearch() {
   return {
     search,
     searchWithSuggestions,
-    searchByOwner,
+    searchByMaintainer,
     getPackagesByName,
   }
 }

--- a/app/composables/npm/useUserPackages.ts
+++ b/app/composables/npm/useUserPackages.ts
@@ -28,7 +28,7 @@ export function useUserPackages(username: MaybeRefOrGetter<string>) {
   })
   // this is only used in npm path, but we need to extract it when the composable runs
   const { $npmRegistry } = useNuxtApp()
-  const { searchByOwner } = useAlgoliaSearch()
+  const { searchByMaintainer } = useAlgoliaSearch()
 
   // --- Incremental loading state (npm path) ---
   const currentPage = shallowRef(1)
@@ -58,7 +58,7 @@ export function useUserPackages(username: MaybeRefOrGetter<string>) {
       // --- Algolia: fetch all at once ---
       if (provider === 'algolia') {
         try {
-          const response = await searchByOwner(user)
+          const response = await searchByMaintainer(user)
 
           // Guard against stale response (user/provider changed during await)
           if (user !== toValue(username) || provider !== searchProviderValue.value) {


### PR DESCRIPTION
### 🔗 Linked issue

closes #2504 
### 🧭 Context
The profiles for users was querying against an Algolia field which represented repo owner, not npm username. That meant that the packages being displayed on profiles were only tangentially related to said npm username, or completely unrelated.

Once https://github.com/algolia/npm-search/pull/1357 landed upstream at the algolia index, it opened us up to filter on a field which represents an npm user. 

This PR switches to that field.

After this PR, user profile pages will return all packages that an npm user is listed as a maintainer on. This will still include deprecated packages, just like it did previously (whcih was not a bug, just the nature of the data source being used and no filtering, there's some issue about it but that's out of scope here)

> Note: there's no concept of an "owner" that npm exposes publicly that Im aware of. the best you can do is check if a user is in the maintainer's array. That's a detail that's not really important here as the previous logic hinged on that fact anyways despite querying on bad information. I updated the name of the function used here to align with the reality of the npm field we are checking. 

### Before 📸 
any package whos repository field in package.json has the same username as the npm user will show up on the user's page, even if said user is not a maintainer/owner of said package
<img width="376" height="491" alt="Screenshot 2026-04-14 at 5 56 18 AM" src="https://github.com/user-attachments/assets/e0e7e1c1-2030-4aa4-ac5f-541e5d6dce8f" />

and any packages a user maintains which are not in a repo of the same username are omitted
<img width="376" height="150" alt="Screenshot 2026-04-14 at 5 43 37 AM" src="https://github.com/user-attachments/assets/6435b2f7-98e5-4fb8-a6e7-382e9ff8e642" />


### After 📸 
no more spoofing possible!
<img width="376" height="491" alt="Screenshot 2026-04-14 at 5 56 06 AM" src="https://github.com/user-attachments/assets/224fa488-5ef4-4ee6-a998-ba2e93948b59" />

now all packages that an npm user is a maintainer of will be displayed on their profile (express is now accounted for in my profile, hence the download stat change)
<img width="376" height="150" alt="Screenshot 2026-04-14 at 5 43 20 AM" src="https://github.com/user-attachments/assets/87c56300-b75c-4f28-b2bb-6addba8de256" />
