### PR TITLE
fix: round chart numbers in `applyDataCorrection` for consistent rounding

### DIFF
--- a/app/components/Chart/SplitSparkline.vue
+++ b/app/components/Chart/SplitSparkline.vue
@@ -31,9 +31,7 @@ const props = defineProps<{
 
 const { locale } = useI18n()
 const colorMode = useColorMode()
-const numberFormatter = useNumberFormatter({
-  maximumFractionDigits: 0,
-})
+const numberFormatter = useNumberFormatter()
 const resolvedMode = shallowRef<'light' | 'dark'>('light')
 const rootEl = shallowRef<HTMLElement | null>(null)
 const palette = getPalette('')

--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -1540,7 +1540,7 @@ const chartConfig = computed<VueUiXyConfig>(() => {
           const rows = items
             .map((d: Record<string, any>) => {
               const label = String(d?.name ?? '').trim()
-              const raw = Math.round(Number(d?.value ?? 0))
+              const raw = Number(d?.value ?? 0)
               const v = compactNumberFormatter.value.format(Number.isFinite(raw) ? raw : 0)
 
               if (!hasMultipleItems) {

--- a/app/components/Package/WeeklyDownloadStats.vue
+++ b/app/components/Package/WeeklyDownloadStats.vue
@@ -60,9 +60,7 @@ function handleModalTransitioned() {
 }
 
 const { fetchPackageDownloadEvolution } = useCharts()
-const numberFormatter = useNumberFormatter({
-  maximumFractionDigits: 0,
-})
+const numberFormatter = useNumberFormatter()
 
 const { accentColors, selectedAccentColor } = useAccentColor()
 

--- a/app/components/Package/WeeklyDownloadStats.vue
+++ b/app/components/Package/WeeklyDownloadStats.vue
@@ -201,7 +201,7 @@ const correctedDownloads = computed<WeeklyDataPoint[]>(() => {
 
 const dataset = computed<VueUiSparklineDatasetItem[]>(() =>
   correctedDownloads.value.map(d => ({
-    value: Math.ceil(d?.value ?? 0),
+    value: d?.value ?? 0,
     period: $t('package.trends.date_range', {
       start: d.weekStart ?? '-',
       end: d.weekEnd ?? '-',

--- a/app/components/Package/WeeklyDownloadStats.vue
+++ b/app/components/Package/WeeklyDownloadStats.vue
@@ -201,7 +201,7 @@ const correctedDownloads = computed<WeeklyDataPoint[]>(() => {
 
 const dataset = computed<VueUiSparklineDatasetItem[]>(() =>
   correctedDownloads.value.map(d => ({
-    value: d?.value ?? 0,
+    value: Math.ceil(d?.value ?? 0),
     period: $t('package.trends.date_range', {
       start: d.weekStart ?? '-',
       end: d.weekEnd ?? '-',

--- a/app/utils/chart-data-correction.ts
+++ b/app/utils/chart-data-correction.ts
@@ -92,5 +92,6 @@ export function applyDataCorrection<T extends { value: number }>(
   let result = data
   result = movingAverage(result, settings.averageWindow)
   result = smoothing(result, settings.smoothingTau)
+  result = result.map(d => ({ ...d, value: Math.ceil(d.value) }))
   return result
 }

--- a/app/utils/chart-data-correction.ts
+++ b/app/utils/chart-data-correction.ts
@@ -83,7 +83,7 @@ export interface ChartFilterSettings {
 }
 
 /**
- * Applies moving average then smoothing in sequence.
+ * Applies moving average, smoothing and then rounding up in sequence.
  */
 export function applyDataCorrection<T extends { value: number }>(
   data: T[],


### PR DESCRIPTION
### 🔗 Linked issue

There's not.
This is a pretty straightforward and tiny fix.

### 🧭 Context

The weekly download charts shows numbers with fraction when hovering over it and smoothing is enabled:

<img width="404" height="154" alt="image" src="https://github.com/user-attachments/assets/6641fafe-989c-469f-a773-5ba17d92345a" />

Here you can see the exact number of the screenshot coming in to the code location I'm changing with this PR:

<img width="535" height="165" alt="image" src="https://github.com/user-attachments/assets/fe6933c7-f96c-4a58-8616-7e0188c36175" />

### 📚 Description

Download numbers are now rounded up before showing them to the user.
I can also do the change in `applyDataCorrection` instead if that's preferred.
