### PR TITLE
fix: update settings shortcut key from ',' to 's'

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -32,7 +32,7 @@ const desktopLinks = computed<NavigationConfig>(() => [
     name: 'Settings',
     label: $t('nav.settings'),
     to: { name: 'settings' },
-    keyshortcut: ',',
+    keyshortcut: 's',
     type: 'link',
     external: false,
     iconClass: 'i-lucide:settings',
@@ -201,8 +201,8 @@ function handleSearchFocus() {
 }
 
 useShortcuts({
-  'c': () => ({ name: 'compare' }),
-  ',': () => ({ name: 'settings' }),
+  c: () => ({ name: 'compare' }),
+  s: () => ({ name: 'settings' }),
 })
 </script>
 

--- a/test/e2e/interactions.spec.ts
+++ b/test/e2e/interactions.spec.ts
@@ -282,30 +282,30 @@ test.describe('Keyboard Shortcuts', () => {
     await expect(page).toHaveURL(/\/vue/)
   })
 
-  test('"," navigates to /settings', async ({ page, goto }) => {
+  test('"s" navigates to /settings', async ({ page, goto }) => {
     await goto('/compare', { waitUntil: 'hydration' })
 
-    await page.keyboard.press(',')
+    await page.keyboard.press('s')
 
     await expect(page).toHaveURL(/\/settings/)
   })
 
-  test('"," does not navigate when any modifier key is pressed', async ({ page, goto }) => {
+  test('"s" does not navigate when any modifier key is pressed', async ({ page, goto }) => {
     await goto('/settings', { waitUntil: 'hydration' })
 
     const searchInput = page.locator('#header-search')
     await searchInput.focus()
     await expect(searchInput).toBeFocused()
 
-    await page.keyboard.press('Shift+,')
+    await page.keyboard.press('Shift+s')
     await expect(page).toHaveURL(/\/settings/)
-    await page.keyboard.press('Control+,')
+    await page.keyboard.press('Control+s')
     await expect(page).toHaveURL(/\/settings/)
-    await page.keyboard.press('Alt+,')
+    await page.keyboard.press('Alt+s')
     await expect(page).toHaveURL(/\/settings/)
-    await page.keyboard.press('Meta+,')
+    await page.keyboard.press('Meta+s')
     await expect(page).toHaveURL(/\/settings/)
-    await page.keyboard.press('ControlOrMeta+Shift+,')
+    await page.keyboard.press('ControlOrMeta+Shift+s')
     await expect(page).toHaveURL(/\/settings/)
   })
 })
@@ -317,13 +317,13 @@ test.describe('Keyboard Shortcuts disabled', () => {
     })
   })
 
-  test('"," (header) does not navigate to /settings when shortcuts are disabled', async ({
+  test('"s" (header) does not navigate to /settings when shortcuts are disabled', async ({
     page,
     goto,
   }) => {
     await goto('/compare', { waitUntil: 'hydration' })
 
-    await page.keyboard.press(',')
+    await page.keyboard.press('s')
 
     await expect(page).toHaveURL(/\/compare/)
   })


### PR DESCRIPTION
### 🔗 Linked issue

#2543 

### 🧭 Context

This PR improves keyboard shortcut usability in the header navigation.

### 📚 Description

I would like to update the shortcut used for the Settings action in the header. Right now the current shortcut is not very intuitive, and using s would be a better option for discoverability and consistency.

It should be possible to trigger the same action with a clearer shortcut without affecting the existing behavior of the page.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->