### PR TITLE
docs(ui): remove old storybook-v10-compat for @storybook-vue/nuxt

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -84,37 +84,6 @@ const config = {
       },
     })
 
-    // Bridge compatibility between Storybook v10 core and v9 @storybook-vue/nuxt
-    // v10 expects module federation globals that v9 doesn't provide
-    newConfig.plugins.push({
-      name: 'storybook-v10-compat',
-      transformIndexHtml: {
-        order: 'pre',
-        handler() {
-          return [
-            {
-              tag: 'script',
-              injectTo: 'head-prepend' as const,
-              children: [
-                '// Minimal shims for Storybook v10 module federation system',
-                '// These will be replaced when Storybook runtime loads',
-                'window.__STORYBOOK_MODULE_GLOBAL__ = { global: window };',
-                'window.__STORYBOOK_MODULE_CLIENT_LOGGER__ = {',
-                "  deprecate: console.warn.bind(console, '[deprecated]'),",
-                '  once: console.log.bind(console),',
-                '  logger: console',
-                '};',
-                'window.__STORYBOOK_MODULE_CHANNELS__ = {',
-                '  Channel: class { on() {} off() {} emit() {} once() {} },',
-                '  createBrowserChannel: () => new window.__STORYBOOK_MODULE_CHANNELS__.Channel()',
-                '};',
-              ].join('\n'),
-            },
-          ]
-        },
-      },
-    })
-
     newConfig.plugins.push({
       name: 'ignore-internals',
       transform(_, id) {


### PR DESCRIPTION
### 🔗 Linked issue
#2664 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

We recently updated to a version of `@storybook-vue/next` that is compatible with Storybook 10. So we should no longer need to rely on this compat work around in our storybook vite config.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Removes `storybook-v10-compat` which was providing shims for `@storybook-vue/next` which at the time had been configured for use with Storybook 9.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
