### PR TITLE
feat: add stale workflow

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -14,7 +14,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
         with:
           days-before-stale: 30
           days-before-close: 14

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,0 +1,68 @@
+name: Close Stale Issues and PRs
+
+on:
+  schedule:
+    # Run daily at 2 AM UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 14
+          remove-stale-when-updated: true
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          close-issue-label: 'stale'
+          close-pr-label: 'stale'
+          stale-issue-message: |
+            Thank you for your contribution! 🙏
+
+            This issue has been inactive for 30 days and is now marked as stale. If there's no activity in the next 14 days, it will be closed to keep our repository tidy.
+
+            **To keep this issue open**, feel free to:
+            - Leave a comment explaining your progress or needs
+            - Push a commit with updates
+            - Ask for help from maintainers
+
+            We appreciate your interest in npmx and hope you'll continue contributing! 💙
+          stale-pr-message: |
+            Thank you for your contribution! 🙏
+
+            This PR has been inactive for 30 days and is now marked as stale. If there's no activity in the next 14 days, it will be closed to keep our repository tidy.
+
+            **To keep this PR open**, feel free to:
+            - Leave a comment explaining your progress or needs
+            - Push a commit with updates
+            - Ask for help from maintainers
+
+            We appreciate your interest in npmx and hope you'll continue contributing! 💙
+          close-issue-message: |
+            Thank you for your contribution! 🙏
+
+            Unfortunately, this issue has been marked as stale for 14 days without any updates and we're now closing it to keep our repository tidy.
+
+            **If you'd like to continue working on this**, feel free to:
+            - Reopen this issue
+            - Leave a comment explaining your progress
+
+            We appreciate your interest in npmx and hope you'll continue contributing! 💙
+          close-pr-message: |
+            Thank you for your contribution! 🙏
+
+            Unfortunately, this PR has been marked as stale for 14 days without any updates and we're now closing it to keep our repository tidy.
+
+            **If you'd like to continue working on this**, feel free to:
+            - Reopen this PR
+            - Leave a comment explaining your progress
+
+            We appreciate your interest in npmx and hope you'll continue contributing! 💙
+          operations-per-run: 100


### PR DESCRIPTION
### 🧭 Context

We currently have 20 stale PRs, some of which were created 3+ months ago and have been tagged as stale for more than 2 weeks. I think we need an automated way to deal with these issues and PRs to keep our repository tidy. ✨ 

### 📚 Description
It uses the built-in GitHub stale action to automate the entire stale-tagging process and auto-close PRs 14 days after they are tagged.
Issues or PRs will be tagged after 30 days and automatically closed 14 days later.