### PR TITLE
fix(i18n): footer translations should actually be applied

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -36,7 +36,7 @@ const socialLinks = computed(() => [
   },
 ])
 
-const footerSections: Array<{ label: string; links: FooterLink[] }> = [
+const footerSections = computed<Array<{ label: string; links: FooterLink[] }>>(() => [
   {
     label: t('footer.resources'),
     links: [
@@ -93,7 +93,7 @@ const footerSections: Array<{ label: string; links: FooterLink[] }> = [
       },
     ],
   },
-]
+])
 </script>
 
 <template>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
resolves #2710

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

make the `AppFooter` component display the correct i18n value

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<img width="1242" height="301" alt="image" src="https://github.com/user-attachments/assets/3b53b602-b928-45a3-a0a4-ff85189e567c" />
After modification, the correct translation value of the current i18n can be displayed correctly.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
