### PR TITLE
fix(ui): inline headings inside collapsible summaries

### DIFF
--- a/app/components/Readme.vue
+++ b/app/components/Readme.vue
@@ -487,6 +487,20 @@ function handleClick(event: MouseEvent) {
   summary {
     font-size: 1rem;
     color: var(--fg-muted);
+
+    /* Markdown often wraps headings/paragraphs inside <summary>, which
+       forces them onto new lines. Inline them so the disclosure marker
+       sits next to the label while preserving heading styles. */
+    > h1,
+    > h2,
+    > h3,
+    > h4,
+    > h5,
+    > h6,
+    > p {
+      display: inline;
+      margin: 0;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- Markdown readmes commonly put headings inside `<summary>` (e.g. `<summary><h5>...</h5></summary>`). Because headings are block-level, the disclosure marker and the heading text wrapped onto two lines.
- Inline headings and paragraphs that are direct children of `<summary>` so the marker sits next to the label. Heading font-size/weight are preserved (still comes from existing `[data-level]` rules), matching GitHub/JSR rendering.

Closes #2596

Reference of expected behavior: https://jsr.io/@nikelborm/fetch-github-folder


## BEFORE

<img width="1007" height="643" alt="Screenshot 2026-04-20 at 14 42 31" src="https://github.com/user-attachments/assets/d323effc-8a86-4cfd-812e-862c06b3aa1d" />


## AFTER

<img width="1001" height="549" alt="Screenshot 2026-04-20 at 14 43 03" src="https://github.com/user-attachments/assets/c7c79756-2c57-485d-8b00-8a1a185b4e69" />


## Test plan
- [x] `/package/fetch-github-folder` → collapsed and expanded disclosures render on one line
- [x] Heading styling (size/weight) is still visually distinct from body text
- [ ] Other readmes with plain-text summaries are unaffected