### PR TITLE
fix(ui): bail on fetchMore recursion when no new items

### DIFF
--- a/app/composables/npm/useSearch.ts
+++ b/app/composables/npm/useSearch.ts
@@ -261,6 +261,8 @@ export function useSearch(
       const doSearch = provider === 'algolia' ? searchAlgolia : searchNpm
       const response = await doSearch(q, { size, from })
 
+      const beforeCount = cache.value?.objects.length ?? 0
+
       if (cache.value && cache.value.query === q && cache.value.provider === provider) {
         const existingNames = new Set(cache.value.objects.map(obj => obj.package.name))
         const newObjects = response.objects.filter(obj => !existingNames.has(obj.package.name))
@@ -277,6 +279,12 @@ export function useSearch(
           objects: response.objects,
           total: response.total,
         }
+      }
+
+      // Bail if the provider gave us no new unique items
+      // Without something like this the recursion below never terminates.
+      if ((cache.value?.objects.length ?? 0) === beforeCount) {
+        return
       }
 
       if (


### PR DESCRIPTION
## 🔗 Linked issue

closes #2305

## 🧭 Context

### Problem

Scrolling past ~1000 results on the `/search` view freezes/crashes the browser tab. My Chrome task manager showed it pegged at ~120% CPU.

**Repro:**

1. Go to `/search?q=react` in an incognito tab (to use the defaults aka algolia search provider, infinite scroll)
2. Scroll baby scroll
3. Your browser tab will freeze or crash, you can pop the chrome task manager to confirm the thread is cpu pegged

### Root cause
**tldr;`fetchMore` recurses without a termination check for "server returned nothing new." When Algolia returns empty hits past its 1000 result cap, the recursion never exits, and each cycle's Vue reactivity flush pegs the main thread.**

---
`fetchMore` in `app/composables/npm/useSearch.ts` recurses while the following condition is true:

```ts
if (
  cache.value &&
  cache.value.objects.length < targetSize &&
  cache.value.objects.length < cache.value.total
) {
  await fetchMore(targetSize)
}
```

Algolia enforces a `paginationLimitedTo` cap of 1000 on the `npm-search` index (it's just their default, it could be tweaked in the future). As in, regardless of how many results are available, you can never `offset=` your way past 1k results.

The npmx bug, though, is that algolia returns an empty array of "hits" `{ hits: [], nbHits: 64812, ... }` so the condition above will always be true, we can never break out of the recursion as our result set will always be less than the total reported from the response. 

So we recurse. Since every iteration uses the same params (`currentCount` stayed at 1000), the algolia client's in-memory response cache returns instantly, which lets the recursion turn into a tight nearly synchronous loop. Each iteration reassigns the reactive ref `cache.value`, triggering vue's `flushJobs` which does synchronous work on the main thread. :boom: pegged main thread.

## 📚 Description

### Solution

Bail out when a fetch fails to grow the merged cache:

```ts
const beforeCount = cache.value?.objects.length ?? 0
// ...
if ((cache.value?.objects.length ?? 0) === beforeCount) {
  return
}
```

This fix is defensive, it doesn't assume any specific reason the server stopped returning items. If a fetch produced no progress, stop asking, bail out of the infinite recursion.

**After this PR, you can scroll all the way to page 40 without the tab crashing. No further though, bc by then the server has stopped returning results (default page size 25 * 40 = 1k).**

### Caveats!

This PR only stops the freeze. It does not fix the UI, which will still tell users there are more results, but sadly they just can't access them. That's a fine tradeoff as a short term, bc right now npmx.dev can freeze your browser tab which is a way worse experience.

Here's what I mean about the lying UX, it lists 400k packages for "react" but you can only view 1k, and in table view it shows lots of pages that will just be empty. That's exactly how it is today, just without freezing the site.

<img width="438" height="232" alt="image" src="https://github.com/user-attachments/assets/cd6bfd73-e454-4823-9f52-10d081527f68" />

and the table view...
<img width="438" height="230" alt="image" src="https://github.com/user-attachments/assets/25c97f5d-2b09-4549-85d7-6e793e827163" />


### Follow-up Fix

Keeping this PR scoped to just the freeze. I have a follow-up staged that reads Algolia's `paginationLimitedTo` cap dynamically from the response (`nbPages * hitsPerPage` gives it to you when `nbHits` is over cap), so we don't hardcode 1000. If `npm-search` ever bumps the cap, npmx picks it up for free.

There's a UX wrinkle worth hashing out separately though. Once the total is honest, broad queries will just say "1,000 packages" without any hint that there are actually 100k+ matches out there. Whether we signal that is a judgment call, and I'd rather not bundle it in here.

---
> btw if I have a favorite reactive framework bug to trace, it's dead loops and I hope that comes through here bc this was really fun to track down! it takes a lot of work to make such a small change 🙃 