### PR TITLE
fix: remove duplicate og:image meta tag on package pages

### DIFF
--- a/app/pages/package-code/[[org]]/[packageName]/v/[version]/[...filePath].vue
+++ b/app/pages/package-code/[[org]]/[packageName]/v/[version]/[...filePath].vue
@@ -324,15 +324,7 @@ defineOgImage(
     version: () => version.value,
     variant: 'code-tree',
   },
-  [
-    { key: 'og', alt: () => `Source code file tree for ${packageName.value}@${version.value}` },
-    {
-      key: 'whatsapp',
-      width: 800,
-      height: 800,
-      alt: () => `Source code file tree for ${packageName.value}@${version.value}`,
-    },
-  ],
+  { alt: () => `Source code file tree for ${packageName.value}@${version.value}` },
 )
 
 useCommandPaletteContextCommands(

--- a/app/pages/package-docs/[...path].vue
+++ b/app/pages/package-docs/[...path].vue
@@ -149,15 +149,7 @@ defineOgImage(
     version: () => resolvedVersion.value,
     variant: 'function-tree',
   },
-  [
-    { key: 'og', alt: () => `API documentation for ${packageName.value}` },
-    {
-      key: 'whatsapp',
-      width: 800,
-      height: 800,
-      alt: () => `API documentation for ${packageName.value}`,
-    },
-  ],
+  { alt: () => `API documentation for ${packageName.value}` },
 )
 
 const showLoading = computed(

--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -42,15 +42,7 @@ defineOgImage(
     version: () => requestedVersion.value,
     variant: 'download-chart',
   },
-  [
-    { key: 'og', alt: () => `npm package ${packageName.value} download chart and stats` },
-    {
-      key: 'whatsapp',
-      width: 800,
-      height: 800,
-      alt: () => `npm package ${packageName.value} download chart and stats`,
-    },
-  ],
+  { alt: () => `npm package ${packageName.value} download chart and stats` },
 )
 
 if (import.meta.server) {


### PR DESCRIPTION
## Summary
On `/package/...`, `/package-docs/...`, and `/package-code/...`, `defineOgImage` was registering a second variant with `key: 'whatsapp'`. In `nuxt-og-image`, `generateMeta` only special-cases `key === 'og'` and `key === 'twitter'` — any other key still emits a regular `<meta property="og:image">` tag. Result: two `og:image` tags in the head, which Discord (and other unfurlers) render as a side-by-side gallery.

This drops the `whatsapp` variants and keeps the single 1200×630 og entry, which works fine across Discord, X/Twitter, Slack, and WhatsApp.

Closes #2691

## Test plan
- [ ] `curl -s http://127.0.0.1:3000/package/vite | grep -oE 'property="og:image"[^>]*'` returns exactly one match
- [ ] Same for `/package-docs/<pkg>` and `/package-code/<pkg>/v/<ver>/<file>`
- [ ] Posting a package URL in Discord shows a single embed image