### PR TITLE
ci: replace deprecated codecov action, improve setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,9 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
+          disable_search: true
           files: test-report.junit.xml
+          flags: unit
           report_type: test_results
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -90,6 +92,7 @@ jobs:
         with:
           disable_search: true
           files: coverage/clover.xml
+          flags: unit
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -117,7 +120,9 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
+          disable_search: true
           files: test-report.junit.xml
+          flags: component
           report_type: test_results
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -128,6 +133,7 @@ jobs:
         with:
           disable_search: true
           files: coverage/clover.xml
+          flags: component
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -157,6 +163,18 @@ jobs:
 
       - name: 🖥️ Test project (browser)
         run: vp run test:browser:prebuilt
+
+      - name: ⬆︎ Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        with:
+          disable_search: true
+          files: test-report.junit.xml
+          flags: browser
+          report_type: test_results
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      # TODO(serhalp): Upload browser *coverage* report once we've instrumented the prebuilt bundle
 
   a11y:
     name: ♿ Accessibility audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,12 @@ jobs:
 
       - name: ⬆︎ Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          files: test-report.junit.xml
+          report_type: test_results
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test:
     name: 🧪 Component tests
@@ -101,9 +104,11 @@ jobs:
       - name: 🧪 Component tests
         run: vp test --project nuxt --coverage --reporter=default --reporter=junit --outputFile=test-report.junit.xml
 
-      - name: ⬆︎ Upload coverage reports to Codecov
+      - name: ⬆︎ Upload test results to Codecov
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
+          files: test-report.junit.xml
           report_type: test_results
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,15 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: ⬆︎ Upload coverage reports to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        with:
+          disable_search: true
+          files: coverage/clover.xml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   test:
     name: 🧪 Component tests
     runs-on: ubuntu-24.04-arm
@@ -114,7 +123,11 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: ⬆︎ Upload coverage reports to Codecov
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        with:
+          disable_search: true
+          files: coverage/clover.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,12 @@ export default defineConfig<ConfigOptions>({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  reporter: 'html',
+  reporter: process.env.CI
+    ? [
+        ['html'],
+        ['junit', { outputFile: 'test-report.junit.xml' }],
+      ]
+    : 'html',
   timeout: 120_000,
   webServer: {
     command: 'pnpm start:playwright:webserver',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,10 +11,7 @@ export default defineConfig<ConfigOptions>({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI
-    ? [
-        ['html'],
-        ['junit', { outputFile: 'test-report.junit.xml' }],
-      ]
+    ? [['html'], ['junit', { outputFile: 'test-report.junit.xml' }]]
     : 'html',
   timeout: 120_000,
   webServer: {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

I'm seeing two deprecation warnings in CI:

```
This action is being deprecated in favor of 'codecov-action'.
      Please update CI accordingly to use 'codecov-action@v5' with
      'report_type: test_results'.
      The 'codecov-action' should and can be run at least once for
      coverage and once for test results.
```

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected:
codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3.
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
Node.js 20 will be removed from the runner on September 16th, 2026.
Please check if updated versions of these actions are available that support Node.js 24.
To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file.
Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

### 📚 Description

- Replace the deprecated action with the recommended one
- Be more explicit about upload test results vs. coverage reports
- Add missing exclusion for cancelled runs
- Actually upload unit test report
- Add Codecov "tags" for unit, component, browser

Basically:

| Job | Before | After |
|---|---|---|
| Unit | Test results only | Test results + coverage; `unit` flag |
| Component | Test results + coverage | Same; `component` flag |
| Browser | None | Test results; `browser` flag |
| Lighthouse a11y | LHCI only | Unchanged |