### PR TITLE
ci: configure zizmor GHA security checks, fix findings

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
           cache: true
@@ -39,4 +39,4 @@ jobs:
       - name: 🔠 Fix lint errors
         run: vp run lint:fix
 
-      - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27 # 635ffb0c9798bd160680f18fd73371e355b85f27
+      - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27 # v1.3.2

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -27,7 +27,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
           cache: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -25,6 +25,7 @@ jobs:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
       - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:
@@ -45,6 +47,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:
@@ -60,6 +64,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:
@@ -81,6 +87,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:
@@ -113,6 +121,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: 👑 Fix Git ownership
         run: git config --global --add safe.directory /__w/npmx.dev/npmx.dev
@@ -139,6 +149,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:
@@ -160,6 +172,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:
@@ -175,6 +189,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
           run-install: false
@@ -50,7 +50,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
           cache: true
@@ -67,7 +67,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
           cache: true
@@ -90,7 +90,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
           cache: true
@@ -127,7 +127,7 @@ jobs:
       - name: 👑 Fix Git ownership
         run: git config --global --add safe.directory /__w/npmx.dev/npmx.dev
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
           cache: true
@@ -152,7 +152,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
           cache: true
@@ -175,7 +175,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
           cache: true
@@ -192,7 +192,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
           run-install: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
     name: 🖥️ Browser tests
     runs-on: ubuntu-24.04-arm
     container:
-      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      image: mcr.microsoft.com/playwright:v1.58.2-noble@sha256:6446946a1d9fd62d9ae501312a2d76a43ee688542b21622056a372959b65d63d
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/dependency-diff-comment.yml
+++ b/.github/workflows/dependency-diff-comment.yml
@@ -6,15 +6,20 @@ on:
     types:
       - completed
 
-permissions:
-  pull-requests: write
-  actions: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   dependency-diff-comment:
     name: 💬 Dependency diff comment
     runs-on: ubuntu-slim
     if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write # post dependency diff comments on pull requests
+      actions: read # download artifacts from dependency-diff runs
 
     steps:
       - name: 📥 Download artifact

--- a/.github/workflows/dependency-diff.yml
+++ b/.github/workflows/dependency-diff.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 🔎 Compare dependencies
         id: analyze

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -1,3 +1,5 @@
+name: deploy-canary
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
           run-install: false

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:

--- a/.github/workflows/lunaria.yml
+++ b/.github/workflows/lunaria.yml
@@ -27,6 +27,7 @@ jobs:
           # Necessary for Lunaria to work properly
           # Makes the action clone the entire git history
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:

--- a/.github/workflows/lunaria.yml
+++ b/.github/workflows/lunaria.yml
@@ -10,15 +10,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
   cancel-in-progress: true
 
-# Allow this job to clone the repository and comment on the pull request
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   lunaria-overview:
     name: 🌝 Generate Lunaria Overview
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      pull-requests: write # post Lunaria overview comments on pull requests
 
     steps:
       - name: Checkout

--- a/.github/workflows/lunaria.yml
+++ b/.github/workflows/lunaria.yml
@@ -29,10 +29,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
           cache: true
 
       - name: Generate Lunaria Overview
-        uses: lunariajs/action@4911ad0736d1e3b20af4cb70f5079aea2327ed8e # v1-prerelease
+        uses: lunariajs/action@4911ad0736d1e3b20af4cb70f5079aea2327ed8e # astro-docs

--- a/.github/workflows/mirror-tangled.yml
+++ b/.github/workflows/mirror-tangled.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 🔑 Configure SSH
         env:

--- a/.github/workflows/mirror-tangled.yml
+++ b/.github/workflows/mirror-tangled.yml
@@ -7,6 +7,10 @@ on:
     tags:
       - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -5,15 +5,20 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  pull-requests: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   release-pr:
     name: 🚀 Create or update release PR
     runs-on: ubuntu-slim
     if: github.repository == 'npmx-dev/npmx.dev'
