### PR TITLE
fix: use file icon for LICENSE files

### DIFF
--- a/app/utils/file-icons.ts
+++ b/app/utils/file-icons.ts
@@ -264,12 +264,12 @@ export const FILENAME_ICONS: Record<string, string> = {
   'CONTRIBUTING.md': 'vscode-icons-file-type-markdown',
   'contributing.md': 'vscode-icons-file-type-markdown',
   'CODE_OF_CONDUCT.md': 'vscode-icons-file-type-markdown',
-  'LICENSE': 'vscode-icons-file-type-license',
-  'LICENSE.md': 'vscode-icons-file-type-license',
-  'LICENSE.txt': 'vscode-icons-file-type-license',
-  'license': 'vscode-icons-file-type-license',
-  'license.md': 'vscode-icons-file-type-license',
-  'license.txt': 'vscode-icons-file-type-license',
+  'LICENSE': 'vscode-icons-default-file',
+  'LICENSE.md': 'vscode-icons-default-file',
+  'LICENSE.txt': 'vscode-icons-default-file',
+  'license': 'vscode-icons-default-file',
+  'license.md': 'vscode-icons-default-file',
+  'license.txt': 'vscode-icons-default-file',
 
   // Node
   '.npmrc': 'vscode-icons-file-type-npm',

--- a/test/unit/app/utils/file-icons.spec.ts
+++ b/test/unit/app/utils/file-icons.spec.ts
@@ -9,6 +9,12 @@ describe('getFileIcon', () => {
     expect(getFileIcon('eslint.config.js')).toBe('vscode-icons-file-type-eslint')
     expect(getFileIcon('vitest.config.ts')).toBe('vscode-icons-file-type-vitest')
     expect(getFileIcon('.env')).toBe('vscode-icons-file-type-dotenv')
+    expect(getFileIcon('LICENSE')).toBe('vscode-icons-default-file')
+    expect(getFileIcon('LICENSE.md')).toBe('vscode-icons-default-file')
+    expect(getFileIcon('LICENSE.txt')).toBe('vscode-icons-default-file')
+    expect(getFileIcon('license')).toBe('vscode-icons-default-file')
+    expect(getFileIcon('license.md')).toBe('vscode-icons-default-file')
+    expect(getFileIcon('license.txt')).toBe('vscode-icons-default-file')
   })
 
   it('returns correct icons for compound extensions', () => {


### PR DESCRIPTION
### 🔗 Linked issue

Close #2558

### 📚 Description

Use file icon for LICENSE files.

Before: 

<img width="186" height="181" alt="Screenshot 2026-04-18 at 15 15 08" src="https://github.com/user-attachments/assets/97c2e23f-bb65-42b7-8073-d244ee17a1f1" />

After:

<img width="170" height="174" alt="Screenshot 2026-04-18 at 15 14 15" src="https://github.com/user-attachments/assets/6c29d2d8-f2cf-4968-8122-57099c930a92" />

Before creating the pull request, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- [x] Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- [x] Update the corresponding documentation if needed.
- [x] Include relevant tests that fail without this PR but pass with it.
- [x] Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.