### PR TITLE
feat: restore brand link in footer and command palette

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -49,6 +49,10 @@ const footerSections: Array<{ label: string; links: FooterLink[] }> = [
         href: '/about',
       },
       {
+        name: t('footer.brand'),
+        href: '/brand',
+      },
+      {
         name: t('a11y.footer_title'),
         href: '/accessibility',
       },

--- a/app/composables/useCommandPaletteGlobalCommands.ts
+++ b/app/composables/useCommandPaletteGlobalCommands.ts
@@ -311,6 +311,16 @@ export function useCommandPaletteGlobalCommands() {
         to: { name: 'blog' },
       },
       {
+        id: 'brand',
+        group: 'npmx',
+        label: t('footer.brand'),
+        keywords: [t('footer.brand')],
+        iconClass: 'i-lucide:palette',
+        active: route.name === 'brand',
+        activeLabel: activeLabel(route.name === 'brand', t('command_palette.here')),
+        to: { name: 'brand' },
+      },
+      {
         id: 'privacy',
         group: 'npmx',
         label: t('privacy_policy.title'),


### PR DESCRIPTION
## Summary
- Add `brand` link back to the footer under the Resources section (next to About / Accessibility)
- Add a `brand` entry to the command palette (cmd+k) under the npmx group, with active-state when on `/brand`

Per discussion, the brand page link was dropped during the footer redesign. This restores it in both the footer and the cmd+k palette so people can discover it.

## Test plan
- [x] Footer shows "brand" link under Resources, navigating to `/brand`
- [ ] Cmd+K → "brand" navigates to `/brand` and shows the active "here" badge while on the page