### PR TITLE
ci: deploy manually to canary env from main

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -5,6 +5,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: deploy-canary-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy-canary:
     if: github.repository == 'npmx-dev/npmx.dev'
@@ -14,6 +18,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - run: npx vercel deploy --target=canary --token="$VERCEL_TOKEN"
+      - run: npx vercel deploy --target=canary
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
       - run: npx vercel deploy --target=canary
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -2,6 +2,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   deploy-canary:
     if: github.repository == 'npmx-dev/npmx.dev'

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -1,0 +1,16 @@
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy-canary:
+    if: github.repository == 'npmx-dev/npmx.dev'
+    name: 🚀 Deploy to canary (main.npmx.dev)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - run: npx vercel deploy --target=canary --token="$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -16,7 +16,14 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - run: npx vercel deploy --target=canary
+
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+        with:
+          node-version: lts/*
+          run-install: false
+
+      - run: vp install -g vercel
+      - run: vercel deploy --target=canary
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Instead of using "branch tracking" on the canary Vercel env, this triggers a deploy from GitHub Actions on pushes to the `main` branch in this repo. The branch tracking feature has limitations that this does not suffer from.

### 📚 Description

Trigger a deploy to the "canary" env (main.npmx.dev) on pushes to the `main` branch in this repo