### PR TITLE
fix(i18n): add missing Chinese translations

### DIFF
--- a/i18n/locales/zh-CN.json
+++ b/i18n/locales/zh-CN.json
@@ -280,7 +280,8 @@
       "black": "黑色"
     },
     "keyboard_shortcuts_enabled": "启用快捷键",
-    "keyboard_shortcuts_enabled_description": "如果某些快捷键与其他浏览器或系统快捷键冲突，可以选择将其禁用。"
+    "keyboard_shortcuts_enabled_description": "如果某些快捷键与其他浏览器或系统快捷键冲突，可以选择将其禁用。",
+    "enable_code_ligatures": "在代码中启用连字"
   },
   "i18n": {
     "missing_keys": "{count} 项缺少翻译",
@@ -1325,6 +1326,18 @@
         "vulnerabilities": {
           "label": "漏洞",
           "description": "已知安全漏洞"
+        },
+        "githubStars": {
+          "label": "GitHub 星标",
+          "description": "GitHub 仓库的星标数量"
+        },
+        "githubIssues": {
+          "label": "GitHub 问题数",
+          "description": "GitHub 仓库的问题数量"
+        },
+        "createdAt": {
+          "label": "创建时间",
+          "description": "包创建时间"
         }
       },
       "values": {


### PR DESCRIPTION
### 🔗 Linked issue
No linked issue

### 🧭 Context
This PR updates the Chinese locale file used by npmx. It adds missing translation strings for the settings page and package metadata labels in zh-CN.json.

### 📚 Description
Added translation for enable_code_ligatures
Added translations for GitHub-related package metadata labels:
```
githubStars
githubIssues
createdAt
```
These changes are translation-only and do not affect application logic