### PR TITLE
fix: parse hyphenated language names for code examples on package docs

### DIFF
--- a/server/utils/docs/render.ts
+++ b/server/utils/docs/render.ts
@@ -191,9 +191,9 @@ async function renderJsDocTags(tags: JsDocTag[], symbolLookup: SymbolLookup): Pr
     : null
   const examplePromises = examples.map(async example => {
     if (!example.doc) return ''
-    const langMatch = example.doc.match(/```[ \t]*([^` \t\r\n]*)/)
+    const langMatch = example.doc.match(/```[ \t]*([-\w]+)?/)
     const lang = langMatch?.[1] || 'typescript'
-    const code = example.doc.replace(/```[ \t]*[^` \t\r\n]*[ \t]*(?:\r\n|\r|\n)?/g, '').trim()
+    const code = example.doc.replace(/```[ \t]*[-\w]*[ \t]*(?:\r\n|\r|\n)?/g, '').trim()
     return highlightCodeBlock(code, lang)
   })
 

--- a/server/utils/docs/render.ts
+++ b/server/utils/docs/render.ts
@@ -191,9 +191,9 @@ async function renderJsDocTags(tags: JsDocTag[], symbolLookup: SymbolLookup): Pr
     : null
   const examplePromises = examples.map(async example => {
     if (!example.doc) return ''
-    const langMatch = example.doc.match(/```(\w+)?/)
+    const langMatch = example.doc.match(/```[ \t]*([^` \t\r\n]*)/)
     const lang = langMatch?.[1] || 'typescript'
-    const code = example.doc.replace(/```\w*\n?/g, '').trim()
+    const code = example.doc.replace(/```[ \t]*[^` \t\r\n]*[ \t]*(?:\r\n|\r|\n)?/g, '').trim()
     return highlightCodeBlock(code, lang)
   })
 

--- a/test/unit/server/utils/docs/render.spec.ts
+++ b/test/unit/server/utils/docs/render.spec.ts
@@ -211,6 +211,7 @@ describe('renderDocNodes examples', () => {
     expect(html).toContain('<h4>Example</h4>')
     expect(html).toContain('shiki')
     expect(html).toContain('greeting')
+    expect(html).not.toMatch(/(^|[>\s])-ts([<\s]|$)/)
     expect(html).not.toContain('-ts')
     expect(html).not.toContain('```')
   })

--- a/test/unit/server/utils/docs/render.spec.ts
+++ b/test/unit/server/utils/docs/render.spec.ts
@@ -21,10 +21,11 @@ function createClassSymbol(classDef: DenoDocNode['classDef']): MergedSymbol {
   }
 }
 
-function createFunctionSymbol(name: string): MergedSymbol {
+function createFunctionSymbol(name: string, jsDoc?: DenoDocNode['jsDoc']): MergedSymbol {
   const node: DenoDocNode = {
     name,
     kind: 'function',
+    jsDoc,
     functionDef: {
       params: [],
       returnType: { repr: 'void', kind: 'keyword', keyword: 'void' },
@@ -34,6 +35,7 @@ function createFunctionSymbol(name: string): MergedSymbol {
   return {
     name,
     kind: 'function',
+    jsDoc,
     nodes: [node],
   }
 }
@@ -190,5 +192,26 @@ describe('renderDocNodes ordering', () => {
     expect(alphaIndex).toBeGreaterThanOrEqual(0)
     expect(betaIndex).toBeGreaterThanOrEqual(0)
     expect(alphaIndex).toBeLessThan(betaIndex)
+  })
+})
+
+describe('renderDocNodes examples', () => {
+  it('handles hyphenated fenced code languages in @example tags', async () => {
+    const symbol = createFunctionSymbol('renderTemplate', {
+      tags: [
+        {
+          kind: 'example',
+          doc: '```glimmer-ts\nconst greeting = <template>Hello</template>\n```',
+        },
+      ],
+    })
+
+    const html = await renderDocNodes([symbol], new Map())
+
+    expect(html).toContain('<h4>Example</h4>')
+    expect(html).toContain('shiki')
+    expect(html).toContain('greeting')
+    expect(html).not.toContain('-ts')
+    expect(html).not.toContain('```')
   })
 })


### PR DESCRIPTION
## Summary
- parse `@example` fence languages up to whitespace/backticks so hyphenated Shiki language ids are preserved
- add a regression test for a `glimmer-ts` fenced example

## Testing
- `STORYBOOK=true pnpm vp test --project unit test/unit/server/utils/docs/render.spec.ts`
- `pnpm vp lint server/utils/docs/render.ts test/unit/server/utils/docs/render.spec.ts`
- `pnpm vp fmt --check server/utils/docs/render.ts test/unit/server/utils/docs/render.spec.ts`

Fixes #2437