### PR TITLE
chore: increase operation per run in stale workflow

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -65,4 +65,4 @@ jobs:
             - Leave a comment explaining your progress
 
             We appreciate your interest in npmx and hope you'll continue contributing! 💙
-          operations-per-run: 300
+          operations-per-run: 500

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -65,4 +65,4 @@ jobs:
             - Leave a comment explaining your progress
 
             We appreciate your interest in npmx and hope you'll continue contributing! 💙
-          operations-per-run: 100
+          operations-per-run: 300


### PR DESCRIPTION
### 🧭 Context
Running 100 operations per run was likely too conservative considering the size of npmx, and we weren't able to process all the items we had.
Currently, we have 210 issues, 97 PRs, and comments to review, so we need to expand our quota.

### 📚 Description
Increase the operation-per-run to 500 and see if this is enough. We have 5000 API requests per hour, and this workflow runs once at 2 am, so it's still really safe.