### PR TITLE
fix: improve proxy for images without content-type

### DIFF
--- a/server/api/registry/image-proxy/index.get.ts
+++ b/server/api/registry/image-proxy/index.get.ts
@@ -156,8 +156,14 @@ export default defineEventHandler(async event => {
 
     const contentType = response.headers.get('content-type') || 'application/octet-stream'
 
+    const imagePathname = new URL(url).pathname
+    // Since some services don't specify the content-type, leaving it up to the user, we additionally check the extension.
+    // This doesn't compromise security, as both the extension and the content-type allow the user to forge the value.
+    const isImageLike =
+      contentType === 'application/octet-stream' &&
+      ['.png', '.jpg', '.jpeg', '.gif'].some(ext => imagePathname.endsWith(ext))
     // Allow raster/vector image content types (we don't inject external content into DOM, so SVG is allowed too)
-    if (!contentType.startsWith('image/')) {
+    if (!contentType.startsWith('image/') && !isImageLike) {
       await response.body?.cancel()
       throw createError({
         statusCode: 400,

--- a/server/api/registry/image-proxy/index.get.ts
+++ b/server/api/registry/image-proxy/index.get.ts
@@ -154,16 +154,17 @@ export default defineEventHandler(async event => {
       })
     }
 
-    const contentType = response.headers.get('content-type') || 'application/octet-stream'
+    const rawContentType = response.headers.get('content-type') || 'application/octet-stream'
+    const contentType = rawContentType.split(';', 1)[0]?.trim().toLowerCase()
 
-    const imagePathname = new URL(url).pathname
+    const imagePathname = new URL(url).pathname.toLowerCase()
     // Since some services don't specify the content-type, leaving it up to the user, we additionally check the extension.
     // This doesn't compromise security, as both the extension and the content-type allow the user to forge the value.
     const isImageLike =
       contentType === 'application/octet-stream' &&
       ['.png', '.jpg', '.jpeg', '.gif'].some(ext => imagePathname.endsWith(ext))
     // Allow raster/vector image content types (we don't inject external content into DOM, so SVG is allowed too)
-    if (!contentType.startsWith('image/') && !isImageLike) {
+    if (!contentType?.startsWith('image/') && !isImageLike) {
       await response.body?.cancel()
       throw createError({
         statusCode: 400,


### PR DESCRIPTION
### 🧭 Context

Some services don't specify the content-type (or uses application/octet-stream), leaving it up to the user. 
In these cases, we immediately return an error, although even standard providers such as github do this (example package - https://npmx.dev/package/ag-grid-react)

### 📚 Description

Updated the logic to additionally check the extension. This doesn't compromise security, as both the extension and the content-type allow the user to forge the value.

_In the example package above, one gif still doesn't work because it's above our limit (and we should leave it that way), but the other 3 works_