### PR TITLE
fix: also pin dev dependency install version when trust is downgraded

### DIFF
--- a/app/components/Terminal/Install.vue
+++ b/app/components/Terminal/Install.vue
@@ -41,7 +41,7 @@ function getDevInstallPartsForPM(pmId: PackageManagerId) {
   return getInstallCommandParts({
     packageName: props.packageName,
     packageManager: pmId,
-    version: props.requestedVersion,
+    version: props.installVersionOverride ?? props.requestedVersion,
     jsrInfo: props.jsrInfo,
     dev: true,
   })
@@ -116,7 +116,7 @@ const copyDevInstallCommand = () =>
     getInstallCommand({
       packageName: props.packageName,
       packageManager: selectedPM.value,
-      version: props.requestedVersion,
+      version: props.installVersionOverride ?? props.requestedVersion,
       jsrInfo: props.jsrInfo,
       dev: true,
     }),


### PR DESCRIPTION
Closes #2643

### Before

<img width="774" height="201" alt="image" src="https://github.com/user-attachments/assets/8840c5d4-2811-4274-b896-14e8a2d542d8" />


### After

<img width="771" height="204" alt="image" src="https://github.com/user-attachments/assets/0daa288a-43f8-4e08-ae04-d29f2e3da886" />
