### PR TITLE
fix: show 404 for missing package versions

### DIFF
--- a/app/composables/npm/useResolvedVersion.ts
+++ b/app/composables/npm/useResolvedVersion.ts
@@ -13,6 +13,11 @@ export function useResolvedVersion(
         ? `https://npm.antfu.dev/${name}@${version}`
         : `https://npm.antfu.dev/${name}`
       const data = await $fetch<ResolvedPackageVersion>(url)
+
+      if (data.version === '0.0.0') {
+        throw createError({ statusCode: 404, message: 'Package not found' })
+      }
+
       return data.version
     },
     { default: () => undefined },


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1602

### 🧭 Context

Missing packages can resolve through fast-npm-meta as version `0.0.0`, which lets the package page continue rendering with placeholder data instead of reliably surfacing the not-found state.

### 📚 Description

This change treats the `0.0.0` fallback from the resolved-version request as a not-found result and raises a 404 immediately. That keeps missing package URLs, including uncached ones with cache-busting query strings, on the normal 404 error page instead of leaving the user with a blank package page.
