### PR TITLE
fix: update logic for og image

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -128,9 +128,17 @@ if (import.meta.client) {
   }
 }
 
-// title and description will be inferred
-// this will be overridden by upstream pages that use different templates
-defineOgImage('Page.takumi', {}, { alt: 'npmx — a fast, modern browser for the npm registry' })
+const isBlogPostRoute = computed(() => {
+  return route.path.startsWith('/blog/') && route.path !== '/blog/'
+})
+
+// This is a priority bug that when we set og:image at the component level via useSeoMeta,
+// it is ignored and the image from app.vue is written over it.
+if (!isBlogPostRoute.value) {
+  // title and description will be inferred
+  // this will be overridden by upstream pages that use different templates
+  defineOgImage('Page.takumi', {}, { alt: 'npmx — a fast, modern browser for the npm registry' })
+}
 </script>
 
 <template>


### PR DESCRIPTION
### 🧭 Context

It seems that one of the updates broke the image definition priority. Because of this, even if we defined og:image at the page level, defineOgImage from the application level was used on top of it.

### 📚 Description

Disabled image additions at the application level for blog pages (since blog pages always add an image)

Before:

<img width="1873" height="347" alt="image" src="https://github.com/user-attachments/assets/696199dc-d1b6-4505-80b8-59dfa7b08e91" />

After:

<img width="1871" height="324" alt="image" src="https://github.com/user-attachments/assets/8cfbcedb-dbf6-4ccd-8b4e-6fca34032ed9" />

<img width="1830" height="327" alt="image" src="https://github.com/user-attachments/assets/365c1ff1-c2fb-44ef-817d-77275b45bdb3" />
