### PR TITLE
fix(ui): incorrect z-index on tooltip

### DIFF
--- a/app/components/Package/Header.vue
+++ b/app/components/Package/Header.vue
@@ -235,7 +235,7 @@ useShortcuts({
   </header>
   <div
     ref="header"
-    class="w-full bg-bg sticky top-14 z-10 border-b border-border pt-2"
+    class="w-full bg-bg sticky top-14 z-50 border-b border-border pt-2"
     :class="[$style.packageHeader]"
     data-testid="package-subheader"
   >

--- a/app/components/Tooltip/Base.vue
+++ b/app/components/Tooltip/Base.vue
@@ -58,7 +58,7 @@ const { floatingStyles } = useFloating(triggerRef, tooltipRef, {
         <div
           v-if="props.isVisible"
           ref="tooltipRef"
-          class="px-2 py-1 font-mono text-xs text-fg bg-bg-elevated border border-border rounded shadow-lg whitespace-pre-line break-words max-w-xs z-[100]"
+          class="px-2 py-1 font-mono text-xs text-fg bg-bg-elevated border border-border rounded shadow-lg whitespace-pre-line break-words max-w-xs z-[40]"
           :class="{ 'pointer-events-none': !interactive }"
           :style="floatingStyles"
           v-bind="tooltipAttr"


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

Z-index on tooltip is above header. This is especially strange on mobile since the tooltip stay active.

<!-- High-level summary of what changed -->

### 📚 Description

I've updated the tooltip z-index as well as the header so it stays behind. 

### Before

https://github.com/user-attachments/assets/5e0ff5ce-bc60-4adc-9513-a377a436714f


### After

https://github.com/user-attachments/assets/e739869b-bb52-480c-8762-31a0ff8fddb7




<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
