### PR TITLE
chore(i18n): fix lunaria pre-commit hook with force: true

### DIFF
--- a/lunaria/lunaria.ts
+++ b/lunaria/lunaria.ts
@@ -11,7 +11,12 @@ if (existsSync('.git/MERGE_HEAD')) {
   process.exit(0)
 }
 
-const lunaria = await createLunaria()
+const lunaria = await createLunaria({
+  // `force: true` configures lunaria to bypass git caching and always read the latest commit from git history,
+  // workarounds issue where lunaria caches becomes stale after rebasing or merging, which causes lunaria to crash
+  // https://github.com/npmx-dev/npmx.dev/issues/2527
+  force: true,
+})
 const status = await lunaria.getFullStatus()
 
 // Generate JSON status for the app


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2527.

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

This resolves issue where lunaria cache becomes stale after rebasing or merging, which causes lunaria to crash and fail git pre-commit hook. Instead configure lunaria to bypass git caching and always read the latest commit from git history.

### 📚 Description

Configures `force: true` when creating lunaria instance to bypass git commit cache.

Here's what I found from investigating this issue.

Lunaria by default uses a cache, stored in `./node_modules/.cache/lunaria`, to keep track of the latest commit hash per locale file, like this:
```
{
  "i18n/locales/en.json":"696d036a75e005e33f7b86bf11e52459de0530ac",
  "i18n/locales/ar-EG.json":"eb4d86207ad164d008eabd0c2864e99773a4e223",
  "i18n/locales/az-AZ.json":"95c2aae90923665f74c91e80de3de1b3e426999a",
  // ...
}
```

This cache is reused between builds (or calls to lunaria instance in git pre-commit hook). Cache helps to skip looking into older commits when looking for the latest commit for each locale file. But this cache can become stale, for example after rebase operations. 

For example, you made a change in locale file, committed, cache updated. Then imagine you rebased your branch, hashes change. This causes lunaria to fail to find that last commit in git database.

When this happens lunaria just aborts process completely instead of throwing, so we can't even capture this error to retry.

Discord thread: https://discord.com/channels/1464542801676206113/1493012869174923476