### PR TITLE
fix: set default smoothing to 0

### DIFF
--- a/app/composables/useSettings.ts
+++ b/app/composables/useSettings.ts
@@ -73,7 +73,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   },
   chartFilter: {
     averageWindow: 0,
-    smoothingTau: 1,
+    smoothingTau: 0,
     anomaliesFixed: true,
     predictionPoints: 4,
   },


### PR DESCRIPTION
Resolves #2510 

Previous default data correction settings had a `smoothingTau` set to 1, which had the advantage of displaying nicer looking trends, but the disadvantage of correcting intermediate values, which can be perceived as an error by new visitors, when comparing the downloads to the npmjs chart.

This sets the default `smootingTau` to 0, to show raw data to all users, until they decide to tweak data correction knobs by themselves.

This does not change the impacts of manual corrections, which remain applied by default.


> [!NOTE] 
> I think we should have these settings made available in the global settings page, because they can be hard to locate (downloads chart modal, inside a details is kind of hidden...). This would require adding a _stats_ section in the settings page, and would be the topic of a separate issue.