### PR TITLE
fix: use fast-npm-meta in timeline

### DIFF
--- a/server/api/registry/timeline/sizes/[...pkg].get.ts
+++ b/server/api/registry/timeline/sizes/[...pkg].get.ts
@@ -1,3 +1,5 @@
+import { getVersions } from 'fast-npm-meta'
+
 const DEFAULT_LIMIT = 25
 
 export interface TimelineSizeEntry {
@@ -39,11 +41,11 @@ export default defineCachedEventHandler(
     const limit = Math.max(1, Math.min(100, Number(query.limit) || DEFAULT_LIMIT))
 
     try {
-      const packument = await fetchNpmPackage(packageName)
+      const { versions, time } = await getVersions(packageName)
 
-      const allVersions = Object.keys(packument.versions)
-        .filter(v => packument.time[v])
-        .sort((a, b) => Date.parse(packument.time[b]!) - Date.parse(packument.time[a]!))
+      const allVersions = versions
+        .filter(v => time[v])
+        .sort((a, b) => Date.parse(time[b]!) - Date.parse(time[a]!))
 
       const pageVersions = allVersions.slice(offset, offset + limit)
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Timeline is currently awfully slow for packages with a large amount of versions.

### 📚 Description

We were fetching the whole packument which is _pretty big_.

So this switches to using fast-npm-meta which is basically just
trimmed down metadata.

