### PR TITLE
feat: prefill package manager from query param

### DIFF
--- a/app/composables/useSelectedPackageManager.ts
+++ b/app/composables/useSelectedPackageManager.ts
@@ -12,6 +12,10 @@ export const useSelectedPackageManager = createSharedComposable(
 
     // Sync to data-pm attribute on the client
     if (import.meta.client) {
+      const queryPM = new URLSearchParams(window.location.search).get('pm')
+      if (queryPM && packageManagers.some(pm => pm.id === queryPM)) {
+        pm.value = queryPM as PackageManagerId
+      }
       // Watch for changes and update the attribute
       watch(
         pm,

--- a/app/utils/prehydrate.ts
+++ b/app/utils/prehydrate.ts
@@ -42,7 +42,7 @@ export function initPreferencesOnPrehydrate() {
     let pm = 'npm'
 
     // Support package manager preference in query string (for example, ?pm=pnpm)
-    const queryPM = new URLSearchParams(document.location.search).get('pm')
+    const queryPM = new URLSearchParams(window.location.search).get('pm')
     if (queryPM && validPMs.has(queryPM)) {
       pm = queryPM
       localStorage.setItem('npmx-pm', pm)

--- a/app/utils/prehydrate.ts
+++ b/app/utils/prehydrate.ts
@@ -39,20 +39,28 @@ export function initPreferencesOnPrehydrate() {
       document.documentElement.dataset.bgTheme = preferredBackgroundTheme
     }
 
-    // Read and apply package manager preference
-    const storedPM = localStorage.getItem('npmx-pm')
-    // Parse the stored value (it's stored as a JSON string by useLocalStorage)
     let pm = 'npm'
-    if (storedPM) {
-      try {
-        const parsed = JSON.parse(storedPM)
-        if (validPMs.has(parsed)) {
-          pm = parsed
-        }
-      } catch {
-        // If parsing fails, check if it's a plain string (legacy format)
-        if (validPMs.has(storedPM)) {
-          pm = storedPM
+
+    // Support package manager preference in query string (for example, ?pm=pnpm)
+    const queryPM = new URLSearchParams(document.location.search).get('pm')
+    if (queryPM && validPMs.has(queryPM)) {
+      pm = queryPM
+      localStorage.setItem('npmx-pm', pm)
+    } else {
+      // Read and apply package manager preference
+      const storedPM = localStorage.getItem('npmx-pm')
+      // Parse the stored value (it's stored as a JSON string by useLocalStorage)
+      if (storedPM) {
+        try {
+          const parsed = JSON.parse(storedPM)
+          if (validPMs.has(parsed)) {
+            pm = parsed
+          }
+        } catch {
+          // If parsing fails, check if it's a plain string (legacy format)
+          if (validPMs.has(storedPM)) {
+            pm = storedPM
+          }
         }
       }
     }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2515

### 🧭 Context

Third-party package managers or individual services may find it useful to link to us so that a specific package manager is immediately configured.

Added support for selecting and saving a package manager based on the query param (`?pm=pnpm`)