### PR TITLE
chore: add issue types and missing label to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,7 @@
 name: "\U0001F41E Bug report"
 description: Create a report to help us improve npmx
+type: bug
+labels: ['pending triage']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,6 @@
 name: '🚀 Feature request'
 description: Suggest a feature that will improve npmx
+type: feature
 labels: ['pending triage']
 body:
   - type: markdown


### PR DESCRIPTION
### 🔗 Linked issue

Reference: https://discord.com/channels/1464542801676206113/1464544758020968448/1493981022411427861

### 🧭 Context

- New issues created from templates don't have a type assigned, requiring maintainers to add them manually.
- The bug template is missing the "pending triage" label.

### 📚 Description

Adds the `type` field to the bug and feature request template ([see docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms)). The identifiers are case insensitive ([see discussion](https://github.com/orgs/community/discussions/112806#discussioncomment-10003196)).

Adds the label "pending triage" (currently only present in the feature request template) to the bug report template. Please note that the actual label had only been created earlier today, which is why (as of now) only one feature issue has the label assigned.
