### PR TITLE
feat: add the new package timeline page to the command palette

### DIFF
--- a/app/components/Package/Header.vue
+++ b/app/components/Package/Header.vue
@@ -164,15 +164,7 @@ const diffLink = computed((): RouteLocationRaw | null => {
 
 const timelineLink = computed((): RouteLocationRaw | null => {
   if (props.pkg == null || props.resolvedVersion == null) return null
-  const split = props.pkg.name.split('/')
-  return {
-    name: 'timeline',
-    params: {
-      org: split.length === 2 ? split[0] : undefined,
-      packageName: split.length === 2 ? split[1]! : split[0]!,
-      version: props.resolvedVersion,
-    },
-  }
+  return packageTimelineRoute(props.pkg.name, props.resolvedVersion)
 })
 
 useShortcuts({

--- a/app/composables/useCommandPalettePackageCommands.ts
+++ b/app/composables/useCommandPalettePackageCommands.ts
@@ -89,6 +89,20 @@ export function useCommandPalettePackageCommands(
           to: codeLink,
         },
         {
+          id: 'package-timeline',
+          group: 'package',
+          label: t('package.links.timeline'),
+          keywords: [
+            resolvedContext.packageName,
+            t('shortcuts.open_timeline'),
+            t('package.links.timeline'),
+          ],
+          iconClass: 'i-lucide:history',
+          active: route.name === 'timeline',
+          activeLabel: activeLabel(route.name === 'timeline', t('command_palette.here')),
+          to: packageTimelineRoute(resolvedContext.packageName, resolvedContext.resolvedVersion),
+        },
+        {
           id: 'package-compare',
           group: 'package',
           label: t('command_palette.package.compare'),

--- a/app/pages/package-timeline/[[org]]/[packageName].vue
+++ b/app/pages/package-timeline/[[org]]/[packageName].vue
@@ -22,6 +22,8 @@ const packageName = computed(() =>
 const version = computed(() => route.params.version)
 
 const { data: pkg } = usePackage(packageName, version)
+const { versions: commandPaletteVersions, ensureLoaded: ensureCommandPaletteVersionsLoaded } =
+  useCommandPalettePackageVersions(packageName)
 
 const latestVersion = computed(() => {
   if (!pkg.value) return null
@@ -30,10 +32,31 @@ const latestVersion = computed(() => {
   return pkg.value.versions[latestTag] ?? null
 })
 
+const commandPalettePackageContext = computed(() => {
+  const packageData = pkg.value
+  if (!packageData) return null
+
+  return {
+    packageName: packageData.name,
+    resolvedVersion: version.value ?? packageData['dist-tags']?.latest ?? null,
+    latestVersion: packageData['dist-tags']?.latest ?? null,
+    versions: commandPaletteVersions.value ?? Object.keys(packageData.versions ?? {}),
+  }
+})
+
+useCommandPalettePackageContext(commandPalettePackageContext, {
+  onOpen: ensureCommandPaletteVersionsLoaded,
+})
+useCommandPalettePackageCommands(commandPalettePackageContext)
+
 const versionUrlPattern = computed(() => {
   const { org, packageName: name } = route.params
   return `/package-timeline/${org ? `${org}/` : ''}${name}/v/{version}`
 })
+
+useCommandPaletteVersionCommands(commandPalettePackageContext, nextVersion =>
+  packageTimelineRoute(packageName.value, nextVersion),
+)
 
 function packageRoute(ver: string): RouteLocationRaw {
   return {

--- a/app/utils/router.ts
+++ b/app/utils/router.ts
@@ -52,3 +52,16 @@ export function diffRoute(
     },
   }
 }
+
+export function packageTimelineRoute(packageName: string, version: string): RouteLocationRaw {
+  const { org, name } = splitPackageName(packageName)
+
+  return {
+    name: 'timeline',
+    params: {
+      org: org || undefined,
+      packageName: name,
+      version: version.replace(/\s+/g, ''),
+    },
+  }
+}

--- a/test/nuxt/composables/use-command-palette-commands.spec.ts
+++ b/test/nuxt/composables/use-command-palette-commands.spec.ts
@@ -230,6 +230,14 @@ describe('useCommandPaletteCommands', () => {
     expect(flatCommands.value.find(command => command.id === 'package-diff')).toBeTruthy()
     expect(flatCommands.value.find(command => command.id === 'package-download')).toBeTruthy()
     expect(flatCommands.value.find(command => command.id === 'package-main')?.to).toBeTruthy()
+    expect(flatCommands.value.find(command => command.id === 'package-timeline')?.to).toEqual({
+      name: 'timeline',
+      params: {
+        org: undefined,
+        packageName: 'vue',
+        version: '3.4.0',
+      },
+    })
     expect(groupedCommands.value.at(-1)?.id).toBe('versions')
     expect(groupedCommands.value.at(-1)?.items[0]?.id).toBe('version:3.4.0')
     expect(groupedCommands.value.at(-1)?.items[0]?.active).toBe(true)
@@ -509,6 +517,14 @@ describe('useCommandPaletteCommands', () => {
       name: 'docs',
       params: {
         path: ['@scope', 'pkg', 'v', '1.0.0'],
+      },
+    })
+    expect(flatCommands.value.find(command => command.id === 'package-timeline')?.to).toEqual({
+      name: 'timeline',
+      params: {
+        org: '@scope',
+        packageName: 'pkg',
+        version: '1.0.0',
       },
     })
 


### PR DESCRIPTION
### 🔗 Linked issue

#2244

### 🧭 Context

This was missed in #2245. All pages and capabilities of the app should be accessible through the command palette.

### 📚 Description

- Add the package timeline to the command palette when on a page with a package context.

<img width="1185" height="691" alt="Screenshot 2026-04-26 at 20 30 40" src="https://github.com/user-attachments/assets/75462fbc-a405-42c5-a94f-eb9495e00dba" />

- Add all the missing package context command palette commands when on the package timeline page.

<img width="1032" height="655" alt="Screenshot 2026-04-26 at 20 29 45" src="https://github.com/user-attachments/assets/16b23a14-0723-421a-9250-2b7baa46ff43" />

> [!NOTE]
> This is stacked on a refactor that felt overdue: https://github.com/npmx-dev/npmx.dev/pull/2635 