### PR TITLE
ci: add a `name` to deploy-canary.yml

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -1,3 +1,5 @@
+name: Deploy canary
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
### 🔗 Linked issue

N/A – follow-up to #2627

### 🧭 Context

Oops, I forgot to specify a `name` and the default is not pretty:

<img width="742" height="66" alt="Screenshot 2026-04-26 at 08 37 38" src="https://github.com/user-attachments/assets/adb58c37-566b-4d27-89b8-2f7e3a98a699" />


### 📚 Description

Add a `name` to the new workflow