### PR TITLE
fix: persist zoom state in line charts

### DIFF
--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -1589,6 +1589,7 @@ const chartConfig = computed<VueUiXyConfig>(() => {
         maxWidth: isMobile.value ? 350 : 500,
         highlightColor: colors.value.bgElevated,
         useResetSlot: true,
+        keepState: true,
         minimap: {
           show: true,
           lineColor: '#FAFAFA',


### PR DESCRIPTION
follow-up to #2688

This fixes the unwanted re-rendering of the zoom component in line charts for downloads when the chart config is dynamically updated.

Test:
- display a downloads chart (modal, or compare page)
- use the zoom
- hover the chart: zoom does not reset
