### PR TITLE
chore: clean up `.env.example` comment formatting + empty values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-#secure password, can use openssl rand -hex 32
-NUXT_SESSION_PASSWORD=""
+# secure password, can use openssl rand -hex 32
+NUXT_SESSION_PASSWORD=
 
-#HMAC secret for image-proxy and OG image URL signing, can use openssl rand -hex 32
-NUXT_IMAGE_PROXY_SECRET=""
+# HMAC secret for image-proxy and OG image URL signing, can use openssl rand -hex 32
+NUXT_IMAGE_PROXY_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-# secure password, can use openssl rand -hex 32
-NUXT_SESSION_PASSWORD=
+# secure password, can use `openssl rand -hex 32`
+NUXT_SESSION_PASSWORD=""
 
-# HMAC secret for image-proxy and OG image URL signing, can use openssl rand -hex 32
-NUXT_IMAGE_PROXY_SECRET=
+# HMAC secret for image-proxy and OG image URL signing, can use `openssl rand -hex 32`
+NUXT_IMAGE_PROXY_SECRET=""


### PR DESCRIPTION
I think it is looking slightly beautiful.