### PR TITLE
fix(i18n): add missing pt-BR translations for "shortcuts"

### DIFF
--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -27,6 +27,9 @@
       "search": "Pesquisar",
       "package": "Pacote"
     },
+    "ctrl_key": "Ctrl",
+    "command_palette": "Abrir paleta de comandos",
+    "command_palette_description": "Use a paleta de comandos para navegar entre páginas, visualizações de pacote, configurações e links externos sem sair do teclado. No macOS, pressione ⌘K. No Windows e Linux, pressione {ctrlKey}+K.",
     "focus_search": "Focar pesquisa",
     "show_kbd_hints": "Destacar dicas de teclado",
     "settings": "Abrir configurações",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

N/A

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

Brazilian portuguese translation currently lacks 226 keys for full coverage as reported by [npmx.dev/translation-status](https://npmx.dev/translation-status)

Add translations for `shortcuts` missing keys to `pt-BR.json`

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Added translations to `shortcuts.ctrl_key`, `shortcuts.command_palette` and `shortcuts.command_palette_description` in the `pt-BR.json`.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
