### PR TITLE
ci: disable e18e action duplicate dep PR comments

### DIFF
--- a/.github/workflows/dependency-diff.yml
+++ b/.github/workflows/dependency-diff.yml
@@ -35,7 +35,8 @@ jobs:
         with:
           mode: artifact
           detect-replacements: 'true'
-          duplicate-threshold: '4'
+          # Too noisy. Disabling until this can report on duplicate CHANGES in this PR.
+          duplicate-threshold: '999'
           dependency-threshold: '15'
           size-threshold: '200000'
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

We added this workflow recently, but it just posts (roughly) the same inactionable comment on PRs. It isn't really actionable information unless it calls out changes incurred by the PR itself.

### 📚 Description

Disable this functionality of the e18e dependency diff action.