### PR TITLE
chore: bump vue-data-ui from 3.19.6 to 3.19.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "0.1.20",
     "vue": "3.5.34",
-    "vue-data-ui": "3.19.6",
+    "vue-data-ui": "3.19.7",
     "vue-router": "5.0.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,8 +254,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@6.0.2)
       vue-data-ui:
-        specifier: 3.19.6
-        version: 3.19.6(vue@3.5.34)
+        specifier: 3.19.7
+        version: 3.19.7(vue@3.5.34)
       vue-router:
         specifier: 5.0.4
         version: 5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.34)
@@ -11362,8 +11362,11 @@ packages:
   vue-component-type-helpers@3.2.8:
     resolution: {integrity: sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==}
 
-  vue-data-ui@3.19.6:
-    resolution: {integrity: sha512-b2S9RjAqWSdPmdSb0TjBNXkto1xfw5UwVZmsuQsTV8qOatAhsGnDnoMIvgcfw2kzJ54IRSZauoFOQ9g9V/bdbg==}
+  vue-component-type-helpers@3.2.9:
+    resolution: {integrity: sha512-S3BiWYaLSzHxTpln665ELSrMR9UYmrIDUmhik7nVZxmJjTKL2/a+ew1hvGxksKelivm0ujjWfG1fYOiU/2e8rA==}
+
+  vue-data-ui@3.19.7:
+    resolution: {integrity: sha512-4ZpYg5SDpo11EyV59jvwa/cAFe6Oiz+LtwcAC60LTBANZO6x8F1GLo0i22TuZo3kKOxXN5TQFbVfwIQhg62i5w==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -16194,7 +16197,7 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
       type-fest: 2.19.0
       vue: 3.5.34(typescript@6.0.2)
-      vue-component-type-helpers: 3.2.8
+      vue-component-type-helpers: 3.2.9
 
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
@@ -24135,7 +24138,9 @@ snapshots:
 
   vue-component-type-helpers@3.2.8: {}
 
-  vue-data-ui@3.19.6(vue@3.5.34):
+  vue-component-type-helpers@3.2.9: {}
+
+  vue-data-ui@3.19.7(vue@3.5.34):
     dependencies:
       vue: 3.5.34(typescript@6.0.2)
 


### PR DESCRIPTION
Bump vue-data-ui to `3.19.7` ([release notes](https://github.com/graphieros/vue-data-ui/releases/tag/v3.19.7))

- fixes an issue in the line chart (visible in the compare page), when series are stacked using the chart menu to display series on top of each other, the state of the chart was unstable and any internal update was setting the layout to non-stacked, with undesirable individual scale effect.

- improves the layout of y-axis labels of the line chart (compare page) in stack mode, by swapping the position of series names and scale labels:

| Before | After |
|-|-|
|<img width="400"  alt="image" src="https://github.com/user-attachments/assets/521d2e11-f303-470a-ba84-02b745f207f8" />|<img width="400" alt="image" src="https://github.com/user-attachments/assets/68efe36c-f24c-4215-af90-53e9b9b85cc4" />| 

- No impacts on other instances of line charts