### PR TITLE
feat: improve scatter legend interactivity

### DIFF
--- a/app/components/Compare/FacetScatterChart.vue
+++ b/app/components/Compare/FacetScatterChart.vue
@@ -5,6 +5,7 @@ import {
   VueUiScatter,
   type VueUiScatterConfig,
   type VueUiScatterDatasetItem,
+  type VueUiScatterSeries,
 } from 'vue-data-ui/vue-ui-scatter'
 import { buildCompareScatterChartDataset } from '~/utils/compare-scatter-chart'
 import { loadFile, copyAltTextForCompareScatterChart } from '~/utils/charts'
@@ -285,6 +286,11 @@ function toggleAxisHighlight(state: AxisHighlight) {
   highlightedAxis.value = state
 }
 
+function toggleLegendItem(legendItem: VueUiScatterSeries) {
+  legendItem.segregate()
+  legendItem.onEnter()
+}
+
 const readyTeleport = shallowRef(false)
 
 onMounted(async () => {
@@ -389,34 +395,26 @@ onMounted(async () => {
                       : 'text-sm leading-6'
                   "
                 >
-                  <li v-for="datapoint in legend" :key="datapoint.name">
+                  <li v-for="legendItem in legend" :key="legendItem.name">
                     <button
-                      :aria-pressed="datapoint.isSegregated"
-                      :aria-label="datapoint.name"
+                      :aria-pressed="legendItem.isSegregated"
+                      :aria-label="legendItem.name"
                       type="button"
                       class="flex gap-1.5 place-items-center"
-                      :class="{
-                        'hover:underline': !datapoint.isSegregated,
-                        'line-through': datapoint.isSegregated,
-                      }"
-                      @click="
-                        () => {
-                          datapoint.segregate()
-                          datapoint.onEnter()
-                        }
-                      "
-                      @mouseenter="datapoint.onEnter()"
-                      @mouseleave="datapoint.onLeave()"
-                      @focus="datapoint.onEnter()"
-                      @blur="datapoint.onLeave()"
+                      :class="legendItem.isSegregated ? 'line-through' : 'hover:underline'"
+                      @click="() => toggleLegendItem(legendItem)"
+                      @mouseenter="legendItem.onEnter()"
+                      @mouseleave="legendItem.onLeave()"
+                      @focus="legendItem.onEnter()"
+                      @blur="legendItem.onLeave()"
                     >
                       <div class="h-3 w-3" aria-hidden="true">
                         <svg viewBox="0 0 2 2" class="w-full">
-                          <circle cx="1" cy="1" r="1" :fill="datapoint.color" />
+                          <circle cx="1" cy="1" r="1" :fill="legendItem.color" />
                         </svg>
                       </div>
                       <span class="text-fg">
-                        {{ datapoint.name }}
+                        {{ legendItem.name }}
                       </span>
                     </button>
                   </li>

--- a/app/components/Compare/FacetScatterChart.vue
+++ b/app/components/Compare/FacetScatterChart.vue
@@ -402,7 +402,7 @@ onMounted(async () => {
                       type="button"
                       class="flex gap-1.5 place-items-center"
                       :class="legendItem.isSegregated ? 'line-through' : 'hover:underline'"
-                      @click="() => toggleLegendItem(legendItem)"
+                      @click="toggleLegendItem(legendItem)"
                       @mouseenter="legendItem.onEnter()"
                       @mouseleave="legendItem.onLeave()"
                       @focus="legendItem.onEnter()"

--- a/app/components/Compare/FacetScatterChart.vue
+++ b/app/components/Compare/FacetScatterChart.vue
@@ -395,19 +395,27 @@ onMounted(async () => {
                       :aria-label="datapoint.name"
                       type="button"
                       class="flex gap-1.5 place-items-center"
-                      @click="datapoint.segregate()"
+                      :class="{
+                        'hover:underline': !datapoint.isSegregated,
+                        'line-through': datapoint.isSegregated,
+                      }"
+                      @click="
+                        () => {
+                          datapoint.segregate()
+                          datapoint.onEnter()
+                        }
+                      "
+                      @mouseenter="datapoint.onEnter()"
+                      @mouseleave="datapoint.onLeave()"
+                      @focus="datapoint.onEnter()"
+                      @blur="datapoint.onLeave()"
                     >
                       <div class="h-3 w-3" aria-hidden="true">
                         <svg viewBox="0 0 2 2" class="w-full">
                           <circle cx="1" cy="1" r="1" :fill="datapoint.color" />
                         </svg>
                       </div>
-                      <span
-                        class="text-fg"
-                        :style="{
-                          textDecoration: datapoint.isSegregated ? 'line-through' : undefined,
-                        }"
-                      >
+                      <span class="text-fg">
                         {{ datapoint.name }}
                       </span>
                     </button>
@@ -559,14 +567,35 @@ onMounted(async () => {
 </template>
 
 <style scoped>
+:deep(.vue-data-ui-component) {
+  --super-ease-out: cubic-bezier(0.15, 0.75, 0.35, 1);
+}
+
 :deep(.vue-data-ui-component svg:focus-visible) {
   outline: 1px solid var(--accent) !important;
   border-radius: 0.1rem;
   outline-offset: 0;
 }
+
 :deep(.vue-ui-user-options-button:focus-visible),
 :deep(.vue-ui-user-options :first-child:focus-visible) {
   outline: 0.1rem solid var(--accent) !important;
   border-radius: 0.25rem;
+}
+
+:deep(.vue-ui-scatter-scale-group),
+:deep(.vue-ui-scatter-datapoint text),
+:deep(.vue-ui-scatter-datapoint circle),
+:deep(.vue-ui-scatter-datapoint-label) {
+  transition: all 0.5s var(--super-ease-out) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :deep(.vue-ui-scatter-scale-group),
+  :deep(.vue-ui-scatter-datapoint text),
+  :deep(.vue-ui-scatter-datapoint circle),
+  :deep(.vue-ui-scatter-datapoint-label) {
+    transition: none !important;
+  }
 }
 </style>

--- a/app/components/Compare/FacetScatterChart.vue
+++ b/app/components/Compare/FacetScatterChart.vue
@@ -395,7 +395,7 @@ onMounted(async () => {
                       : 'text-sm leading-6'
                   "
                 >
-                  <li v-for="legendItem in legend" :key="legendItem.name">
+                  <li v-for="legendItem in legend" :key="legendItem.id">
                     <button
                       :aria-pressed="legendItem.isSegregated"
                       :aria-label="legendItem.name"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "vite-plugin-pwa": "1.2.0",
     "vite-plus": "0.1.16",
     "vue": "3.5.33",
-    "vue-data-ui": "3.18.0",
+    "vue-data-ui": "3.18.2",
     "vue-router": "5.0.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,8 +249,8 @@ importers:
         specifier: 3.5.33
         version: 3.5.33(typescript@6.0.2)
       vue-data-ui:
-        specifier: 3.18.0
-        version: 3.18.0(vue@3.5.33)
+        specifier: 3.18.2
+        version: 3.18.2(vue@3.5.33)
       vue-router:
         specifier: 5.0.4
         version: 5.0.4(@vue/compiler-sfc@3.5.33)(vue@3.5.33)
@@ -11129,8 +11129,8 @@ packages:
   vue-component-type-helpers@3.2.7:
     resolution: {integrity: sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==}
 
-  vue-data-ui@3.18.0:
-    resolution: {integrity: sha512-sPCYLVEMC4sVe7kf3qEf5VkIkkflCg95/jsMdveR8r3C6d6fga/50lRPd3wK14wFI1Mkt3cd4X3r3x3wgONLww==}
+  vue-data-ui@3.18.2:
+    resolution: {integrity: sha512-BJP+YMrJeAdVnT2rmBsZBe+rHksReCHrzFM8MYXAgndgAdPJlzsLigylwflLhm9sndQeAt6ihCslX0VIU+nyUQ==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -23836,7 +23836,7 @@ snapshots:
 
   vue-component-type-helpers@3.2.7: {}
 
-  vue-data-ui@3.18.0(vue@3.5.33):
+  vue-data-ui@3.18.2(vue@3.5.33):
     dependencies:
       vue: 3.5.33(typescript@6.0.2)
 


### PR DESCRIPTION
Follow up to #2493 

This improves the interactivity features of the legend of the scatter chart in the compare page:

- bump vue-data-ui to 3.18.2 (adds events to the `#legend` slot, see [release notes](https://github.com/graphieros/vue-data-ui/releases/tag/v3.18.2))
- datapoints are highlighted when hovering legend items (same behavior has hovering actual datapoints)
- a css transition was added to ease the plots repositioning when filtering out a series results in a change of scale. This transition is not applied if prefers-reduced-motion.

https://github.com/user-attachments/assets/91a194f3-76c6-4d8c-8631-3fccce846786


