### PR TITLE
fix: add deduplication logic in tree sprite generation

### DIFF
--- a/scripts/generate-file-tree-sprite.ts
+++ b/scripts/generate-file-tree-sprite.ts
@@ -32,9 +32,14 @@ async function loadCollections() {
 
 function groupByCollection(iconNames: string[]) {
   const grouped: { [key: string]: string[] } = {}
+  const seen = new Set<string>()
+
   for (const name of iconNames) {
     const [, group, iconName] = name.match(COLLECTION_REGEXP) || []
     if (group && iconName) {
+      const key = `${group}-${iconName}`
+      if (seen.has(key)) continue
+      seen.add(key)
       grouped[group] ||= []
       grouped[group].push(iconName)
     }


### PR DESCRIPTION
### 🔗 Linked issue

Close #2558

### 🧭 Context

SVGs with duplicated IDs are not working correctly on Safari and Firefox.

### 📚 Description

Added a small logic to keep the ID unique.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