+    permissions:
+      contents: read
+      pull-requests: write # create or update the release pull request
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
           run-install: false

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-slim
     if: github.repository == 'npmx-dev/npmx.dev'
     permissions:
-      contents: write
+      contents: write # create release tags and GitHub releases
     outputs:
       version: ${{ steps.version.outputs.next }}
       skipped: ${{ steps.check.outputs.skip }}
@@ -92,7 +92,7 @@ jobs:
     if: needs.tag.outputs.skipped == 'false'
     permissions:
       contents: read
-      id-token: write
+      id-token: write # authenticate npm trusted publishing via OIDC
     environment: npm-publish
 
     steps:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
           run-install: false
@@ -97,7 +97,7 @@ jobs:
           ref: release
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: true
 
       - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:
@@ -94,6 +95,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: release
+          persist-credentials: false
 
       - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1
         with:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - release
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/semantic-pull-requests.yml
+++ b/.github/workflows/semantic-pull-requests.yml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
     name: 🧹 Mark stale bug issues
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write # mark and close stale bug issues
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
         with:
@@ -35,7 +35,7 @@ jobs:
     name: 🧹 Mark stale pull requests
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      pull-requests: write # mark and close stale pull requests
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,6 +14,7 @@ permissions: {}
 
 jobs:
   stale-bugs:
+    name: 🧹 Mark stale bug issues
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -31,6 +32,7 @@ jobs:
           operations-per-run: 500
 
   stale-prs:
+    name: 🧹 Mark stale pull requests
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch: # Allow manual trigger
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,13 +6,13 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch: # Allow manual trigger
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   stale-bugs:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
         with:
@@ -28,6 +28,8 @@ jobs:
 
   stale-prs:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       issues: write # mark and close stale bug issues
     steps:
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 7
@@ -37,7 +37,7 @@ jobs:
     permissions:
       pull-requests: write # mark and close stale pull requests
     steps:
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           days-before-issue-stale: -1
           days-before-issue-close: -1

--- a/.github/workflows/welcome-close.yml
+++ b/.github/workflows/welcome-close.yml
@@ -5,6 +5,10 @@ on:
     types:
       - closed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/welcome-open.yml
+++ b/.github/workflows/welcome-open.yml
@@ -5,14 +5,19 @@ on:
     branches: [main]
     types: [opened]
 
-permissions:
-  pull-requests: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   greeting:
     name: Greet First-Time Contributors
     if: github.repository == 'npmx-dev/npmx.dev'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # post first-time contributor greeting comments
     steps:
       - uses: zephyrproject-rtos/action-first-interaction@58853996b1ac504b8e0f6964301f369d2bb22e5c
         with:

--- a/.github/workflows/welcome-open.yml
+++ b/.github/workflows/welcome-open.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       pull-requests: write # post first-time contributor greeting comments
     steps:
-      - uses: zephyrproject-rtos/action-first-interaction@58853996b1ac504b8e0f6964301f369d2bb22e5c
+      - uses: zephyrproject-rtos/action-first-interaction@58853996b1ac504b8e0f6964301f369d2bb22e5c # tag=v1.1.1+zephyr.6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pr-opened-message: |

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,38 @@
+# https://docs.zizmor.sh/
+name: zizmor
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  merge_group:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: 🌈 GitHub Actions security analysis
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read # checkout repository
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic
+          # Use annotations instead of SARIF as this doesn't need special permissions
+          annotations: true
+          advanced-security: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ permissions: {}
 jobs:
   zizmor:
     name: 🌈 GitHub Actions security analysis
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read # checkout repository
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,10 @@
+# Existing privileged PR automation is intentionally isolated to these workflows:
+# they do not checkout pull request head code, and they only comment or set status.
+rules:
+  dangerous-triggers:
+    ignore:
+      - dependency-diff-comment.yml
+      - lunaria.yml
+      - semantic-pull-requests.yml
+      - welcome-close.yml
+      - welcome-open.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,10 @@
 # Existing privileged PR automation is intentionally isolated to these workflows:
 # they do not checkout pull request head code, and they only comment or set status.
 rules:
