### PR TITLE
fix: skip emoji conversion inside code blocks

### DIFF
--- a/shared/utils/emoji.ts
+++ b/shared/utils/emoji.ts
@@ -1,5 +1,5 @@
 // copied from https://github.com/markdown-it/markdown-it-emoji/blob/master/lib/data/full.mjs
-const emojis = {
+const emojis: Record<string, string> = {
   '100': '💯',
   '1234': '🔢',
   'grinning': '😀',
@@ -1905,15 +1905,16 @@ const emojis = {
   'wales': '🏴󠁧󠁢󠁷󠁬󠁳󠁿',
 }
 
-const emojisKeysRegex = new RegExp(
-  Object.keys(emojis)
-    .map(key => `:${key}:`)
-    .join('|'),
-  'g',
-)
-export function convertToEmoji(text: string): string {
-  return text.replace(emojisKeysRegex, match => {
-    const key = match.slice(1, -1) as keyof typeof emojis
-    return emojis[key] || match
-  })
+export function convertToEmoji(html: string): string {  
+  return html.replace(
+    /(<code[\s>][\s\S]*?<\/code>|<pre[\s>][\s\S]*?<\/pre>)|(:[\w+-]+:)/gi,
+    (match, codeBlock: string | undefined, shortcode: string | undefined) => {
+      if (codeBlock) return codeBlock
+      if (shortcode) {
+        const key = shortcode.slice(1, -1)
+        return emojis[key] ?? shortcode 
+      }
+      return match
+    },
+  )
 }

--- a/shared/utils/emoji.ts
+++ b/shared/utils/emoji.ts
@@ -1905,14 +1905,14 @@ const emojis: Record<string, string> = {
   'wales': '🏴󠁧󠁢󠁷󠁬󠁳󠁿',
 }
 
-export function convertToEmoji(html: string): string {  
+export function convertToEmoji(html: string): string {
   return html.replace(
     /(<code[\s>][\s\S]*?<\/code>|<pre[\s>][\s\S]*?<\/pre>)|(:[\w+-]+:)/gi,
     (match, codeBlock: string | undefined, shortcode: string | undefined) => {
       if (codeBlock) return codeBlock
       if (shortcode) {
         const key = shortcode.slice(1, -1)
-        return emojis[key] ?? shortcode 
+        return emojis[key] ?? shortcode
       }
       return match
     },

--- a/test/unit/shared/utils/emoji.spec.ts
+++ b/test/unit/shared/utils/emoji.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { convertToEmoji } from '#shared/utils/emoji'
+
+describe('convertToEmoji', () => {
+  it('converts :1234: to emoji', () => {
+    expect(convertToEmoji('<p>:1234:</p>')).toBe('<p>🔢</p>')
+  })
+
+  it('leaves :1234: in codeblocks untouched', () => {
+    expect(convertToEmoji('<code>:1234:</code>')).toBe('<code>:1234:</code>')
+  })
+
+  it('converts :1234: to emoji outside of codeblock', () => {
+    expect(convertToEmoji('<p>:1234:</p><code>:1234:</code>')).toBe('<p>🔢</p><code>:1234:</code>')
+    expect(convertToEmoji('<code>:1234:</code><p>:1234:</p>')).toBe('<code>:1234:</code><p>🔢</p>')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Closes #2364
Closes #2373


### 🧭 Context

| | Screenshot |
| - | - |
| Before | <img width="953" height="164" alt="image" src="https://github.com/user-attachments/assets/864734c0-943a-44ea-a1c2-618b9f068f6e" /> | 
| After | <img width="958" height="158" alt="image" src="https://github.com/user-attachments/assets/198b770c-4cda-4081-9b75-b5a8e83f21be" /> |

### 📚 Description

Skips emoji conversion inside code blocks

Thank you to @ffedex (#2373) for the original PR
