### PR TITLE
fix: npmx connector Node.js v22 compatibility

### DIFF
--- a/cli/src/npm-client.ts
+++ b/cli/src/npm-client.ts
@@ -574,6 +574,9 @@ export async function packageInit(
 
   const tempDirPath = await mkdtemp(join(tmpdir(), 'npmx-init-'))
 
+  let publishResult: NpmExecResult | null = null
+  let publishError: unknown = null
+
   try {
     // Determine access type based on whether it's a scoped package
     const isScoped = name.startsWith('@')
@@ -621,8 +624,29 @@ export async function packageInit(
       logError(result.stderr.split('\n')[0] || 'Command failed')
     }
 
-    return result
-  } finally {
-    await rm(tempDirPath, { recursive: true, force: true })
+    publishResult = result
+  } catch (error) {
+    publishError = error
   }
+
+  try {
+    await rm(tempDirPath, { recursive: true, force: true })
+  } catch (cleanupError) {
+    if (publishError) {
+      // Preserve original error
+      Object.assign(cleanupError as Error, { cause: publishError })
+    }
+
+    throw cleanupError
+  }
+
+  if (publishError) {
+    throw publishError
+  }
+
+  if (!publishResult) {
+    throw new Error('packageInit completed without a publish result')
+  }
+
+  return publishResult
 }

--- a/cli/src/npm-client.ts
+++ b/cli/src/npm-client.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto'
 import process from 'node:process'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
-import { mkdtempDisposable, writeFile } from 'node:fs/promises'
+import { mkdtemp, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import * as v from 'valibot'
@@ -572,54 +572,57 @@ export async function packageInit(
 ): Promise<NpmExecResult> {
   validatePackageName(name)
 
-  // Let Node clean up the temp directory automatically when this scope exits.
-  await using tempDir = await mkdtempDisposable(join(tmpdir(), 'npmx-init-'))
+  const tempDirPath = await mkdtemp(join(tmpdir(), 'npmx-init-'))
 
-  // Determine access type based on whether it's a scoped package
-  const isScoped = name.startsWith('@')
-  const access = isScoped ? 'public' : undefined
+  try {
+    // Determine access type based on whether it's a scoped package
+    const isScoped = name.startsWith('@')
+    const access = isScoped ? 'public' : undefined
 
-  // Create minimal package.json
-  const packageJson = {
-    name,
-    version: '0.0.0',
-    description: `Placeholder for ${name}`,
-    main: 'index.js',
-    scripts: {},
-    keywords: [],
-    author: author ? `${author} (https://www.npmjs.com/~${author})` : '',
-    license: 'UNLICENSED',
-    private: false,
-    ...(access && { publishConfig: { access } }),
+    // Create minimal package.json
+    const packageJson = {
+      name,
+      version: '0.0.0',
+      description: `Placeholder for ${name}`,
+      main: 'index.js',
+      scripts: {},
+      keywords: [],
+      author: author ? `${author} (https://www.npmjs.com/~${author})` : '',
+      license: 'UNLICENSED',
+      private: false,
+      ...(access && { publishConfig: { access } }),
+    }
+
+    await writeFile(join(tempDirPath, 'package.json'), JSON.stringify(packageJson, null, 2))
+
+    // Create empty index.js
+    await writeFile(join(tempDirPath, 'index.js'), '// Placeholder\n')
+
+    // Build npm publish args
+    const args = ['publish']
+    if (access) {
+      args.push('--access', access)
+    }
+
+    const displayCmd = options?.otp
+      ? ['npm', ...args, '--otp', '******'].join(' ')
+      : ['npm', ...args].join(' ')
+    logCommand(`${displayCmd} (in temp dir for ${name})`)
+
+    const result = await execNpm(args, { ...options, cwd: tempDirPath, silent: true })
+
+    if (result.exitCode === 0) {
+      logSuccess(`Published ${name}@0.0.0`)
+    } else if (result.requiresOtp) {
+      logError('OTP required')
+    } else if (result.authFailure) {
+      logError('Authentication required - please run "npm login" and restart the connector')
+    } else {
+      logError(result.stderr.split('\n')[0] || 'Command failed')
+    }
+
+    return result
+  } finally {
+    await rm(tempDirPath, { recursive: true, force: true })
   }
-
-  await writeFile(join(tempDir.path, 'package.json'), JSON.stringify(packageJson, null, 2))
-
-  // Create empty index.js
-  await writeFile(join(tempDir.path, 'index.js'), '// Placeholder\n')
-
-  // Build npm publish args
-  const args = ['publish']
-  if (access) {
-    args.push('--access', access)
-  }
-
-  const displayCmd = options?.otp
-    ? ['npm', ...args, '--otp', '******'].join(' ')
-    : ['npm', ...args].join(' ')
-  logCommand(`${displayCmd} (in temp dir for ${name})`)
-
-  const result = await execNpm(args, { ...options, cwd: tempDir.path, silent: true })
-
-  if (result.exitCode === 0) {
-    logSuccess(`Published ${name}@0.0.0`)
-  } else if (result.requiresOtp) {
-    logError('OTP required')
-  } else if (result.authFailure) {
-    logError('Authentication required - please run "npm login" and restart the connector')
-  } else {
-    logError(result.stderr.split('\n')[0] || 'Command failed')
-  }
-
-  return result
 }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2645

### 🧭 Context

`npmx-connector` currently crashes for users trying to run it with Node.js 22, which is still in the maintenance and used by many people. This PR fixes the only incompatible function (`packageInit`).

### 📚 Description

Node v24+ only features used:
- `mkdtempDisposable` - for temp dir creation
- `await using` - to ensure the temp dir cleanup

Replaced with compatible versions:
- `mkdtempDisposable` -> `mkdtemp`
- Automatic disposal with `await using` -> Manual disposal with `rm`

Fix verified on Node v22

~~Tradeoffs: if both the function code and `rm` will throw, only the error from `rm` would be preserved. Should be possible to fix at a cost of complex cleanup logic, but the situation seems unlikely.~~

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
