### PR TITLE
fix: restore maximumFractionDigits: 0 on sparkline data label formatter

### DIFF
--- a/app/components/Package/WeeklyDownloadStats.vue
+++ b/app/components/Package/WeeklyDownloadStats.vue
@@ -63,7 +63,7 @@ function handleModalTransitioned() {
 }
 
 const { fetchPackageDownloadEvolution } = useCharts()
-const numberFormatter = useNumberFormatter()
+const numberFormatter = useNumberFormatter({ maximumFractionDigits: 0 })
 
 const { accentColors, selectedAccentColor } = useAccentColor()
 


### PR DESCRIPTION
### 🔗 Linked issue

Closes #2656

### 🧭 Context

PR #2556 added `Math.ceil` in `applyDataCorrection` to fix decimal numbers in the weekly downloads label, but also removed `maximumFractionDigits: 0` from the formatter in `WeeklyDownloadStats.vue` — which was actually the effective guard.

`VueUiSparkline` does its own internal interpolation and passes float values directly to `dataLabel.formatter`, bypassing `applyDataCorrection` entirely. Without `maximumFractionDigits: 0`, those floats render as `1,195,399.72` instead of `1,195,400`.

### 📚 Description

Restore `maximumFractionDigits: 0` on the `useNumberFormatter` call used for the sparkline data label. One-line change.