### PR TITLE
perf: prevent duplicates in file tree sprite

### DIFF
--- a/scripts/generate-file-tree-sprite.ts
+++ b/scripts/generate-file-tree-sprite.ts
@@ -69,30 +69,23 @@ function buildSprite(
   return `<svg xmlns="http://www.w3.org/2000/svg" style="display:none">${symbols}</svg>\n`
 }
 
-async function main() {
-  const collections = await loadCollections()
-  const iconNames = [
-    ...Object.values(EXTENSION_ICONS),
-    ...Object.values(FILENAME_ICONS),
-    ...Object.values(COMPOUND_EXTENSIONS),
-    ...Object.values(ADDITIONAL_ICONS),
-    DEFAULT_ICON,
-  ]
-  const grouped = groupByCollection(iconNames)
-  const sprite = buildSprite(grouped, collections)
-  await Promise.all([
-    fs.mkdir(path.dirname(outputDevPath), { recursive: true }),
-    fs.mkdir(path.dirname(outputStagePath), { recursive: true }),
-    fs.mkdir(path.dirname(outputProdPath), { recursive: true }),
-  ])
-  await Promise.all([
-    fs.writeFile(outputDevPath, sprite, 'utf8'),
-    fs.writeFile(outputStagePath, sprite, 'utf8'),
-    fs.writeFile(outputProdPath, sprite, 'utf8'),
-  ])
-}
-
-main().catch(error => {
-  console.error(error)
-  process.exitCode = 1
-})
+const collections = await loadCollections()
+const iconNames = [
+  ...Object.values(EXTENSION_ICONS),
+  ...Object.values(FILENAME_ICONS),
+  ...Object.values(COMPOUND_EXTENSIONS),
+  ...Object.values(ADDITIONAL_ICONS),
+  DEFAULT_ICON,
+]
+const grouped = groupByCollection(iconNames)
+const sprite = buildSprite(grouped, collections)
+await Promise.all([
+  fs.mkdir(path.dirname(outputDevPath), { recursive: true }),
+  fs.mkdir(path.dirname(outputStagePath), { recursive: true }),
+  fs.mkdir(path.dirname(outputProdPath), { recursive: true }),
+])
+await Promise.all([
+  fs.writeFile(outputDevPath, sprite, 'utf8'),
+  fs.writeFile(outputStagePath, sprite, 'utf8'),
+  fs.writeFile(outputProdPath, sprite, 'utf8'),
+])

--- a/scripts/generate-file-tree-sprite.ts
+++ b/scripts/generate-file-tree-sprite.ts
@@ -49,13 +49,12 @@ function buildSprite(
   let symbols = ''
   Object.entries(grouped).forEach(([prefix, iconNames]) => {
     const collection = collections[prefix]
-
     if (!collection?.icons) return
 
     const defaultWidth = collection.width ?? 16
     const defaultHeight = collection.height ?? 16
 
-    iconNames.forEach(name => {
+    new Set(iconNames).forEach(name => {
       const icon = collection.icons[name]
 
       if (!icon?.body) return


### PR DESCRIPTION
### 🔗 Linked issue

n/a

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

#1347

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

I noticed that there is duplicate icons in the file tree sprite, which doesn't seem to be intended - but I may be wrong. If I'm correct then this would shrink it currently from 576K to 260K :tada: 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
