### PR TITLE
chore: remove storybook directory from chromatic externals

### DIFF
--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -3,5 +3,5 @@
   "onlyChanged": true,
   "autoAcceptChanges": "main",
   "exitZeroOnChanges": false,
-  "externals": [".storybook/**", "uno.config.ts", "uno.theme.ts"]
+  "externals": ["uno.config.ts", "uno.theme.ts"]
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

Removes `.storybook` directory from the chromatic externals to reduce cache busting.

Per @JReinhold 
> I actually think we should remove the .storybook dir from the cache busting mechanism entirely. I don't think it's necessary honestly, as Chromatic already should be smart enough to find when dependencies in that dir (or the global preview file) is changed.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->
     
Let's chromatic determine itself which of the files in `.storybook` is important to affect snapshots.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