+  stale-action-refs:
+    ignore:
+      # lunariajs/action has no tag refs; keep the branch commit hash-pinned.
+      - lunaria.yml:38
   dangerous-triggers:
     ignore:
       - dependency-diff-comment.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,7 @@ pnpm mock-connector   # Start the mock connector (no npm login needed)
 pnpm vp run lint      # Run linter (oxlint + oxfmt)
 pnpm lint:fix         # Auto-fix lint issues
 pnpm test:types       # TypeScript type checking
+pnpm vp run zizmor    # GitHub Actions security analysis
 
 # Testing
 pnpm test             # Run all Vitest tests
@@ -131,6 +132,28 @@ pnpm test:nuxt        # Nuxt component tests
 pnpm test:browser     # Playwright E2E tests
 pnpm test:a11y        # Lighthouse accessibility audits
 pnpm test:perf        # Lighthouse performance audits (CLS)
+```
+
+### GitHub Actions security analysis
+
+CI runs [zizmor](https://docs.zizmor.sh/) against the repository's GitHub Actions workflows. The shared policy lives in `.github/zizmor.yml`, and the `zizmor` task uses the same pedantic persona as CI.
+
+You may run it locally by [installing `zizmor`](https://docs.zizmor.sh/installation/) and running:
+
+```bash
+pnpm vp run zizmor
+```
+
+Some audits resolve action refs and vulnerability metadata through GitHub. To run those online checks locally, authenticate with the GitHub CLI and pass its token:
+
+```bash
+GH_TOKEN="$(gh auth token)" pnpm vp run zizmor
+```
+
+To fix audit findings automatically, run:
+
+```bash
+GH_TOKEN="$(gh auth token)" pnpm vp run zizmor:fix
 ```
 
 ### Clearing caches during development

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,12 @@ export default defineConfig({
       'lint:css': {
         command: 'node scripts/unocss-checker.ts',
       },
+      'zizmor': {
+        command: 'zizmor --pedantic .',
+      },
+      'zizmor:fix': {
+        command: 'zizmor --pedantic --fix .',
+      },
       'build:lunaria': {
         command: 'node ./lunaria/lunaria.ts',
       },


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

GitHub Actions workflows are a common attack vector for GitHub projects and their maintainers.

https://zizmor.sh implements a number of valuable checks that flag vulnerable patterns immediately on PRs, preventing them from reaching `main`. Let's give it a try.

### 📚 Description

This PR configures zizmor to run in CI, documents how to run it locally if needed, and fixes or suppresses all the issues identified by running a `pedantic` audit ([see all rules here](https://docs.zizmor.sh/audits/)):

- Apply principle of least privilege by always applying permissions to the exact step or job that actually needs it
  - ✅ Fixed 5 issues
- Document why each permission is needed with a comment
  - ✅ Fixed 10 issues
- Pin all actions and images to a specific commit or digest
  - ✅ Fixed 1 issue
  - Require inline comment with human-friendly version/release identifier
  - Require this identifier to actually match the commit/digest
    - ✅ Fixed 17 issues
- Use `persist-credentials: false` for `actions/checkout` (by default it persists a GitHub token for later git command; disabling this decreases risk of credentials exposure through logs, disk, etc.)
  - ✅ Fixed 16 issues
- Use concurrency controls in all workflows
  - ✅ Fixed 9 issues
- Require names for all workflows
  - ✅ Fixed 3 issues

It posts nice inline annotations too!

<img width="1006" height="274" alt="Screenshot 2026-04-26 at 10 15 09" src="https://github.com/user-attachments/assets/37dd3819-a383-41b9-b4e5-519d86f8b661" />