### PR TITLE
fix: increase z-index for CopyToClipboardButton

### DIFF
--- a/app/components/CopyToClipboardButton.vue
+++ b/app/components/CopyToClipboardButton.vue
@@ -34,7 +34,7 @@ function handleClick() {
     <button
       type="button"
       @click="handleClick"
-      class="absolute z-20 inset-is-0 top-full inline-flex items-center gap-1 px-2 py-1 rounded border text-xs font-mono whitespace-nowrap transition-all duration-150 opacity-0 -translate-y-1 pointer-events-none group-hover:opacity-100 group-hover:translate-y-0 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:translate-y-0 focus-visible:pointer-events-auto"
+      class="absolute z-70 inset-is-0 top-full inline-flex items-center gap-1 px-2 py-1 rounded border text-xs font-mono whitespace-nowrap transition-all duration-150 opacity-0 -translate-y-1 pointer-events-none group-hover:opacity-100 group-hover:translate-y-0 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:translate-y-0 focus-visible:pointer-events-auto"
       :class="[
         $style.copyButton,
         copied ? ['text-accent', $style.copiedBg] : 'text-fg-muted bg-bg border-border',

--- a/app/components/CopyToClipboardButton.vue
+++ b/app/components/CopyToClipboardButton.vue
@@ -34,7 +34,7 @@ function handleClick() {
     <button
       type="button"
       @click="handleClick"
-      class="absolute z-70 inset-is-0 top-full inline-flex items-center gap-1 px-2 py-1 rounded border text-xs font-mono whitespace-nowrap transition-all duration-150 opacity-0 -translate-y-1 pointer-events-none group-hover:opacity-100 group-hover:translate-y-0 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:translate-y-0 focus-visible:pointer-events-auto"
+      class="absolute z-20 inset-is-0 top-full inline-flex items-center gap-1 px-2 py-1 rounded border text-xs font-mono whitespace-nowrap transition-all duration-150 opacity-0 -translate-y-1 pointer-events-none group-hover:opacity-100 group-hover:translate-y-0 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:translate-y-0 focus-visible:pointer-events-auto"
       :class="[
         $style.copyButton,
         copied ? ['text-accent', $style.copiedBg] : 'text-fg-muted bg-bg border-border',

--- a/test/e2e/interactions.spec.ts
+++ b/test/e2e/interactions.spec.ts
@@ -98,7 +98,7 @@ test.describe('Package Page', () => {
     const packageHeading = page.locator('h1').first()
     await expect(packageHeading).toBeVisible({ timeout: 15000 })
 
-// Hover the parent of the heading to trigger the button's visibility
+    // Hover the parent of the heading to trigger the button's visibility
     await packageHeading.locator('..').hover()
 
     const copyButton = page.locator('button[aria-label]').filter({ hasText: /copy/i }).first()
@@ -108,7 +108,7 @@ test.describe('Package Page', () => {
     if (!box) throw new Error('Copy button has no bounding box')
 
     // Define 5-point check (4 corners + center) for maximum coverage
-    const points: {    x: number;    y: number;  }[] = [
+    const points: { x: number; y: number }[] = [
       { x: box.x + 1, y: box.y + 1 }, // top-left
       { x: box.x + box.width - 1, y: box.y + 1 }, // top-right
       { x: box.x + box.width / 2, y: box.y + box.height / 2 }, // center

--- a/test/e2e/interactions.spec.ts
+++ b/test/e2e/interactions.spec.ts
@@ -101,7 +101,7 @@ test.describe('Package Page', () => {
     // Hover the parent of the heading to trigger the button's visibility
     await packageHeading.locator('..').hover()
 
-    const copyButton = page.locator('button[aria-label]').filter({ hasText: /copy/i }).first()
+    const copyButton = page.locator('button[aria-label="copy"]').filter({ hasText: /copy/i }).first()
     await expect(copyButton).toBeVisible({ timeout: 5000 })
 
     const box = await copyButton.boundingBox()
@@ -117,15 +117,16 @@ test.describe('Package Page', () => {
     ]
 
     for (const { x, y } of points) {
-      const isOnTop = await page.evaluate(
+      const result = await page.evaluate(
         ({ pointX, pointY }) => {
           const el = document.elementFromPoint(pointX, pointY)
           // Ensure the element at this point is the button or contained within it
-          return el?.closest('button[aria-label]') !== null
+          const isOnTop = el?.closest('button[aria-label="copy"]') !== null
+          return { isOnTop, tagName: el?.tagName, className: el?.className }
         },
         { pointX: x, pointY: y },
       )
-      expect(isOnTop, `Button is occluded at point (${x.toFixed(0)}, ${y.toFixed(0)})`).toBe(true)
+      expect(result.isOnTop, `Button is occluded at point (${x.toFixed(0)}, ${y.toFixed(0)}) by <${result.tagName} "${result.className}">`).toBe(true)
     }
   })
 })

--- a/test/e2e/interactions.spec.ts
+++ b/test/e2e/interactions.spec.ts
@@ -101,7 +101,10 @@ test.describe('Package Page', () => {
     // Hover the parent of the heading to trigger the button's visibility
     await packageHeading.locator('..').hover()
 
-    const copyButton = page.locator('button[aria-label="copy"]').filter({ hasText: /copy/i }).first()
+    const copyButton = page
+      .locator('button[aria-label="copy"]')
+      .filter({ hasText: /copy/i })
+      .first()
     await expect(copyButton).toBeVisible({ timeout: 5000 })
 
     const box = await copyButton.boundingBox()
@@ -126,7 +129,10 @@ test.describe('Package Page', () => {
         },
         { pointX: x, pointY: y },
       )
-      expect(result.isOnTop, `Button is occluded at point (${x.toFixed(0)}, ${y.toFixed(0)}) by <${result.tagName} "${result.className}">`).toBe(true)
+      expect(
+        result.isOnTop,
+        `Button is occluded at point (${x.toFixed(0)}, ${y.toFixed(0)}) by <${result.tagName} "${result.className}">`,
+      ).toBe(true)
     }
   })
 })

--- a/test/e2e/interactions.spec.ts
+++ b/test/e2e/interactions.spec.ts
@@ -91,6 +91,45 @@ test.describe('Compare Page', () => {
   })
 })
 
+test.describe('Package Page', () => {
+  test('CopyToClipboardButton is fully unoccluded', async ({ page, goto }) => {
+    await goto('/package/vue', { waitUntil: 'hydration' })
+
+    const packageHeading = page.locator('h1').first()
+    await expect(packageHeading).toBeVisible({ timeout: 15000 })
+
+// Hover the parent of the heading to trigger the button's visibility
+    await packageHeading.locator('..').hover()
+
+    const copyButton = page.locator('button[aria-label]').filter({ hasText: /copy/i }).first()
+    await expect(copyButton).toBeVisible({ timeout: 5000 })
+
+    const box = await copyButton.boundingBox()
+    if (!box) throw new Error('Copy button has no bounding box')
+
+    // Define 5-point check (4 corners + center) for maximum coverage
+    const points: {    x: number;    y: number;  }[] = [
+      { x: box.x + 1, y: box.y + 1 }, // top-left
+      { x: box.x + box.width - 1, y: box.y + 1 }, // top-right
+      { x: box.x + box.width / 2, y: box.y + box.height / 2 }, // center
+      { x: box.x + 1, y: box.y + box.height - 1 }, // bottom-left
+      { x: box.x + box.width - 1, y: box.y + box.height - 1 }, // bottom-right
+    ]
+
+    for (const { x, y } of points) {
+      const isOnTop = await page.evaluate(
+        ({ x, y }) => {
+          const el = document.elementFromPoint(x, y)
+          // Ensure the element at this point is the button or contained within it
+          return el?.closest('button[aria-label]') !== null
+        },
+        { x, y },
+      )
+      expect(isOnTop, `Button is occluded at point (${x.toFixed(0)}, ${y.toFixed(0)})`).toBe(true)
+    }
+  })
+})
+
 test.describe('Search Pages', () => {
   test('/search?q=vue → keyboard navigation (arrow keys + enter)', async ({ page, goto }) => {
     await goto('/search?q=vue', { waitUntil: 'hydration' })

--- a/test/e2e/interactions.spec.ts
+++ b/test/e2e/interactions.spec.ts
@@ -96,7 +96,7 @@ test.describe('Package Page', () => {
     await goto('/package/vue', { waitUntil: 'hydration' })
 
     const packageHeading = page.locator('h1').first()
-    await expect(packageHeading).toBeVisible({ timeout: 15000 })
+    await expect(packageHeading).toBeVisible({ timeout: 10000 })
 
     // Hover the parent of the heading to trigger the button's visibility
     await packageHeading.locator('..').hover()

--- a/test/e2e/interactions.spec.ts
+++ b/test/e2e/interactions.spec.ts
@@ -118,12 +118,12 @@ test.describe('Package Page', () => {
 
     for (const { x, y } of points) {
       const isOnTop = await page.evaluate(
-        ({ x, y }) => {
-          const el = document.elementFromPoint(x, y)
+        ({ pointX, pointY }) => {
+          const el = document.elementFromPoint(pointX, pointY)
           // Ensure the element at this point is the button or contained within it
           return el?.closest('button[aria-label]') !== null
         },
-        { x, y },
+        { pointX: x, pointY: y },
       )
       expect(isOnTop, `Button is occluded at point (${x.toFixed(0)}, ${y.toFixed(0)})`).toBe(true)
     }


### PR DESCRIPTION
### 🔗 Linked issue

Closes #2700


### 🧭 Context

| Before | After |
| ------ | ----- |
| <img width="199" height="108" alt="image" src="https://github.com/user-attachments/assets/bade836c-166d-4c29-8986-f1700e369b3d" /> | <img width="194" height="106" alt="image" src="https://github.com/user-attachments/assets/9a3e8e27-550b-42b6-a78f-d587b420dfce" /> |






### 📚 Description

Fixed `CopyToClipboardButton`'s `z-index` 

