### PR TITLE
fix: move tooltips to the sides on line charts to free the view

### DIFF
--- a/app/components/Package/TimelineChart.vue
+++ b/app/components/Package/TimelineChart.vue
@@ -18,6 +18,7 @@ import {
 } from '~/utils/charts'
 import type { TimelineVersion, SubEvent } from '~~/server/api/registry/timeline/[...pkg].get'
 import { drawSmallNpmxLogoAndTaglineWatermark } from '~/composables/useChartWatermark'
+import { useChartTooltipPosition } from '~/composables/useChartTooltipPosition'
 
 import('vue-data-ui/style.css')
 
@@ -250,6 +251,8 @@ function buildExportFilename(extension: 'png' | 'csv' | 'svg') {
   return `${sanitise(packageName.value)}_${$t('package.links.timeline')}_${metricLabel.value.toLocaleLowerCase().replaceAll(' ', '-')}.${extension}`
 }
 
+const tooltipPosition = useChartTooltipPosition(chartRef)
+
 const config = computed<VueUiXyConfig>(() => {
   return {
     theme: isDarkMode.value ? 'dark' : '',
@@ -316,6 +319,8 @@ const config = computed<VueUiXyConfig>(() => {
         color: colors.value.fg,
       },
       tooltip: {
+        position: tooltipPosition.value,
+        offsetX: 24,
         borderColor: colors.value.border,
         borderRadius: 6,
         backgroundColor: colors.value.bg,

--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -25,6 +25,7 @@ import {
 } from '~/utils/chart-data-prediction'
 import { applyBlocklistCorrection, getAnomaliesForPackages } from '~/utils/download-anomalies'
 import { copyAltTextForTrendLineChart, sanitise, loadFile, applyEllipsis } from '~/utils/charts'
+import { useChartTooltipPosition } from '~/composables/useChartTooltipPosition'
 
 import('vue-data-ui/style.css')
 
@@ -66,6 +67,8 @@ const colorMode = useColorMode()
 const resolvedMode = shallowRef<'light' | 'dark'>('light')
 const rootEl = shallowRef<HTMLElement | null>(null)
 const isZoomed = shallowRef(false)
+
+const chartRef = useTemplateRef('chartRef')
 
 function setIsZoom({ isZoom }: { isZoom: boolean }) {
   isZoomed.value = isZoom
@@ -1385,6 +1388,8 @@ watch(
   { immediate: true },
 )
 
+const tooltipPosition = useChartTooltipPosition(chartRef)
+
 // VueUiXy chart component configuration
 const chartConfig = computed<VueUiXyConfig>(() => {
   return {
@@ -1518,6 +1523,9 @@ const chartConfig = computed<VueUiXyConfig>(() => {
       legend: { show: false, position: 'top' },
       tooltip: {
         teleportTo: props.inModal ? '#chart-modal' : undefined,
+        position: tooltipPosition.value,
+        offsetX: 24,
+        offsetY: isMultiPackageMode.value ? undefined : -24,
         borderColor: 'transparent',
         backdropFilter: false,
         backgroundColor: 'transparent',
@@ -1930,6 +1938,7 @@ const isSparklineLayout = computed({
           :aria-labelledby="isMultiPackageMode ? 'combined-chart-layout-tab' : undefined"
         >
           <VueUiXy
+            ref="chartRef"
             :dataset="normalisedDataset"
             :config="chartConfig"
             :class="{

--- a/app/composables/useChartTooltipPosition.ts
+++ b/app/composables/useChartTooltipPosition.ts
@@ -1,7 +1,7 @@
 /**
  * This composable returns a dynamic position to be fed to vue-data-ui components configugration for the `tooltip.position` attribute. Use it to position tooltips to the right or left side to free the view for datapoints, typically on line charts.
  */
-
+import { computed, toValue } from 'vue'
 import { useMouseInElement } from '@vueuse/core'
 
 type TooltipPosition = 'left' | 'right' | 'center'

--- a/app/composables/useChartTooltipPosition.ts
+++ b/app/composables/useChartTooltipPosition.ts
@@ -1,0 +1,26 @@
+/**
+ * This composable returns a dynamic position to be fed to vue-data-ui components configugration for the `tooltip.position` attribute. Use it to position tooltips to the right or left side to free the view for datapoints, typically on line charts.
+ */
+
+import { useMouseInElement } from '@vueuse/core'
+
+type TooltipPosition = 'left' | 'right' | 'center'
+type TemplateRefValue = HTMLElement | { $el?: HTMLElement } | null | undefined
+
+export function useChartTooltipPosition(
+  chartRef: MaybeRefOrGetter<TemplateRefValue>,
+): ComputedRef<TooltipPosition> {
+  const target = computed<HTMLElement | null>(() => {
+    const value = toValue(chartRef)
+    if (!value) return null
+    if (value instanceof HTMLElement) return value
+    return value.$el || null
+  })
+
+  const { elementX, elementWidth, isOutside } = useMouseInElement(target)
+
+  return computed<TooltipPosition>(() => {
+    if (isOutside.value || elementWidth.value === 0) return 'center'
+    return elementX.value > elementWidth.value / 2 ? 'left' : 'right'
+  })
+}

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "vite-plugin-pwa": "1.2.0",
     "vite-plus": "0.1.16",
     "vue": "3.5.34",
-    "vue-data-ui": "3.19.3",
+    "vue-data-ui": "3.19.4",
     "vue-router": "5.0.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,8 +254,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@6.0.2)
       vue-data-ui:
-        specifier: 3.19.3
-        version: 3.19.3(vue@3.5.34)
+        specifier: 3.19.4
+        version: 3.19.4(vue@3.5.34)
       vue-router:
         specifier: 5.0.4
         version: 5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.34)
@@ -11488,8 +11488,8 @@ packages:
   vue-component-type-helpers@3.2.8:
     resolution: {integrity: sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==}
 
-  vue-data-ui@3.19.3:
-    resolution: {integrity: sha512-cBBD6NnZnXMQ1ZDKNxhjPqxq7bxwzZL+WnNxM8O2lJ74384TzfbdMKiKk94QH6jy7B4odCl0MCt4VRgp1LDYCA==}
+  vue-data-ui@3.19.4:
+    resolution: {integrity: sha512-kp12dZnHWCwCczscGbmwec9rjtCFqYFDO5Abenpn2mKaZUUNWrMwnoCVwYtdu8LeBBhs/JQLX7Ty6OjlK05kag==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -24333,7 +24333,7 @@ snapshots:
 
   vue-component-type-helpers@3.2.8: {}
 
-  vue-data-ui@3.19.3(vue@3.5.34):
+  vue-data-ui@3.19.4(vue@3.5.34):
     dependencies:
       vue: 3.5.34(typescript@6.0.2)
 

--- a/test/unit/app/composables/use-chart-tooltip-position.spec.ts
+++ b/test/unit/app/composables/use-chart-tooltip-position.spec.ts
@@ -1,4 +1,4 @@
-import type { computed} from 'vue';
+import type { computed } from 'vue'
 import { ref, shallowRef } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useChartTooltipPosition } from '~/composables/useChartTooltipPosition'

--- a/test/unit/app/composables/use-chart-tooltip-position.spec.ts
+++ b/test/unit/app/composables/use-chart-tooltip-position.spec.ts
@@ -11,7 +11,9 @@ const elementX = ref(0)
 const elementWidth = ref(0)
 const isOutside = ref(true)
 
-class MockHTMLElement {}
+const MockHTMLElement = class {
+  public readonly nodeType = 1
+}
 
 vi.stubGlobal('HTMLElement', MockHTMLElement)
 

--- a/test/unit/app/composables/use-chart-tooltip-position.spec.ts
+++ b/test/unit/app/composables/use-chart-tooltip-position.spec.ts
@@ -1,5 +1,6 @@
-import { computed, ref, shallowRef, toValue } from 'vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { computed} from 'vue';
+import { ref, shallowRef } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useChartTooltipPosition } from '~/composables/useChartTooltipPosition'
 
 const mouseState = vi.hoisted(() => ({
@@ -13,12 +14,15 @@ const isOutside = ref(true)
 class MockHTMLElement {}
 
 vi.stubGlobal('HTMLElement', MockHTMLElement)
-vi.stubGlobal('computed', computed)
-vi.stubGlobal('toValue', toValue)
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 vi.mock('@vueuse/core', () => ({
   useMouseInElement: vi.fn(target => {
     mouseState.target = target
+
     return {
       elementX,
       elementWidth,
@@ -29,6 +33,7 @@ vi.mock('@vueuse/core', () => ({
 
 describe('useChartTooltipPosition', () => {
   beforeEach(() => {
+    vi.stubGlobal('HTMLElement', MockHTMLElement)
     elementX.value = 0
     elementWidth.value = 0
     isOutside.value = true
@@ -38,9 +43,11 @@ describe('useChartTooltipPosition', () => {
   it('returns center when the mouse is outside', () => {
     const element = new MockHTMLElement() as HTMLElement
     const position = useChartTooltipPosition(shallowRef(element))
+
     isOutside.value = true
     elementWidth.value = 100
     elementX.value = 75
+
     expect(position.value).toBe('center')
   })
 

--- a/test/unit/app/composables/use-chart-tooltip-position.spec.ts
+++ b/test/unit/app/composables/use-chart-tooltip-position.spec.ts
@@ -1,0 +1,113 @@
+import { computed, ref, shallowRef, toValue } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useChartTooltipPosition } from '~/composables/useChartTooltipPosition'
+
+const mouseState = vi.hoisted(() => ({
+  target: null as unknown,
+}))
+
+const elementX = ref(0)
+const elementWidth = ref(0)
+const isOutside = ref(true)
+
+class MockHTMLElement {}
+
+vi.stubGlobal('HTMLElement', MockHTMLElement)
+vi.stubGlobal('computed', computed)
+vi.stubGlobal('toValue', toValue)
+
+vi.mock('@vueuse/core', () => ({
+  useMouseInElement: vi.fn(target => {
+    mouseState.target = target
+    return {
+      elementX,
+      elementWidth,
+      isOutside,
+    }
+  }),
+}))
+
+describe('useChartTooltipPosition', () => {
+  beforeEach(() => {
+    elementX.value = 0
+    elementWidth.value = 0
+    isOutside.value = true
+    mouseState.target = null
+  })
+
+  it('returns center when the mouse is outside', () => {
+    const element = new MockHTMLElement() as HTMLElement
+    const position = useChartTooltipPosition(shallowRef(element))
+    isOutside.value = true
+    elementWidth.value = 100
+    elementX.value = 75
+    expect(position.value).toBe('center')
+  })
+
+  it('returns center when element width is 0', () => {
+    const element = new MockHTMLElement() as HTMLElement
+    const position = useChartTooltipPosition(shallowRef(element))
+    isOutside.value = false
+    elementWidth.value = 0
+    elementX.value = 75
+    expect(position.value).toBe('center')
+  })
+
+  it('returns left when the mouse is on the right half of the element', () => {
+    const element = new MockHTMLElement() as HTMLElement
+    const position = useChartTooltipPosition(shallowRef(element))
+    isOutside.value = false
+    elementWidth.value = 100
+    elementX.value = 51
+    expect(position.value).toBe('left')
+  })
+
+  it('returns right when the mouse is on the left half of the element', () => {
+    const element = new MockHTMLElement() as HTMLElement
+    const position = useChartTooltipPosition(shallowRef(element))
+    isOutside.value = false
+    elementWidth.value = 100
+    elementX.value = 49
+    expect(position.value).toBe('right')
+  })
+
+  it('returns right when the mouse is exactly at the center', () => {
+    const element = new MockHTMLElement() as HTMLElement
+    const position = useChartTooltipPosition(shallowRef(element))
+    isOutside.value = false
+    elementWidth.value = 100
+    elementX.value = 50
+    expect(position.value).toBe('right')
+  })
+
+  it('accepts a Vue component ref exposing $el', () => {
+    const element = new MockHTMLElement() as HTMLElement
+    const componentReference = shallowRef({ $el: element })
+    useChartTooltipPosition(componentReference)
+    expect((mouseState.target as ReturnType<typeof computed>).value).toBe(element)
+  })
+
+  it('returns null as target when ref value is null', () => {
+    useChartTooltipPosition(shallowRef(null))
+    expect((mouseState.target as ReturnType<typeof computed>).value).toBe(null)
+  })
+
+  it('returns null when component ref has no $el', () => {
+    const componentReference = shallowRef({})
+    useChartTooltipPosition(componentReference)
+    expect((mouseState.target as ReturnType<typeof computed>).value).toBe(null)
+  })
+
+  it('uses the HTMLElement directly as target', () => {
+    const element = new MockHTMLElement() as HTMLElement
+    useChartTooltipPosition(shallowRef(element))
+    expect((mouseState.target as ReturnType<typeof computed>).value).toBe(element)
+  })
+
+  it('uses the component $el as target', () => {
+    const element = new MockHTMLElement() as HTMLElement
+    const componentReference = shallowRef({ $el: element })
+    useChartTooltipPosition(componentReference)
+    expect((mouseState.target as ReturnType<typeof computed>).value).toBe(element)
+  })
+})


### PR DESCRIPTION
This small improvement moves chart tooltips to the left or right side of the client position to free up the view on line charts and allow a better vision of the selected datapoints.

The tooltip is moved to the left side when the client hovers the right side of the chart area, and vice-versa.

| Hovering on the left side | Hovering on the right side |
|---------------------------|--------------------------|
<img width="181" height="149" alt="image" src="https://github.com/user-attachments/assets/1e8f5d05-b065-4bb3-aebc-e97cd15b808f" />|<img width="181" height="149" alt="image" src="https://github.com/user-attachments/assets/3696db2f-92df-4950-a09c-12212b636ad5" />|
<img width="328" height="220" alt="image" src="https://github.com/user-attachments/assets/dc5e7d19-066d-4cf4-8b7e-6d3aa36531e3" />|<img width="328" height="220" alt="image" src="https://github.com/user-attachments/assets/9e4ff1ed-df86-49fa-b83a-84a7b62cae2d" />|

Only the line charts were updated with this feature:

- Downloads chart (in the modal of the package page, and the line chart of the compare page)
- Timeline

Other:
- update vue-data-ui to latest, with new offset features for tooltips
