### PR TITLE
fix: update trusted images policies

### DIFF
--- a/app/components/Readme.vue
+++ b/app/components/Readme.vue
@@ -444,6 +444,11 @@ function handleClick(event: MouseEvent) {
   z-index: 1;
 }
 
+/* With defined width, height will be automatically calculated using the aspect ratio */
+.readme :deep(img[width]) {
+  height: auto;
+}
+
 .readme :deep(video) {
   height: revert-layer;
   display: revert-layer;

--- a/server/utils/image-proxy.ts
+++ b/server/utils/image-proxy.ts
@@ -34,9 +34,9 @@ export const TRUSTED_IMAGE_DOMAINS = [
   'npmx.dev',
 
   // GitHub (already proxied by GitHub's own camo)
+  // We do not include github.com and user-images.githubusercontent.com because they
+  // might return redirects to s3 which will be blocked by the CSP
   'raw.githubusercontent.com',
-  'github.com',
-  'user-images.githubusercontent.com',
   'avatars.githubusercontent.com',
   'repository-images.githubusercontent.com',
   'github.githubassets.com',
@@ -69,6 +69,7 @@ export const TRUSTED_IMAGE_DOMAINS = [
   'deepwiki.com',
   'saucelabs.github.io',
   'opencollective.com',
+  'images.opencollective.com',
   'circleci.com',
   'www.codetriage.com',
   'badges.gitter.im',
@@ -86,9 +87,8 @@ export function isTrustedImageDomain(url: string): boolean {
   if (!parsed?.hostname) return false
 
   const hostname = parsed.hostname.toLowerCase()
-  return TRUSTED_IMAGE_DOMAINS.some(
-    domain => hostname === domain || hostname.endsWith(`.${domain}`),
-  )
+  // We only look at exact matches (not subdomains), since the same array is used as a check in CSP
+  return TRUSTED_IMAGE_DOMAINS.includes(hostname)
 }
 
 /**

--- a/test/unit/server/utils/image-proxy.spec.ts
+++ b/test/unit/server/utils/image-proxy.spec.ts
@@ -18,12 +18,6 @@ describe('Image Proxy Utils', () => {
       ).toBe(true)
     })
 
-    it('trusts GitHub user images', () => {
-      expect(isTrustedImageDomain('https://user-images.githubusercontent.com/123/image.png')).toBe(
-        true,
-      )
-    })
-
     it('trusts shields.io badge URLs', () => {
       expect(isTrustedImageDomain('https://img.shields.io/badge/test-passing-green')).toBe(true)
     })
@@ -36,8 +30,8 @@ describe('Image Proxy Utils', () => {
       expect(isTrustedImageDomain('https://npmx.dev/images/logo.png')).toBe(true)
     })
 
-    it('trusts subdomain of trusted domains', () => {
-      expect(isTrustedImageDomain('https://sub.gitlab.com/image.png')).toBe(true)
+    it('does not trust subdomain of trusted domains', () => {
+      expect(isTrustedImageDomain('https://sub.gitlab.com/image.png')).toBe(false)
     })
 
     it('does not trust arbitrary domains', () => {
@@ -265,7 +259,7 @@ describe('Image Proxy Utils', () => {
     })
 
     it('does not proxy GitHub blob URLs', () => {
-      const url = 'https://github.com/owner/repo/blob/main/assets/logo.png'
+      const url = 'https://cloud.githubusercontent.com/assets/123/logo.png'
       expect(toProxiedImageUrl(url, TEST_SECRET)).toBe(url)
     })
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2611

### 🧭 Context

I accidentally noticed that our images weren't loading. This was due to different checks: in the client, we were checking for subdomains, but the CSP was set to exact match. I made our parser also check for exact match (https://npmxdev-git-fork-alexdln-fix-images-proxy-npmx.vercel.app/package/eslint-visitor-keys)

I also saw that there's a related open bug - github redirects to S3, causing CSP errors for these images. I removed the redirected domains from the allow list. The other GitHub subdomains seem to be working correctly (https://npmxdev-git-fork-alexdln-fix-images-proxy-npmx.vercel.app/package/effect-web-midi/v/0.2.1)

And another small one from the same issue above: if an image has a specified width and height, we change the width to 100%, but the height remains the user-specified value, and the image stretches. Adjusted this so that if the height is specified, the height will change to auto, and the browser will automatically set the desired height since it knows the image's aspect ratio from the attributes