### PR TITLE
fix(ui): add loading state for translation status generated time

### DIFF
--- a/app/pages/translation-status.vue
+++ b/app/pages/translation-status.vue
@@ -62,7 +62,7 @@ ${template}`
         </div>
         <p class="text-fg-muted text-lg">
           <template v-if="isLoading || !generatedAt">
-            <SkeletonInline class="h-6 w-48" />
+            <SkeletonInline class="h-6 w-96" />
           </template>
           <i18n-t v-else keypath="translation_status.generated_at" tag="span" scope="global">
             <template #date>

--- a/app/pages/translation-status.vue
+++ b/app/pages/translation-status.vue
@@ -17,7 +17,6 @@ defineOgImage(
   { alt: () => `${$t('translation_status.title')} — npmx` },
 )
 
-const nuxt = useNuxtApp()
 const router = useRouter()
 const canGoBack = useCanGoBack()
 const { fetchStatus, status } = useI18nStatus()
@@ -28,14 +27,7 @@ const isLoading = computed<boolean>(
   () => fetchStatus.value === 'idle' || fetchStatus.value === 'pending',
 )
 
-const generatedAt = computed(() => {
-  const gat = status.value?.generatedAt
-  if (import.meta.client) {
-    return (nuxt.isHydrated ? new Date().toISOString() : gat) ?? new Date().toISOString()
-  }
-
-  return gat ?? new Date().toISOString()
-})
+const generatedAt = computed(() => status.value?.generatedAt)
 
 const localeEntries = computed<I18nLocaleStatus[]>(() => status.value?.locales || [])
 
@@ -68,16 +60,16 @@ ${template}`
             <span class="sr-only sm:not-sr-only">{{ $t('nav.back') }}</span>
           </button>
         </div>
-        <i18n-t
-          keypath="translation_status.generated_at"
-          tag="p"
-          scope="global"
-          class="text-fg-muted text-lg"
-        >
-          <template #date>
-            <NuxtTime :locale :datetime="generatedAt" date-style="long" time-style="medium" />
+        <p class="text-fg-muted text-lg">
+          <template v-if="isLoading || !generatedAt">
+            <SkeletonInline class="h-6 w-48" />
           </template>
-        </i18n-t>
+          <i18n-t v-else keypath="translation_status.generated_at" tag="span" scope="global">
+            <template #date>
+              <NuxtTime :locale :datetime="generatedAt" date-style="long" time-style="medium" />
+            </template>
+          </i18n-t>
+        </p>
       </header>
 
       <p class="text-fg-muted leading-relaxed mb-4">


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
#2588

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->
Adds loading state when "generated at date" is not available.

<table>
<tr>
 <td>before (current date, not real date)</td>
 <td>after (skeleton while real date is loading)</td>
<tr>
 <td><img width="700" height="111" alt="image" src="https://github.com/user-attachments/assets/7291f0c8-d5bd-4aa7-af83-562a3e63376a" /></td>
 <td><img width="700" height="111" alt="image" src="https://github.com/user-attachments/assets/cb23a744-c9ed-4f95-ae55-9db3219957c3" /></td>
</table>

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->
     
 Previously the page would show the current date and time before the data loaded. Not only is it incorrect information but  would cause the visual regression tests to consistently need updating. 

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
