### PR TITLE
fix: show license from correct version

### DIFF
--- a/app/composables/npm/usePackage.ts
+++ b/app/composables/npm/usePackage.ts
@@ -17,10 +17,10 @@ function getTrustLevel(version: PackumentVersion): PublishTrustLevel {
 }
 
 function normalizeLicense(license?: PackumentLicense): string | undefined {
-  if (license && typeof license === 'object' && 'type' in license) {
-    return license.type
-  }
-  return typeof license === 'string' ? license : undefined
+  if (!license) return undefined
+  if (typeof license === 'string') return license
+  if (typeof license.type === 'string') return license.type
+  return undefined
 }
 
 /**
@@ -116,7 +116,7 @@ export function transformPackument(
   }
 
   // Normalize license field
-  const license = normalizeLicense(versionData?.license || pkg.license)
+  const license = normalizeLicense(requestedVersion ? versionData?.license : pkg.license)
 
   // Extract storybook field from the requested version (custom package.json field)
   const requestedPkgVersion = requestedVersion ? pkg.versions[requestedVersion] : null

--- a/app/composables/npm/usePackage.ts
+++ b/app/composables/npm/usePackage.ts
@@ -16,6 +16,13 @@ function getTrustLevel(version: PackumentVersion): PublishTrustLevel {
   return 'none'
 }
 
+function normalizeLicense(license?: PackumentLicense): string | undefined {
+  if (license && typeof license === 'object' && 'type' in license) {
+    return license.type
+  }
+  return typeof license === 'string' ? license : undefined
+}
+
 /**
  * Transform a full Packument into a slimmed version for client-side use.
  * Reduces payload size by:
@@ -72,6 +79,7 @@ export function transformPackument(
   for (const v of includedVersions) {
     const version = pkg.versions[v]
     if (version) {
+      const versionLicense = normalizeLicense(version.license)
       if (version.version === requestedVersion) {
         // Strip readme from each version, extract install scripts info
         const { readme: _readme, scripts, ...slimVersion } = version
@@ -80,17 +88,12 @@ export function transformPackument(
         const installScripts = scripts ? extractInstallScriptsInfo(scripts) : null
         versionData = {
           ...slimVersion,
+          license: versionLicense,
           installScripts: installScripts ?? undefined,
         }
       }
       const trustLevel = getTrustLevel(version)
       const hasProvenance = trustLevel !== 'none'
-
-      // Normalize license: some versions use { type: "MIT" } instead of "MIT"
-      let versionLicense = version.license
-      if (versionLicense && typeof versionLicense === 'object' && 'type' in versionLicense) {
-        versionLicense = (versionLicense as { type: string }).type
-      }
 
       filteredVersions[v] = {
         hasProvenance,
@@ -98,7 +101,7 @@ export function transformPackument(
         version: version.version,
         deprecated: version.deprecated,
         tags: version.tags as string[],
-        license: typeof versionLicense === 'string' ? versionLicense : undefined,
+        license: versionLicense,
         type: typeof version.type === 'string' ? version.type : undefined,
       }
     }
@@ -113,10 +116,7 @@ export function transformPackument(
   }
 
   // Normalize license field
-  let license = pkg.license
-  if (license && typeof license === 'object' && 'type' in license) {
-    license = license.type
-  }
+  const license = normalizeLicense(versionData?.license || pkg.license)
 
   // Extract storybook field from the requested version (custom package.json field)
   const requestedPkgVersion = requestedVersion ? pkg.versions[requestedVersion] : null

--- a/shared/types/npm-registry.ts
+++ b/shared/types/npm-registry.ts
@@ -23,10 +23,12 @@ export interface PackumentVersion extends PackumentVersionWithoutAttestations {
   dist: PackumentVersionWithoutAttestations['dist'] & { attestations?: NpmVersionAttestations }
 }
 
+export type PackumentLicense = string | { type: string; url?: string }
+
 export type Packument = Omit<PackumentWithoutLicenseObjects, 'license' | 'versions'> & {
   // Fix for license field being incorrectly typed in @npm/types
   // TODO: Remove this type override when @npm/types fixes the license field typing
-  license?: string | { type: string; url?: string }
+  license?: PackumentLicense
   versions: Record<string, PackumentVersion>
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2163
Closes #2186

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

Before:

[<img width="300" height="112" alt="image" src="https://github.com/user-attachments/assets/22ab7e27-f753-488e-91fa-965b10e7241a" />](https://npmx.dev/package/glob/v/9.3.5)

After:

[<img width="266" height="143" alt="image" src="https://github.com/user-attachments/assets/f72ff54f-889e-4f0a-8f3d-89bc7d64dc8e" />](https://npmxdev-git-fork-gameroman-fix-license-version-npmx.vercel.app/package/glob/v/9.3.5)

