### PR TITLE
docs(ui): add stories for PDS page

### DIFF
--- a/.storybook/handlers.ts
+++ b/.storybook/handlers.ts
@@ -57,3 +57,37 @@ export const contributorsHandler = http.get('/api/contributors', () => {
     },
   ])
 })
+
+export const pdsUsersHandler = http.get('/api/atproto/pds-users', () => {
+  return HttpResponse.json([
+    {
+      did: 'did:plc:mock0001',
+      handle: 'patak.dog',
+      displayName: 'Patak Dog',
+      avatar:
+        'https://cdn.bsky.app/img/avatar/plain/did:plc:zjfptjaegvgc7r2axkkyyzqn/bafkreihrcqhp575f6dph4uztbeyxfrmfnbv7x2gvovrgu4idgdsdw7wety',
+    },
+    {
+      did: 'did:plc:mock0002',
+      handle: 'patakllama.mockpmx.social',
+      displayName: 'Patak Llama',
+      avatar: 'https://api.dicebear.com/9.x/initials/svg?seed=llama',
+    },
+    {
+      did: 'did:plc:mock0003',
+      handle: 'patak.horse',
+      displayName: 'Patak Horse',
+      avatar:
+        'https://cdn.bsky.app/img/avatar/plain/did:plc:vqh7id7sddkrfkhgt7tstlpd/bafkreifodkgqszgpt2qnoyljnbafokr6eujqwztj2kxo473adv5b57hjse',
+    },
+    {
+      did: 'did:plc:mock0004',
+      handle: 'patakcatapiller.mockpmx.social',
+    },
+    {
+      did: 'did:plc:mock0005',
+      handle: 'patakgoat.mockpmx.social',
+      displayName: 'Patak Goat',
+    },
+  ])
+})

--- a/app/pages/pds.stories.ts
+++ b/app/pages/pds.stories.ts
@@ -1,0 +1,30 @@
+import Pds from './pds.vue'
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import { pageDecorator } from '../../.storybook/decorators'
+import { pdsUsersHandler } from '../../.storybook/handlers'
+
+const meta = {
+  component: Pds,
+  parameters: {
+    layout: 'fullscreen',
+    msw: {
+      handlers: [pdsUsersHandler],
+    },
+  },
+  decorators: [pageDecorator],
+} satisfies Meta<typeof Pds>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** `/api/atproto/pds-users` is intercepted by MSW so the community section displays both avatar images and text-only entries. */
+export const Default: Story = {}
+
+/** Community section shows an empty/loading state with no API response. */
+export const WithoutUsers: Story = {
+  parameters: {
+    msw: {
+      handlers: [],
+    },
+  },
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
#2150 

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

This would enable a storybook mock page, storybook a11y checks, and chromatic visual regression tests for this page as documented by the storybook stories.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->
     
Adds stories for PDS page and MSW `pdsUserHandler` for mocking pds-users API.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
