### PR TITLE
fix: resolve readme copy functionality in Safari

### DIFF
--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -25,7 +25,7 @@ module.exports = {
   ci: {
     collect: {
       startServerCommand: 'pnpm preview',
-      startServerReadyPattern: 'Listening',
+      startServerReadyPattern: '(Listening|Local|:3000)',
       url: [
         'http://localhost:3000/',
         'http://localhost:3000/search?q=nuxt',

--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -25,7 +25,7 @@ module.exports = {
   ci: {
     collect: {
       startServerCommand: 'pnpm preview',
-      startServerReadyPattern: '(Listening|Local|:3000)',
+      startServerReadyPattern: 'Listening',
       url: [
         'http://localhost:3000/',
         'http://localhost:3000/search?q=nuxt',

--- a/app/composables/useClipboardAsync.ts
+++ b/app/composables/useClipboardAsync.ts
@@ -9,7 +9,7 @@ type UseClipboardAsyncOptions = {
   copiedDuring: number
 }
 
-export default function useClipboardAsync(
+export function useClipboardAsync(
   fn: () => Promise<string>,
   options?: UseClipboardAsyncOptions,
 ): UseClipboardAsyncReturn {

--- a/app/composables/useClipboardAsync.ts
+++ b/app/composables/useClipboardAsync.ts
@@ -18,16 +18,20 @@ export function useClipboardAsync(
     immediate: false,
   })
 
-  function copy() {
+  async function copy() {
     const asyncClipboard = new ClipboardItem({
       'text/plain': fn().then(text => {
         return new Blob([text], { type: 'text/plain' })
       }),
     })
 
-    copied.value = true
-    navigator.clipboard.write([asyncClipboard])
-    timeout.start()
+    try {
+      await navigator.clipboard.write([asyncClipboard])
+      copied.value = true
+      timeout.start()
+    } catch {
+      copied.value = false
+    }
   }
 
   return {

--- a/app/composables/useClipboardAsync.ts
+++ b/app/composables/useClipboardAsync.ts
@@ -1,0 +1,37 @@
+import type { ShallowRef } from 'vue'
+
+type UseClipboardAsyncReturn = {
+  copy: () => void
+  copied: ShallowRef<boolean>
+}
+
+type UseClipboardAsyncOptions = {
+  copiedDuring: number
+}
+
+export default function useClipboardAsync(
+  fn: () => Promise<string>,
+  options?: UseClipboardAsyncOptions,
+): UseClipboardAsyncReturn {
+  const copied = shallowRef(false)
+  const timeout = useTimeoutFn(() => (copied.value = false), options?.copiedDuring ?? 0, {
+    immediate: false,
+  })
+
+  function copy() {
+    const asyncClipboard = new ClipboardItem({
+      'text/plain': fn().then(text => {
+        return new Blob([text], { type: 'text/plain' })
+      }),
+    })
+
+    copied.value = true
+    navigator.clipboard.write([asyncClipboard])
+    timeout.start()
+  }
+
+  return {
+    copy,
+    copied,
+  }
+}

--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -99,6 +99,7 @@ const {
 const { copied: copiedReadme, copy: copyReadme } = useClipboard({
   source: () => '',
   copiedDuring: 2000,
+  legacy: true,
 })
 
 function prefetchReadmeMarkdown() {

--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -96,25 +96,20 @@ const {
 )
 
 //copy README file as Markdown
-const { copied: copiedReadme, copy: copyReadme } = useClipboard({
-  source: () => '',
-  copiedDuring: 2000,
-  legacy: true,
-})
+const { copied: copiedReadme, copy: copyReadme } = useClipboardAsync(
+  async () => {
+    await fetchReadmeMarkdown()
+    return readmeMarkdownData.value?.markdown ?? ''
+  },
+  {
+    copiedDuring: 2000,
+  },
+)
 
 function prefetchReadmeMarkdown() {
   if (readmeMarkdownStatus.value === 'idle') {
     fetchReadmeMarkdown()
   }
-}
-
-async function copyReadmeHandler() {
-  await fetchReadmeMarkdown()
-
-  const markdown = readmeMarkdownData.value?.markdown
-  if (!markdown) return
-
-  await copyReadme(markdown)
 }
 
 // Track active TOC item based on scroll position
@@ -1020,7 +1015,7 @@ const showSkeleton = shallowRef(false)
                 <ButtonBase
                   @mouseenter="prefetchReadmeMarkdown"
                   @focus="prefetchReadmeMarkdown"
-                  @click="copyReadmeHandler()"
+                  @click="copyReadme"
                   :aria-pressed="copiedReadme"
                   :aria-label="
                     copiedReadme ? $t('common.copied') : $t('package.readme.copy_as_markdown')


### PR DESCRIPTION
### 🔗 Linked issue

resolves #2151

### 🧭 Context

The copy Readme button doesn't work in Safari

### 📚 Description

Unfortunately, for security reasons, Safari doesn't allow the Clipboard API to be used with async operations, so it silently fails without copying anything.
I've created a custom useClipboardAsync that addresses the security issues and handles the async call.
