### PR TITLE
fix(i18n): update Japanese translations

### DIFF
--- a/i18n/locales/ja-JP.json
+++ b/i18n/locales/ja-JP.json
@@ -1671,7 +1671,7 @@
   "action_bar": {
     "title": "アクションバー",
     "selection": "0 選択済み | 1 選択済み | {count} 選択済み",
-    "shortcut": "\"\"\"{key}\"\" を押してアクションにフォーカス\"",
+    "shortcut": "「{key}」を押してアクションにフォーカス",
     "button_close_aria_label": "アクションバーを閉じる"
   },
   "logo_menu": {

--- a/i18n/locales/ja-JP.json
+++ b/i18n/locales/ja-JP.json
@@ -19,7 +19,11 @@
     "social": "ソーシャル",
     "chat": "チャット",
     "builders_chat": "ビルダー",
-    "keyboard_shortcuts": "キーボードショートカット"
+    "keyboard_shortcuts": "キーボードショートカット",
+    "brand": "brand",
+    "resources": "Resources",
+    "features": "Features",
+    "other": "Other"
   },
   "shortcuts": {
     "section": {
@@ -27,6 +31,9 @@
       "search": "検索",
       "package": "パッケージ"
     },
+    "ctrl_key": "Ctrl",
+    "command_palette": "Open command palette",
+    "command_palette_description": "Use the command palette to jump between pages, package views, settings, and external links without leaving the keyboard. On macOS, press ⌘K. On Windows and Linux, press {ctrlKey}+K.",
     "focus_search": "検索にフォーカス",
     "show_kbd_hints": "キーボードヒントをハイライト",
     "settings": "設定を開く",
@@ -36,7 +43,10 @@
     "go_to_result": "結果に移動",
     "open_code_view": "コードビューを開く",
     "open_docs": "ドキュメントを開く",
-    "disable_shortcuts": "{settings} でキーボードショートカットを無効化できます。"
+    "disable_shortcuts": "{settings} でキーボードショートカットを無効化できます。",
+    "open_main": "Open main information",
+    "open_diff": "Open version differences",
+    "open_timeline": "Open timeline"
   },
   "search": {
     "label": "npmパッケージを検索",
@@ -73,6 +83,114 @@
     "instant_search_turn_off": "オフにする",
     "instant_search_advisory": "{label} {state} — {action}"
   },
+  "command_palette": {
+    "title": "command palette",
+    "quick_actions": "jump to...",
+    "subtitle": "navigate across npmx and switch settings quickly",
+    "subtitle_languages": "choose a language or help improve translations",
+    "instructions": "Type to filter commands. Use the arrow keys to move through results and Enter to run a command.",
+    "input_label": "Command palette search",
+    "results_label": "Command results",
+    "placeholder": "type a command...",
+    "back": "Back",
+    "empty": "No matching commands",
+    "empty_search_hint": "Press Enter to search for \"{query}\".",
+    "current": "current",
+    "here": "you are here",
+    "connected": "connected",
+    "state": {
+      "on": "on",
+      "off": "off"
+    },
+    "groups": {
+      "actions": "Actions",
+      "help": "Help",
+      "language": "Language",
+      "connections": "Connections",
+      "navigation": "Navigation",
+      "links": "Links",
+      "npmx": "npmx",
+      "package": "Package",
+      "package_with_name": "Package ({name})",
+      "versions": "Versions",
+      "versions_with_name": "Versions of {name}"
+    },
+    "actions": {
+      "search": "Search",
+      "search_for": "Search for \"{query}\"",
+      "keyboard_shortcuts": "Keyboard shortcuts",
+      "help_translate": "Help translate"
+    },
+    "connections": {
+      "npm_connect": "Connect to npm CLI",
+      "npm_connected": "npm CLI (~{username})",
+      "npm_disconnect": "Disconnect npm CLI",
+      "atmosphere_connect": "Connect to Atmosphere",
+      "atmosphere_connected": "atmosphere ({'@'}{handle})",
+      "atmosphere_disconnect": "Disconnect Atmosphere"
+    },
+    "navigation": {
+      "home": "home",
+      "packages": "packages (~{username})",
+      "orgs": "orgs (~{username})",
+      "profile": "profile ({'@'}{handle})"
+    },
+    "links": {
+      "external": "External link"
+    },
+    "package_links": {
+      "stars": "Repository stars",
+      "forks": "Repository forks"
+    },
+    "theme": {
+      "system": "Use system theme",
+      "light": "Use light theme",
+      "dark": "Use dark theme"
+    },
+    "package": {
+      "main": "Package page",
+      "docs": "Docs",
+      "code": "Code",
+      "diff": "Diff",
+      "compare": "Compare this package",
+      "download": "Download tarball",
+      "changelog": "Changelog"
+    },
+    "package_actions": {
+      "copy_run": "Copy run command"
+    },
+    "code": {
+      "copy_file": "Copy file contents"
+    },
+    "diff": {
+      "merge_modified_lines": "Merge modified lines",
+      "word_wrap": "Word wrap"
+    },
+    "version": {
+      "label": "{version}"
+    },
+    "status": {
+      "available_in_context": "{context}. No commands available | {context}. 1 command available | {context}. {count} commands available",
+      "matching_in_context": "{context}. No matching commands | {context}. 1 matching command | {context}. {count} matching commands",
+      "no_matches_search_in_context": "{context}. No matching commands. Press Enter to search for \"{query}\"."
+    },
+    "announcements": {
+      "language_changed": "Language set to {language}.",
+      "relative_dates_on": "Relative dates on.",
+      "relative_dates_off": "Relative dates off.",
+      "theme_changed": "Theme set to {theme}.",
+      "accent_color_changed": "Accent color set to {color}.",
+      "background_theme_changed": "Background shade set to {theme}.",
+      "download_started": "Downloading {package} tarball.",
+      "copied_to_clipboard": "Copied to clipboard.",
+      "npm_disconnected": "npm CLI disconnected.",
+      "atmosphere_disconnected": "Atmosphere disconnected.",
+      "facets_all_selected": "All facets selected.",
+      "facets_all_deselected": "All facets deselected.",
+      "view_switched": "Switched to {view} view.",
+      "setting_toggled": "{setting} {state}."
+    }
+  },
   "nav": {
     "main_navigation": "メイン",
     "popular_packages": "人気のパッケージ",
@@ -94,6 +212,7 @@
     },
     "draft_badge": "下書き",
     "draft_banner": "これは未公開の下書きです。内容が不完全であったり、不正確な情報が含まれている可能性があります。",
+    "no_posts": "No posts found.",
     "atproto": {
       "view_on_bluesky": "Blueskyで表示",
       "reply_on_bluesky": "Blueskyでリプライ",
@@ -136,22 +255,40 @@
     "include_types_description": "型定義のないパッケージのインストールコマンドに{'@'}typesパッケージを追加します",
     "hide_platform_packages": "検索でプラットフォーム固有のパッケージを非表示",
     "hide_platform_packages_description": "検索結果から{'@'}esbuild/linux-x64のようなネイティブバイナリパッケージを非表示にします",
+    "enable_graph_pulse_loop": "Enable looping of pulse effect on mini graph",
+    "enable_graph_pulse_loop_description": "Activate a continuous pulse animation on the weekly download graph. This animation may be distracting for some users.",
     "theme": "テーマ",
     "theme_light": "ライト",
     "theme_dark": "ダーク",
     "theme_system": "システム",
     "language": "言語",
     "help_translate": "npmxの翻訳に協力する",
+    "translation_status": "Check global translation status",
     "accent_colors": {
-      "label": "アクセントカラー"
+      "label": "アクセントカラー",
+      "neutral": "Neutral",
+      "sky": "Sky",
+      "coral": "Coral",
+      "amber": "Amber",
+      "emerald": "Emerald",
+      "violet": "Violet",
+      "magenta": "Magenta"
     },
     "clear_accent": "アクセントカラーをクリア",
     "translation_progress": "翻訳の進捗状況",
     "background_themes": {
-      "label": "背景シェード"
+      "label": "背景シェード",
+      "neutral": "Neutral",
+      "stone": "Stone",
+      "zinc": "Zinc",
+      "slate": "Slate",
+      "black": "Black"
     },
     "keyboard_shortcuts_enabled": "キーボードショートカットを有効化",
-    "keyboard_shortcuts_enabled_description": "ブラウザやシステムのショートカットと競合する場合、キーボードショートカットを無効化できます"
+    "keyboard_shortcuts_enabled_description": "ブラウザやシステムのショートカットと競合する場合、キーボードショートカットを無効化できます",
+    "enable_code_ligatures": "Enable ligatures in code",
+    "enable_changelog_autoscroll": "Auto scroll to requested version",
+    "enable_changelog_autoscroll_description": "Auto scroll to or close to the requested version at package changelog"
   },
   "i18n": {
     "missing_keys": "{count} 件の未翻訳項目",
@@ -183,6 +320,7 @@
     "warnings": "警告:",
     "go_back_home": "ホームへ戻る",
     "per_week": "/ 週",
+    "per_week_short": "/wk",
     "vanity_downloads_hint": "バニティ番号: パッケージが表示されていません|バニティ番号: 表示されているパッケージの数値|バニティ番号: 表示されている {count} 個のパッケージの合計",
     "sort": {
       "name": "名前",
@@ -205,9 +343,14 @@
       "gitea": "Giteaで表示",
       "gitee": "Giteeで表示",
       "radicle": "Radicleで表示",
+      "socket_dev": "View on socket.dev",
       "sourcehut": "SourceHutで表示",
       "tangled": "Tangledで表示"
-    }
+    },
+    "collapse": "Collapse",
+    "collapse_with_name": "Collapse {name}",
+    "expand": "Expand",
+    "expand_with_name": "Expand {name}"
   },
   "profile": {
     "display_name": "表示名",
@@ -245,9 +388,18 @@
       "size": "インストールサイズが {percent} 増加（{size} 増）",
       "deps": "依存関係が {count} 件増加"
     },
+    "size_decrease": {
+      "title_size": "Package size decreased since v{version}!",
+      "title_deps": "Dependency count decreased since v{version}!",
+      "title_both": "Package size and dependency count decreased since v{version}!",
+      "size": "Install size reduced by {percent} ({size} smaller)",
+      "deps": "{count} fewer dependencies"
+    },
     "replacement": {
       "title": "この依存関係は不要な可能性があります。",
+      "example": "Example:",
       "native": "これは Node {nodeVersion} 以降で利用可能な {replacement} で置き換え可能です。",
+      "native_no_version": "This package can be replaced with {replacement}.",
       "simple": "{community} はこのパッケージを冗長としてフラグを立てており、次のアドバイスがあります: {replacement}",
       "documented": "{community} により、このパッケージにはよりパフォーマンスの高い代替手段があることが報告されています。",
       "none": "このパッケージは不要になったとフラグが立てられています。その機能はすべてのエンジンでネイティブに利用できる可能性があります。",
@@ -285,9 +437,11 @@
         "refs": "{count} 個の参照",
         "assets": "{count} 個のアセット"
       },
-      "view_source": "ソースを表示"
+      "view_source": "ソースを表示",
+      "skills_cli": "skills CLI"
     },
     "links": {
+      "main": "main",
       "repo": "リポジトリ",
       "homepage": "ホームページ",
       "issues": "issues",
@@ -295,15 +449,28 @@
       "code": "コード",
       "docs": "ドキュメント",
       "fund": "資金援助",
-      "compare": "比較"
+      "compare": "比較",
+      "timeline": "timeline",
+      "compare_this_package": "compare this package",
+      "changelog": "changelog"
     },
     "likes": {
       "like": "このパッケージをいいねする",
-      "unlike": "このパッケージのいいねを解除する"
+      "unlike": "このパッケージのいいねを解除する",
+      "top_rank_tooltip": "This is among the top 10 most liked packages on npmx! (#{rank})",
+      "top_rank_label": "#{rank}",
+      "top_rank_link_label": "View likes leaderboard. This package is ranked #{rank}."
     },
     "docs": {
+      "contents": "Contents",
+      "default_not_available": "Docs are not available for this version.",
       "not_available": "ドキュメントは利用できません",
-      "not_available_detail": "このバージョンのドキュメントを生成できませんでした。"
+      "not_available_detail": "このバージョンのドキュメントを生成できませんでした。",
+      "page_title": "API Docs - npmx",
+      "page_title_name": "{name} docs - npmx",
+      "page_title_version": "{name} docs - npmx",
+      "og_title": "{name} - Docs",
+      "view_package": "View package"
     },
     "get_started": {
       "title": "はじめに",
@@ -333,7 +500,8 @@
         "warning": "警告",
         "caution": "注意"
       },
-      "copy_as_markdown": "READMEをMarkdownとしてコピーする"
+      "copy_as_markdown": "READMEをMarkdownとしてコピーする",
+      "error_loading": "Failed to load README details"
     },
     "provenance_section": {
       "title": "Provenance",
@@ -363,7 +531,9 @@
       "published": "公開済み",
       "weekly_downloads": "週間ダウンロード数",
       "keywords": "キーワード",
-      "license": "ライセンス"
+      "license": "ライセンス",
+      "select": "Select package",
+      "select_maximum": "Maximum {count} packages can be selected"
     },
     "versions": {
       "title": "バージョン",
@@ -378,6 +548,7 @@
       "all_covered": "すべてのバージョンが上記のタグに含まれています",
       "deprecated_title": "{version}（非推奨）",
       "view_all": "{count} 個のバージョンを表示|{count} 個のすべてのバージョンを表示",
+      "view_all_versions": "View all versions",
       "distribution_title": "Semverグループ",
       "distribution_modal_title": "バージョン",
       "distribution_range_date_same_year": "{endYear} 年 {from} から {to}",
@@ -385,9 +556,11 @@
       "grouping_major": "メジャー",
       "grouping_minor": "マイナー",
       "grouping_versions_title": "バージョン",
+      "grouping_versions_about": "About version grouping",
       "grouping_versions_all": "すべて",
       "grouping_versions_only_recent": "直近のみ",
       "grouping_usage_title": "使用状況",
+      "grouping_usage_about": "About usage grouping",
       "grouping_usage_all": "すべて",
       "grouping_usage_most_used": "最多使用",
       "recent_versions_only_tooltip": "過去1年以内に公開されたバージョンのみ表示します。",
@@ -398,10 +571,45 @@
       "filter_help": "semver範囲フィルタのヘルプ",
       "filter_tooltip": "{link} を使ってバージョンを絞り込みます。例えば、^3.0.0は3.xのすべてのバージョンを表示します。",
       "filter_tooltip_link": "semver範囲",
+      "license_change_help": "License Change Details",
+      "license_change_warning": "License changed since previous version.",
+      "license_change_record": "The license of this package changed from \"{from}\" to \"{to}\".",
       "no_matches": "この範囲に一致するバージョンはありません",
       "copy_alt": {
         "per_version_analysis": "バージョン {version} は {downloads} 回ダウンロードされました",
         "general_description": "{package_name} パッケージの {versions_count} 個の {semver_grouping_mode} バージョンにおけるバージョン別ダウンロード数を示す棒グラフ。期間は {date_range_label}（{first_version} から {last_version} まで）。最多ダウンロードはバージョン {max_downloaded_version} で {max_version_downloads} 回。{per_version_analysis}。{watermark}。"
+      },
+      "page_title": "Version History",
+      "current_tags": "Current Tags",
+      "no_match_filter": "No versions match {filter}"
+    },
+    "timeline": {
+      "load_more": "Load more",
+      "load_error": "Failed to load timeline. Please try again later.",
+      "size_increase": "Install size increased by {percent}% ({size})",
+      "size_decrease": "Install size decreased by {percent}% ({size})",
+      "dep_increase": "{count} dependencies added",
+      "dep_decrease": "{count} dependencies removed",
+      "license_change": "License changed from {from} to {to}",
+      "esm_added": "Module type changed to ESM",
+      "esm_removed": "Module type changed from ESM to CJS",
+      "types_added": "TypeScript types added",
+      "types_removed": "TypeScript types removed",
+      "trusted_publisher_added": "Trusted publishing enabled",
+      "trusted_publisher_removed": "Trusted publishing removed",
+      "provenance_added": "Provenance enabled",
+      "provenance_removed": "Provenance removed",
+      "chart": {
+        "tab_aria_label": "Metric selection",
+        "base_scale": "start y-axis at zero",
+        "zoom": "zoom",
+        "reset_minimap": "reset minimap",
+        "ordered_versions": "stable only",
+        "copy_alt": {
+          "key_changes": "Key changes: {version_events}.",
+          "version_events": "version {version}: {events}",
+          "general_description": "Line chart showing the {metric} of the {package} package, from version {first} to {last}. The {metric} in version {first} is {first_value}, in version {last} is {last_value} ({overall_progress_percentage}% overall). {key_changes} {watermark}."
+        }
       }
     },
     "dependencies": {
@@ -413,7 +621,8 @@
       "outdated_major": "最新から {count} 個のメジャーバージョン遅れています (最新: {latest})",
       "outdated_minor": "最新から {count} 個のマイナーバージョン遅れています (最新: {latest})",
       "outdated_patch": "パッチアップデートがあります (最新: {latest})",
-      "has_replacement": "この依存関係には代替の候補があります"
+      "has_replacement": "この依存関係には代替の候補があります",
+      "vulnerabilities_count": "{count} vulnerability | {count} vulnerabilities"
     },
     "peer_dependencies": {
       "title": "ピア依存関係（{count}）",
@@ -437,9 +646,19 @@
       "cancel_add": "ownerの追加をキャンセル",
       "add_owner": "+ ownerを追加",
       "show_more": "（他 {count} 個を表示）",
-      "show_less": "（表示を減らす）"
+      "show_less": "（表示を減らす）",
+      "maintainer_template": "{avatar} {char126}{name}"
     },
     "trends": {
+      "chart_assistive_text": {
+        "keyboard_navigation_horizontal": "Use the left and right arrow keys to cycle through data points.",
+        "keyboard_navigation_vertical": "Use the up and down arrow keys to cycle through data points.",
+        "table_available": "A data table for this chart is available below.",
+        "table_caption": "Chart data table"
+      },
+      "chart_view_toggle": "Toggle view",
+      "chart_view_combined": "Combined view",
+      "chart_view_split": "Split view",
       "granularity": "粒度",
       "granularity_daily": "日次",
       "granularity_weekly": "週次",
@@ -498,7 +717,8 @@
     "downloads": {
       "title": "週間ダウンロード数",
       "community_distribution": "コミュニティの採用分布を表示",
-      "subtitle": "全バージョン合計"
+      "subtitle": "全バージョン合計",
+      "sparkline_nav_hint": "Use ← →"
     },
     "install_scripts": {
       "title": "インストールスクリプト",
@@ -514,6 +734,7 @@
       "esm": "ESモジュール対応",
       "cjs": "CommonJS対応",
       "no_esm": "ESモジュール非対応",
+      "wasm": "Has WebAssembly",
       "types_label": "型定義",
       "types_included": "型定義同梱",
       "types_available": "{package} 経由で型定義を利用可能",
@@ -588,7 +809,20 @@
       "kb": "{size} kB",
       "mb": "{size} MB"
     },
-    "download": {}
+    "download": {
+      "button": "Download",
+      "tarball": "Download Tarball as .tar.gz"
+    }
+  },
+  "leaderboard": {
+    "likes": {
+      "title": "Likes Leaderboard",
+      "description": "The 10 most liked packages on npmx right now.",
+      "rank": "Rank",
+      "likes": "Likes",
+      "unavailable_title": "No likes leaderboard yet",
+      "unavailable_description": "We don't have a likes leaderboard to show right now."
+    }
   },
   "connector": {
     "modal": {
@@ -771,8 +1005,12 @@
     "lines": "{count} 行",
     "toggle_tree": "ファイルツリーを切り替え",
     "close_tree": "ファイルツリーを閉じる",
+    "copy_content": "Copy file content",
     "copy_link": "リンクをコピー",
     "view_raw": "RAWファイルを表示",
+    "toggle_container": "Toggle code container width",
+    "open_raw_file": "Open raw file",
+    "open_path_dropdown": "Open path segments dropdown",
     "file_too_large": "ファイルが大きすぎるためプレビューできません",
     "file_size_warning": "{size} は構文強調表示の制限である500KBを超えています",
     "failed_to_load": "ファイルの読み込みに失敗しました",
@@ -790,7 +1028,9 @@
       "preview": "プレビュー",
       "code": "コード"
     },
-    "file_path": "ファイルパス"
+    "file_path": "ファイルパス",
+    "binary_file": "Binary file",
+    "binary_rendering_warning": "File type \"{contentType}\" is not supported for preview."
   },
   "badges": {
     "provenance": {
@@ -852,6 +1092,8 @@
       "secure": "警告なし",
       "insecure": "警告あり"
     },
+    "view_selected": "View selected",
+    "clear_selected_label": "Clear selected",
     "sort": {
       "label": "パッケージ一覧を並び替える",
       "toggle_direction": "並び順を切り替える",
@@ -877,7 +1119,8 @@
       "published": "最新の公開",
       "maintainers": "メンテナ",
       "keywords": "キーワード",
-      "security": "セキュリティ"
+      "security": "セキュリティ",
+      "selection": "Select package"
     },
     "view_mode": {
       "label": "表示モード",
@@ -1024,7 +1267,8 @@
       "error": "organizationの読み込みに失敗しました",
       "empty": "organizationは見つかりませんでした",
       "view_all": "すべて表示"
-    }
+    },
+    "pr": "Open GitHub pull request #{prNumber}"
   },
   "compare": {
     "packages": {
@@ -1043,7 +1287,10 @@
       "empty_title": "比較するパッケージを選択",
       "empty_description": "上部の検索から2つ以上のパッケージを追加すると、メトリクスを並べて比較できます。",
       "table_view": "テーブル",
-      "charts_view": "グラフ"
+      "charts_view": "グラフ",
+      "no_chartable_data": "No chartable data available for the selected facets.",
+      "bar_chart_nav_hint": "Use ↑ ↓",
+      "line_chart_nav_hint": "Use ← →"
     },
     "selector": {
       "search_label": "パッケージを検索",
@@ -1053,6 +1300,17 @@
       "remove_package": "{package} を削除",
       "packages_selected": "{count}/{max} パッケージ選択中。",
       "add_hint": "比較するには少なくとも2つのパッケージを追加してください。"
+    },
+    "scatter_chart": {
+      "title": "Compare {x} vs {y}",
+      "freshness_score": "Freshness score",
+      "copy_alt": {
+        "analysis": "{package} : {x_name} ({x_value}) and {y_name} ({y_value})",
+        "description": "Scatter plot chart mapping {x_name} versus {y_name} for the {packages} packages. {analysis}. {watermark}"
+      },
+      "filename": "{x}-vs-{y}-scatter-chart",
+      "x_axis": "X-AXIS ↦",
+      "y_axis": "Y-AXIS ↥"
     },
     "no_dependency": {
       "label": "(依存関係なし)",
@@ -1066,6 +1324,10 @@
     "facets": {
       "all": "すべて",
       "none": "なし",
+      "select_all_category_facets": "Select all {category} facets",
+      "deselect_all_category_facets": "Deselect all {category} facets",
+      "selected_all_category_facets": "Selected all {category} facets",
+      "deselected_all_category_facets": "Deselected all {category} facets",
       "coming_soon": "近日公開",
       "select_all": "すべての項目を選択",
       "deselect_all": "すべての項目の選択を解除",
@@ -1128,6 +1390,18 @@
         "vulnerabilities": {
           "label": "脆弱性",
           "description": "既知のセキュリティ脆弱性"
+        },
+        "githubStars": {
+          "label": "GitHub Stars",
+          "description": "Number of stars on the GitHub repository"
+        },
+        "githubIssues": {
+          "label": "GitHub Issues",
+          "description": "Number of issues on the GitHub repository"
+        },
+        "createdAt": {
+          "label": "Created At",
+          "description": "When the package was created"
         }
       },
       "values": {
@@ -1152,7 +1426,15 @@
     "file_size_warning": "{size} は比較制限の250KBを超えています",
     "compare_versions": "diff",
     "compare_versions_title": "最新バージョンと比較",
-    "version_invalid_url_format": {},
+    "comparing_versions_label": "Comparing versions...",
+    "version_back_to_package": "Back to package",
+    "version_error_message": "Failed to compare versions.",
+    "version_invalid_url_format": {
+      "hint": "Invalid comparison URL. Use format: {0}",
+      "from_version": "from",
+      "to_version": "to"
+    },
+    "version_selector_title": "Compare with version",
     "summary": "要約",
     "deps_count": "依存関係 {count} 件",
     "dependencies": "依存関係",
@@ -1178,7 +1460,18 @@
     "files_button": "ファイル",
     "select_file_prompt": "サイドバーからファイルを選択してdiffを表示",
     "close_files_panel": "ファイルパネルを閉じる",
-    "filter_files_label": "変更タイプでファイルをフィルタリング"
+    "filter_files_label": "変更タイプでファイルをフィルタリング",
+    "change_ratio": "Change ratio",
+    "char_edits": "Char edits",
+    "diff_distance": "Diff distance",
+    "loading_diff": "Loading diff...",
+    "loading_diff_error": "Failed to load diff",
+    "merge_modified_lines": "Merge modified lines",
+    "no_content_changes": "No content changes detected",
+    "options": "Options",
+    "view_file": "View file",
+    "view_in_code_browser": "View in code browser",
+    "word_wrap": "Word wrap"
   },
   "pds": {
     "title": "npmx.social",
@@ -1319,7 +1612,128 @@
     }
   },
   "translation_status": {
-    "table": {}
+    "title": "translation status",
+    "generated_at": "Generation date: {date}",
+    "welcome": "If you're interested in helping us to translate {npmx} into one of the languages listed below, you've come to the right place! This auto-updating page always lists all the content that could use your help right now.",
+    "p1": "We use {lang} as the default language, with a total of {count}. If you'd like to help add translations, locate the language in {bylang} and expand the details.",
+    "p1_lang": "American English (en-US)",
+    "p1_count": "0 messages | 1 message |{count} messages",
+    "p2": "Before starting, please read our {guide} to learn about our translation process and how you can get involved.",
+    "guide": "localization (i18n) guide",
+    "by_locale": "Translation progress by locale",
+    "by_file": "Translation progress by file",
+    "complete_text": "This translation is complete, amazing job!",
+    "missing_text": "missing",
+    "missing_keys": "There is no missing translations | Missing translation | Missing translations",
+    "progress_label": "Progress status for {locale}",
+    "table": {
+      "file": "File",
+      "status": "Status",
+      "error": "Error while loading file list.",
+      "empty": "No files found",
+      "file_link": "Edit {file} ({lang}) on GitHub"
+    }
   },
-  "action_bar": {}
+  "vacations": {
+    "title": "on vacation",
+    "meta_description": "The npmx team was recharging. Discord reopened after a week.",
+    "heading": "recharging",
+    "subtitle": "we were building npmx at a pace that was costing {some} of us sleep. we didn't want that to be the norm! so we took a week off. together.",
+    "illustration_alt": "a single row of cosy icons",
+    "poke_log": "Poke the campfire",
+    "what": {
+      "title": "what happened",
+      "p1": "discord was closed {dates}.",
+      "dates": "February 14 – 21",
+      "p2": "all invite links were gone and channels were locked – except {garden}, which stayed open for folks who wanted to keep hanging out.",
+      "garden": "#garden"
+    },
+    "meantime": {
+      "title": "in the meantime",
+      "p1": "{site} and {repo} stayed open – people still dug in, filed some issues, opened a few PRs, but mainly everyone spent time somewhere near a cosy fireplace.",
+      "repo_link": "the repo"
+    },
+    "return": {
+      "title": "we came back!",
+      "p1": "we came back recharged and ready for the final push to March 3rd. {social} for updates.",
+      "social_link": "follow us on Bluesky"
+    },
+    "stats": {
+      "contributors": "Contributors",
+      "commits": "Commits",
+      "pr": "PRs Merged",
+      "subtitle": {
+        "some": "some",
+        "all": "all"
+      }
+    }
+  },
+  "action_bar": {
+    "title": "action bar",
+    "selection": "0 selected | 1 selected | {count} selected",
+    "shortcut": "Press \"{key}\" to focus actions",
+    "button_close_aria_label": "Close action bar"
+  },
+  "logo_menu": {
+    "copy_svg": "Copy logo as SVG",
+    "copied": "Copied!",
+    "browse_brand": "Browse brand kit"
+  },
+  "brand": {
+    "title": "Brand",
+    "heading": "brand",
+    "meta_description": "npmx brand guidelines, logos, colors, and typography for use in press and media.",
+    "intro": "Resources and guidelines for using the npmx brand in your projects, articles, and media.",
+    "logos": {
+      "title": "logos",
+      "description": "Download npmx logos in SVG and PNG formats. Use the appropriate variant for your background.",
+      "wordmark": "FULL WORDMARK",
+      "wordmark_alt": "npmx full wordmark logo with blue slash on dark background",
+      "wordmark_light_alt": "npmx full wordmark logo with accent slash on light background",
+      "mark": "LOGO MARK",
+      "mark_alt": "npmx logo mark with dot and slash on dark background",
+      "mark_light_alt": "npmx logo mark with dot and slash on light background",
+      "on_dark": "on dark",
+      "on_light": "on light",
+      "download_svg": "SVG",
+      "download_png": "PNG",
+      "download_svg_aria": "Download {name} as SVG",
+      "download_png_aria": "Download {name} as PNG"
+    },
+    "customize": {
+      "title": "customize your logo",
+      "description": "Preview the npmx logo with your accent color and background. The preview reflects your current settings — pick a color, toggle the background, and download.",
+      "accent_label": "accent",
+      "bg_label": "background",
+      "download_svg_aria": "Download customized logo as SVG",
+      "download_png_aria": "Download customized logo as PNG"
+    },
+    "typography": {
+      "title": "typography",
+      "description": "npmx uses the Geist font family by Vercel for both interface text and code.",
+      "sans": "Geist Sans",
+      "sans_desc": "Used for body text and UI elements.",
+      "mono": "Geist Mono",
+      "mono_desc": "Used for code, headings, and technical content.",
+      "pangram": "The quick brown fox jumps over the lazy dog",
+      "numbers": "0123456789"
+    },
+    "guidelines": {
+      "title": "just a note",
+      "message": "Accessibility matters to us, and we would love you to follow us in this vision. When using mentioned media, ensure there is enough contrast against the background, and don't go smaller than 24px. If you need any other resources or additional information about the project, feel free to reach us at {link}.",
+      "discord_link_text": "chat.npmx.dev"
+    }
+  },
+  "alt_logo_kawaii": "A cute, rounded, and colorful version of the npmx logo.",
+  "changelog": {
+    "pre_release": "Pre-release",
+    "draft": "Draft",
+    "no_logs": "Sorry, this package does not publish changelogs or its changelog format is not supported.",
+    "error": {
+      "p1": "Sorry, the changelog for {package} couldn't be loaded",
+      "p2": "Please try again later or {viewon}"
+    },
+    "rate_limit_ungh": "Sorry, Github's rate limit has been hit, try again in a moment",
+    "version_unavailable": "The requested version is not available."
+  }
 }

--- a/i18n/locales/ja-JP.json
+++ b/i18n/locales/ja-JP.json
@@ -20,10 +20,10 @@
     "chat": "チャット",
     "builders_chat": "ビルダー",
     "keyboard_shortcuts": "キーボードショートカット",
-    "brand": "brand",
-    "resources": "Resources",
-    "features": "Features",
-    "other": "Other"
+    "brand": "ブランド",
+    "resources": "リソース",
+    "features": "機能",
+    "other": "その他"
   },
   "shortcuts": {
     "section": {
@@ -32,8 +32,8 @@
       "package": "パッケージ"
     },
     "ctrl_key": "Ctrl",
-    "command_palette": "Open command palette",
-    "command_palette_description": "Use the command palette to jump between pages, package views, settings, and external links without leaving the keyboard. On macOS, press ⌘K. On Windows and Linux, press {ctrlKey}+K.",
+    "command_palette": "コマンドパレットを開く",
+    "command_palette_description": "キーボード操作だけでページ、パッケージビュー、設定、外部リンクの間を移動できます。macOSでは⌘K、WindowsやLinuxでは{ctrlKey}+Kを押してください。",
     "focus_search": "検索にフォーカス",
     "show_kbd_hints": "キーボードヒントをハイライト",
     "settings": "設定を開く",
@@ -44,9 +44,9 @@
     "open_code_view": "コードビューを開く",
     "open_docs": "ドキュメントを開く",
     "disable_shortcuts": "{settings} でキーボードショートカットを無効化できます。",
-    "open_main": "Open main information",
-    "open_diff": "Open version differences",
-    "open_timeline": "Open timeline"
+    "open_main": "メイン情報を開く",
+    "open_diff": "バージョンの差分を開く",
+    "open_timeline": "タイムラインを開く"
   },
   "search": {
     "label": "npmパッケージを検索",
@@ -84,111 +84,111 @@
     "instant_search_advisory": "{label} {state} — {action}"
   },
   "command_palette": {
-    "title": "command palette",
-    "quick_actions": "jump to...",
-    "subtitle": "navigate across npmx and switch settings quickly",
-    "subtitle_languages": "choose a language or help improve translations",
-    "instructions": "Type to filter commands. Use the arrow keys to move through results and Enter to run a command.",
-    "input_label": "Command palette search",
-    "results_label": "Command results",
-    "placeholder": "type a command...",
-    "back": "Back",
-    "empty": "No matching commands",
-    "empty_search_hint": "Press Enter to search for \"{query}\".",
-    "current": "current",
-    "here": "you are here",
-    "connected": "connected",
+    "title": "コマンドパレット",
+    "quick_actions": "ジャンプ",
+    "subtitle": "npmx内の移動と設定の素早い切り替え",
+    "subtitle_languages": "言語の選択、または翻訳の改善に協力",
+    "instructions": "入力してコマンドを絞り込みます。矢印キーで移動し、Enterで実行します。",
+    "input_label": "コマンドパレット検索",
+    "results_label": "コマンド結果",
+    "placeholder": "コマンドを入力...",
+    "back": "戻る",
+    "empty": "一致するコマンドがありません",
+    "empty_search_hint": "「{query}」を検索するにはEnterを押してください。",
+    "current": "現在",
+    "here": "現在地",
+    "connected": "接続済み",
     "state": {
-      "on": "on",
-      "off": "off"
+      "on": "オン",
+      "off": "オフ"
     },
     "groups": {
-      "actions": "Actions",
-      "help": "Help",
-      "language": "Language",
-      "connections": "Connections",
-      "navigation": "Navigation",
-      "links": "Links",
+      "actions": "アクション",
+      "help": "ヘルプ",
+      "language": "言語",
+      "connections": "接続",
+      "navigation": "ナビゲーション",
+      "links": "リンク",
       "npmx": "npmx",
-      "package": "Package",
-      "package_with_name": "Package ({name})",
-      "versions": "Versions",
-      "versions_with_name": "Versions of {name}"
+      "package": "パッケージ",
+      "package_with_name": "パッケージ ({name})",
+      "versions": "バージョン",
+      "versions_with_name": "{name} のバージョン"
     },
     "actions": {
-      "search": "Search",
-      "search_for": "Search for \"{query}\"",
-      "keyboard_shortcuts": "Keyboard shortcuts",
-      "help_translate": "Help translate"
+      "search": "検索",
+      "search_for": "「{query}」を検索",
+      "keyboard_shortcuts": "キーボードショートカット",
+      "help_translate": "翻訳に協力する"
     },
     "connections": {
-      "npm_connect": "Connect to npm CLI",
+      "npm_connect": "npm CLIに接続",
       "npm_connected": "npm CLI (~{username})",
-      "npm_disconnect": "Disconnect npm CLI",
-      "atmosphere_connect": "Connect to Atmosphere",
+      "npm_disconnect": "npm CLIから切断",
+      "atmosphere_connect": "Atmosphereに接続",
       "atmosphere_connected": "atmosphere ({'@'}{handle})",
-      "atmosphere_disconnect": "Disconnect Atmosphere"
+      "atmosphere_disconnect": "Atmosphereから切断"
     },
     "navigation": {
-      "home": "home",
-      "packages": "packages (~{username})",
-      "orgs": "orgs (~{username})",
-      "profile": "profile ({'@'}{handle})"
+      "home": "ホーム",
+      "packages": "パッケージ (~{username})",
+      "orgs": "Organization (~{username})",
+      "profile": "プロフィール ({'@'}{handle})"
     },
     "links": {
-      "external": "External link"
+      "external": "外部リンク"
     },
     "package_links": {
-      "stars": "Repository stars",
-      "forks": "Repository forks"
+      "stars": "リポジトリのスター数",
+      "forks": "リポジトリのフォーク数"
     },
     "theme": {
-      "system": "Use system theme",
-      "light": "Use light theme",
-      "dark": "Use dark theme"
+      "system": "システムテーマを使用",
+      "light": "ライトテーマを使用",
+      "dark": "ダークテーマを使用"
     },
     "package": {
-      "main": "Package page",
-      "docs": "Docs",
-      "code": "Code",
-      "diff": "Diff",
-      "compare": "Compare this package",
-      "download": "Download tarball",
+      "main": "パッケージページ",
+      "docs": "ドキュメント",
+      "code": "コード",
+      "diff": "差分",
+      "compare": "このパッケージを比較",
+      "download": "tarballをダウンロード",
       "changelog": "Changelog"
     },
     "package_actions": {
-      "copy_run": "Copy run command"
+      "copy_run": "実行コマンドをコピー"
     },
     "code": {
-      "copy_file": "Copy file contents"
+      "copy_file": "ファイル内容をコピー"
     },
     "diff": {
-      "merge_modified_lines": "Merge modified lines",
-      "word_wrap": "Word wrap"
+      "merge_modified_lines": "変更行をマージ",
+      "word_wrap": "右端で折り返す"
     },
     "version": {
       "label": "{version}"
     },
     "status": {
-      "available_in_context": "{context}. No commands available | {context}. 1 command available | {context}. {count} commands available",
-      "matching_in_context": "{context}. No matching commands | {context}. 1 matching command | {context}. {count} matching commands",
-      "no_matches_search_in_context": "{context}. No matching commands. Press Enter to search for \"{query}\"."
+      "available_in_context": "{context}。利用可能なコマンドはありません | {context}。1つのコマンドが利用可能 | {context}。{count} つのコマンドが利用可能",
+      "matching_in_context": "{context}。一致するコマンドはありません | {context}。1つのコマンドが一致 | {context}。{count} つのコマンドが一致",
+      "no_matches_search_in_context": "{context}。一致するコマンドはありません。Enterを押すと「{query}」を検索します。"
     },
     "announcements": {
-      "language_changed": "Language set to {language}.",
-      "relative_dates_on": "Relative dates on.",
-      "relative_dates_off": "Relative dates off.",
-      "theme_changed": "Theme set to {theme}.",
-      "accent_color_changed": "Accent color set to {color}.",
-      "background_theme_changed": "Background shade set to {theme}.",
-      "download_started": "Downloading {package} tarball.",
-      "copied_to_clipboard": "Copied to clipboard.",
-      "npm_disconnected": "npm CLI disconnected.",
-      "atmosphere_disconnected": "Atmosphere disconnected.",
-      "facets_all_selected": "All facets selected.",
-      "facets_all_deselected": "All facets deselected.",
-      "view_switched": "Switched to {view} view.",
-      "setting_toggled": "{setting} {state}."
+      "language_changed": "言語を {language} に設定しました。",
+      "relative_dates_on": "相対日付をオンにしました。",
+      "relative_dates_off": "相対日付をオフにしました。",
+      "theme_changed": "テーマを {theme} に設定しました。",
+      "accent_color_changed": "アクセントカラーを {color} に設定しました。",
+      "background_theme_changed": "背景シェードを {theme} に設定しました。",
+      "download_started": "{package} のtarballをダウンロード中。",
+      "copied_to_clipboard": "クリップボードにコピーしました。",
+      "npm_disconnected": "npm CLIから切断しました。",
+      "atmosphere_disconnected": "Atmosphereから切断しました。",
+      "facets_all_selected": "すべてのファセットを選択しました。",
+      "facets_all_deselected": "すべてのファセットの選択を解除しました。",
+      "view_switched": "{view} ビューに切り替えました。",
+      "setting_toggled": "{setting} を {state} にしました。"
     }
   },
   "nav": {
@@ -212,7 +212,7 @@
     },
     "draft_badge": "下書き",
     "draft_banner": "これは未公開の下書きです。内容が不完全であったり、不正確な情報が含まれている可能性があります。",
-    "no_posts": "No posts found.",
+    "no_posts": "記事が見つかりません。",
     "atproto": {
       "view_on_bluesky": "Blueskyで表示",
       "reply_on_bluesky": "Blueskyでリプライ",
@@ -255,40 +255,40 @@
     "include_types_description": "型定義のないパッケージのインストールコマンドに{'@'}typesパッケージを追加します",
     "hide_platform_packages": "検索でプラットフォーム固有のパッケージを非表示",
     "hide_platform_packages_description": "検索結果から{'@'}esbuild/linux-x64のようなネイティブバイナリパッケージを非表示にします",
-    "enable_graph_pulse_loop": "Enable looping of pulse effect on mini graph",
-    "enable_graph_pulse_loop_description": "Activate a continuous pulse animation on the weekly download graph. This animation may be distracting for some users.",
+    "enable_graph_pulse_loop": "ミニグラフのパルス効果のループを有効化",
+    "enable_graph_pulse_loop_description": "週間ダウンロードグラフで連続したパルスアニメーションを有効にします。このアニメーションは一部のユーザーにとって煩わしく感じられる場合があります。",
     "theme": "テーマ",
     "theme_light": "ライト",
     "theme_dark": "ダーク",
     "theme_system": "システム",
     "language": "言語",
     "help_translate": "npmxの翻訳に協力する",
-    "translation_status": "Check global translation status",
+    "translation_status": "全体の翻訳状況を確認",
     "accent_colors": {
       "label": "アクセントカラー",
-      "neutral": "Neutral",
-      "sky": "Sky",
-      "coral": "Coral",
-      "amber": "Amber",
-      "emerald": "Emerald",
-      "violet": "Violet",
-      "magenta": "Magenta"
+      "neutral": "ニュートラル",
+      "sky": "スカイ",
+      "coral": "コーラル",
+      "amber": "アンバー",
+      "emerald": "エメラルド",
+      "violet": "バイオレット",
+      "magenta": "マゼンタ"
     },
     "clear_accent": "アクセントカラーをクリア",
     "translation_progress": "翻訳の進捗状況",
     "background_themes": {
       "label": "背景シェード",
-      "neutral": "Neutral",
-      "stone": "Stone",
-      "zinc": "Zinc",
-      "slate": "Slate",
-      "black": "Black"
+      "neutral": "ニュートラル",
+      "stone": "ストーン",
+      "zinc": "ジンク",
+      "slate": "スレート",
+      "black": "ブラック"
     },
     "keyboard_shortcuts_enabled": "キーボードショートカットを有効化",
     "keyboard_shortcuts_enabled_description": "ブラウザやシステムのショートカットと競合する場合、キーボードショートカットを無効化できます",
-    "enable_code_ligatures": "Enable ligatures in code",
-    "enable_changelog_autoscroll": "Auto scroll to requested version",
-    "enable_changelog_autoscroll_description": "Auto scroll to or close to the requested version at package changelog"
+    "enable_code_ligatures": "コードのリガチャを有効化",
+    "enable_changelog_autoscroll": "要求されたバージョンへ自動スクロール",
+    "enable_changelog_autoscroll_description": "パッケージのchangelogで要求されたバージョン（またはその付近）まで自動スクロール"
   },
   "i18n": {
     "missing_keys": "{count} 件の未翻訳項目",
@@ -320,7 +320,7 @@
     "warnings": "警告:",
     "go_back_home": "ホームへ戻る",
     "per_week": "/ 週",
-    "per_week_short": "/wk",
+    "per_week_short": "/週",
     "vanity_downloads_hint": "バニティ番号: パッケージが表示されていません|バニティ番号: 表示されているパッケージの数値|バニティ番号: 表示されている {count} 個のパッケージの合計",
     "sort": {
       "name": "名前",
@@ -343,14 +343,14 @@
       "gitea": "Giteaで表示",
       "gitee": "Giteeで表示",
       "radicle": "Radicleで表示",
-      "socket_dev": "View on socket.dev",
+      "socket_dev": "socket.devで表示",
       "sourcehut": "SourceHutで表示",
       "tangled": "Tangledで表示"
     },
-    "collapse": "Collapse",
-    "collapse_with_name": "Collapse {name}",
-    "expand": "Expand",
-    "expand_with_name": "Expand {name}"
+    "collapse": "折りたたむ",
+    "collapse_with_name": "{name} を折りたたむ",
+    "expand": "展開",
+    "expand_with_name": "{name} を展開"
   },
   "profile": {
     "display_name": "表示名",
@@ -389,17 +389,17 @@
       "deps": "依存関係が {count} 件増加"
     },
     "size_decrease": {
-      "title_size": "Package size decreased since v{version}!",
-      "title_deps": "Dependency count decreased since v{version}!",
-      "title_both": "Package size and dependency count decreased since v{version}!",
-      "size": "Install size reduced by {percent} ({size} smaller)",
-      "deps": "{count} fewer dependencies"
+      "title_size": "v{version} 以降、パッケージサイズが減少しました！",
+      "title_deps": "v{version} 以降、依存関係の数が減少しました！",
+      "title_both": "v{version} 以降、パッケージサイズと依存関係の数が減少しました！",
+      "size": "インストールサイズが {percent} ({size}) 減少",
+      "deps": "依存関係が {count} 個減少"
     },
     "replacement": {
       "title": "この依存関係は不要な可能性があります。",
-      "example": "Example:",
+      "example": "例:",
       "native": "これは Node {nodeVersion} 以降で利用可能な {replacement} で置き換え可能です。",
-      "native_no_version": "This package can be replaced with {replacement}.",
+      "native_no_version": "このパッケージは {replacement} で置き換え可能です。",
       "simple": "{community} はこのパッケージを冗長としてフラグを立てており、次のアドバイスがあります: {replacement}",
       "documented": "{community} により、このパッケージにはよりパフォーマンスの高い代替手段があることが報告されています。",
       "none": "このパッケージは不要になったとフラグが立てられています。その機能はすべてのエンジンでネイティブに利用できる可能性があります。",
@@ -441,7 +441,7 @@
       "skills_cli": "skills CLI"
     },
     "links": {
-      "main": "main",
+      "main": "メイン",
       "repo": "リポジトリ",
       "homepage": "ホームページ",
       "issues": "issues",
@@ -450,27 +450,27 @@
       "docs": "ドキュメント",
       "fund": "資金援助",
       "compare": "比較",
-      "timeline": "timeline",
-      "compare_this_package": "compare this package",
+      "timeline": "タイムライン",
+      "compare_this_package": "このパッケージを比較",
       "changelog": "changelog"
     },
     "likes": {
       "like": "このパッケージをいいねする",
       "unlike": "このパッケージのいいねを解除する",
-      "top_rank_tooltip": "This is among the top 10 most liked packages on npmx! (#{rank})",
+      "top_rank_tooltip": "このパッケージはnpmxで最も「いいね」されている上位10パッケージの一つです！ (#{rank})",
       "top_rank_label": "#{rank}",
-      "top_rank_link_label": "View likes leaderboard. This package is ranked #{rank}."
+      "top_rank_link_label": "いいねリーダーボードを表示。このパッケージは #{rank} 位です。"
     },
     "docs": {
-      "contents": "Contents",
-      "default_not_available": "Docs are not available for this version.",
+      "contents": "目次",
+      "default_not_available": "このバージョンではドキュメントを利用できません。",
       "not_available": "ドキュメントは利用できません",
       "not_available_detail": "このバージョンのドキュメントを生成できませんでした。",
-      "page_title": "API Docs - npmx",
-      "page_title_name": "{name} docs - npmx",
-      "page_title_version": "{name} docs - npmx",
-      "og_title": "{name} - Docs",
-      "view_package": "View package"
+      "page_title": "API ドキュメント - npmx",
+      "page_title_name": "{name} ドキュメント - npmx",
+      "page_title_version": "{name} ドキュメント - npmx",
+      "og_title": "{name} - ドキュメント",
+      "view_package": "パッケージを表示"
     },
     "get_started": {
       "title": "はじめに",
@@ -501,7 +501,7 @@
         "caution": "注意"
       },
       "copy_as_markdown": "READMEをMarkdownとしてコピーする",
-      "error_loading": "Failed to load README details"
+      "error_loading": "READMEの詳細の読み込みに失敗しました"
     },
     "provenance_section": {
       "title": "Provenance",
@@ -532,8 +532,8 @@
       "weekly_downloads": "週間ダウンロード数",
       "keywords": "キーワード",
       "license": "ライセンス",
-      "select": "Select package",
-      "select_maximum": "Maximum {count} packages can be selected"
+      "select": "パッケージを選択",
+      "select_maximum": "最大 {count} 個のパッケージを選択できます"
     },
     "versions": {
       "title": "バージョン",
@@ -548,7 +548,7 @@
       "all_covered": "すべてのバージョンが上記のタグに含まれています",
       "deprecated_title": "{version}（非推奨）",
       "view_all": "{count} 個のバージョンを表示|{count} 個のすべてのバージョンを表示",
-      "view_all_versions": "View all versions",
+      "view_all_versions": "すべてのバージョンを表示",
       "distribution_title": "Semverグループ",
       "distribution_modal_title": "バージョン",
       "distribution_range_date_same_year": "{endYear} 年 {from} から {to}",
@@ -556,11 +556,11 @@
       "grouping_major": "メジャー",
       "grouping_minor": "マイナー",
       "grouping_versions_title": "バージョン",
-      "grouping_versions_about": "About version grouping",
+      "grouping_versions_about": "バージョンのグループ化について",
       "grouping_versions_all": "すべて",
       "grouping_versions_only_recent": "直近のみ",
       "grouping_usage_title": "使用状況",
-      "grouping_usage_about": "About usage grouping",
+      "grouping_usage_about": "使用状況のグループ化について",
       "grouping_usage_all": "すべて",
       "grouping_usage_most_used": "最多使用",
       "recent_versions_only_tooltip": "過去1年以内に公開されたバージョンのみ表示します。",
@@ -571,44 +571,44 @@
       "filter_help": "semver範囲フィルタのヘルプ",
       "filter_tooltip": "{link} を使ってバージョンを絞り込みます。例えば、^3.0.0は3.xのすべてのバージョンを表示します。",
       "filter_tooltip_link": "semver範囲",
-      "license_change_help": "License Change Details",
-      "license_change_warning": "License changed since previous version.",
-      "license_change_record": "The license of this package changed from \"{from}\" to \"{to}\".",
+      "license_change_help": "ライセンス変更の詳細",
+      "license_change_warning": "前のバージョンからライセンスが変更されています。",
+      "license_change_record": "このパッケージのライセンスが「{from}」から「{to}」に変更されました。",
       "no_matches": "この範囲に一致するバージョンはありません",
       "copy_alt": {
         "per_version_analysis": "バージョン {version} は {downloads} 回ダウンロードされました",
         "general_description": "{package_name} パッケージの {versions_count} 個の {semver_grouping_mode} バージョンにおけるバージョン別ダウンロード数を示す棒グラフ。期間は {date_range_label}（{first_version} から {last_version} まで）。最多ダウンロードはバージョン {max_downloaded_version} で {max_version_downloads} 回。{per_version_analysis}。{watermark}。"
       },
-      "page_title": "Version History",
-      "current_tags": "Current Tags",
-      "no_match_filter": "No versions match {filter}"
+      "page_title": "バージョン履歴",
+      "current_tags": "現在のタグ",
+      "no_match_filter": "{filter} に一致するバージョンはありません"
     },
     "timeline": {
-      "load_more": "Load more",
-      "load_error": "Failed to load timeline. Please try again later.",
-      "size_increase": "Install size increased by {percent}% ({size})",
-      "size_decrease": "Install size decreased by {percent}% ({size})",
-      "dep_increase": "{count} dependencies added",
-      "dep_decrease": "{count} dependencies removed",
-      "license_change": "License changed from {from} to {to}",
-      "esm_added": "Module type changed to ESM",
-      "esm_removed": "Module type changed from ESM to CJS",
-      "types_added": "TypeScript types added",
-      "types_removed": "TypeScript types removed",
-      "trusted_publisher_added": "Trusted publishing enabled",
-      "trusted_publisher_removed": "Trusted publishing removed",
-      "provenance_added": "Provenance enabled",
-      "provenance_removed": "Provenance removed",
+      "load_more": "さらに読み込む",
+      "load_error": "タイムラインの読み込みに失敗しました。後で再試行してください。",
+      "size_increase": "インストールサイズが {percent}% ({size}) 増加",
+      "size_decrease": "インストールサイズが {percent}% ({size}) 減少",
+      "dep_increase": "依存関係を {count} 個追加",
+      "dep_decrease": "依存関係を {count} 個削除",
+      "license_change": "ライセンスを {from} から {to} に変更",
+      "esm_added": "モジュールタイプをESMに変更",
+      "esm_removed": "モジュールタイプをESMからCJSに変更",
+      "types_added": "TypeScript型定義を追加",
+      "types_removed": "TypeScript型定義を削除",
+      "trusted_publisher_added": "Trusted publishingを有効化",
+      "trusted_publisher_removed": "Trusted publishingを削除",
+      "provenance_added": "Provenanceを有効化",
+      "provenance_removed": "Provenanceを削除",
       "chart": {
-        "tab_aria_label": "Metric selection",
-        "base_scale": "start y-axis at zero",
-        "zoom": "zoom",
-        "reset_minimap": "reset minimap",
-        "ordered_versions": "stable only",
+        "tab_aria_label": "メトリクスの選択",
+        "base_scale": "Y軸を0から開始",
+        "zoom": "ズーム",
+        "reset_minimap": "ミニマップをリセット",
+        "ordered_versions": "安定版のみ",
         "copy_alt": {
-          "key_changes": "Key changes: {version_events}.",
-          "version_events": "version {version}: {events}",
-          "general_description": "Line chart showing the {metric} of the {package} package, from version {first} to {last}. The {metric} in version {first} is {first_value}, in version {last} is {last_value} ({overall_progress_percentage}% overall). {key_changes} {watermark}."
+          "key_changes": "主な変更: {version_events}",
+          "version_events": "バージョン {version}: {events}",
+          "general_description": "パッケージ {package} の {metric} をバージョン {first} から {last} まで示すラインチャート。{first} 時の {metric} は {first_value}、{last} 時は {last_value} (全体で {overall_progress_percentage}% 変化) です。{key_changes} {watermark}。"
         }
       }
     },
@@ -622,7 +622,7 @@
       "outdated_minor": "最新から {count} 個のマイナーバージョン遅れています (最新: {latest})",
       "outdated_patch": "パッチアップデートがあります (最新: {latest})",
       "has_replacement": "この依存関係には代替の候補があります",
-      "vulnerabilities_count": "{count} vulnerability | {count} vulnerabilities"
+      "vulnerabilities_count": "{count} 件の脆弱性"
     },
     "peer_dependencies": {
       "title": "ピア依存関係（{count}）",
@@ -651,14 +651,14 @@
     },
     "trends": {
       "chart_assistive_text": {
-        "keyboard_navigation_horizontal": "Use the left and right arrow keys to cycle through data points.",
-        "keyboard_navigation_vertical": "Use the up and down arrow keys to cycle through data points.",
-        "table_available": "A data table for this chart is available below.",
-        "table_caption": "Chart data table"
+        "keyboard_navigation_horizontal": "左右の矢印キーでデータポイントを移動できます。",
+        "keyboard_navigation_vertical": "上下の矢印キーでデータポイントを移動できます。",
+        "table_available": "このチャートのデータテーブルを以下で利用できます。",
+        "table_caption": "チャートデータテーブル"
       },
-      "chart_view_toggle": "Toggle view",
-      "chart_view_combined": "Combined view",
-      "chart_view_split": "Split view",
+      "chart_view_toggle": "表示の切り替え",
+      "chart_view_combined": "結合ビュー",
+      "chart_view_split": "分割ビュー",
       "granularity": "粒度",
       "granularity_daily": "日次",
       "granularity_weekly": "週次",
@@ -718,7 +718,7 @@
       "title": "週間ダウンロード数",
       "community_distribution": "コミュニティの採用分布を表示",
       "subtitle": "全バージョン合計",
-      "sparkline_nav_hint": "Use ← →"
+      "sparkline_nav_hint": "← → キーを使用してください"
     },
     "install_scripts": {
       "title": "インストールスクリプト",
@@ -734,7 +734,7 @@
       "esm": "ESモジュール対応",
       "cjs": "CommonJS対応",
       "no_esm": "ESモジュール非対応",
-      "wasm": "Has WebAssembly",
+      "wasm": "WebAssemblyを含む",
       "types_label": "型定義",
       "types_included": "型定義同梱",
       "types_available": "{package} 経由で型定義を利用可能",
@@ -810,18 +810,18 @@
       "mb": "{size} MB"
     },
     "download": {
-      "button": "Download",
-      "tarball": "Download Tarball as .tar.gz"
+      "button": "ダウンロード",
+      "tarball": "Tarball (.tar.gz) をダウンロード"
     }
   },
   "leaderboard": {
     "likes": {
-      "title": "Likes Leaderboard",
-      "description": "The 10 most liked packages on npmx right now.",
-      "rank": "Rank",
-      "likes": "Likes",
-      "unavailable_title": "No likes leaderboard yet",
-      "unavailable_description": "We don't have a likes leaderboard to show right now."
+      "title": "いいねリーダーボード",
+      "description": "現在npmxで最も「いいね」されている10パッケージ。",
+      "rank": "順位",
+      "likes": "いいね数",
+      "unavailable_title": "リーダーボードはまだありません",
+      "unavailable_description": "現在表示できるいいねリーダーボードはありません。"
     }
   },
   "connector": {
@@ -1005,12 +1005,12 @@
     "lines": "{count} 行",
     "toggle_tree": "ファイルツリーを切り替え",
     "close_tree": "ファイルツリーを閉じる",
-    "copy_content": "Copy file content",
+    "copy_content": "ファイル内容をコピー",
     "copy_link": "リンクをコピー",
     "view_raw": "RAWファイルを表示",
-    "toggle_container": "Toggle code container width",
-    "open_raw_file": "Open raw file",
-    "open_path_dropdown": "Open path segments dropdown",
+    "toggle_container": "コードコンテナの幅を切り替え",
+    "open_raw_file": "RAWファイルを開く",
+    "open_path_dropdown": "パスセグメントのドロップダウンを開く",
     "file_too_large": "ファイルが大きすぎるためプレビューできません",
     "file_size_warning": "{size} は構文強調表示の制限である500KBを超えています",
     "failed_to_load": "ファイルの読み込みに失敗しました",
@@ -1029,8 +1029,8 @@
       "code": "コード"
     },
     "file_path": "ファイルパス",
-    "binary_file": "Binary file",
-    "binary_rendering_warning": "File type \"{contentType}\" is not supported for preview."
+    "binary_file": "バイナリファイル",
+    "binary_rendering_warning": "ファイルタイプ「{contentType}」はプレビューに対応していません。"
   },
   "badges": {
     "provenance": {
@@ -1092,8 +1092,8 @@
       "secure": "警告なし",
       "insecure": "警告あり"
     },
-    "view_selected": "View selected",
-    "clear_selected_label": "Clear selected",
+    "view_selected": "選択したものを表示",
+    "clear_selected_label": "選択を解除",
     "sort": {
       "label": "パッケージ一覧を並び替える",
       "toggle_direction": "並び順を切り替える",
@@ -1120,7 +1120,7 @@
       "maintainers": "メンテナ",
       "keywords": "キーワード",
       "security": "セキュリティ",
-      "selection": "Select package"
+      "selection": "パッケージを選択"
     },
     "view_mode": {
       "label": "表示モード",
@@ -1268,7 +1268,7 @@
       "empty": "organizationは見つかりませんでした",
       "view_all": "すべて表示"
     },
-    "pr": "Open GitHub pull request #{prNumber}"
+    "pr": "GitHubのPull Request #{prNumber} を開く"
   },
   "compare": {
     "packages": {
@@ -1288,9 +1288,9 @@
       "empty_description": "上部の検索から2つ以上のパッケージを追加すると、メトリクスを並べて比較できます。",
       "table_view": "テーブル",
       "charts_view": "グラフ",
-      "no_chartable_data": "No chartable data available for the selected facets.",
-      "bar_chart_nav_hint": "Use ↑ ↓",
-      "line_chart_nav_hint": "Use ← →"
+      "no_chartable_data": "選択したファセットに使用可能なチャートデータがありません。",
+      "bar_chart_nav_hint": "↑ ↓ キーを使用",
+      "line_chart_nav_hint": "← → キーを使用"
     },
     "selector": {
       "search_label": "パッケージを検索",
@@ -1302,15 +1302,15 @@
       "add_hint": "比較するには少なくとも2つのパッケージを追加してください。"
     },
     "scatter_chart": {
-      "title": "Compare {x} vs {y}",
-      "freshness_score": "Freshness score",
+      "title": "{x} と {y} の比較",
+      "freshness_score": "フレッシュネススコア",
       "copy_alt": {
-        "analysis": "{package} : {x_name} ({x_value}) and {y_name} ({y_value})",
-        "description": "Scatter plot chart mapping {x_name} versus {y_name} for the {packages} packages. {analysis}. {watermark}"
+        "analysis": "{package} : {x_name} ({x_value}) および {y_name} ({y_value})",
+        "description": "{packages} パッケージの {x_name} 対 {y_name} の散布図。{analysis}。{watermark}"
       },
       "filename": "{x}-vs-{y}-scatter-chart",
-      "x_axis": "X-AXIS ↦",
-      "y_axis": "Y-AXIS ↥"
+      "x_axis": "X軸 ↦",
+      "y_axis": "Y軸 ↥"
     },
     "no_dependency": {
       "label": "(依存関係なし)",
@@ -1324,10 +1324,10 @@
     "facets": {
       "all": "すべて",
       "none": "なし",
-      "select_all_category_facets": "Select all {category} facets",
-      "deselect_all_category_facets": "Deselect all {category} facets",
-      "selected_all_category_facets": "Selected all {category} facets",
-      "deselected_all_category_facets": "Deselected all {category} facets",
+      "select_all_category_facets": "すべての {category} ファセットを選択",
+      "deselect_all_category_facets": "{category} ファセットをすべて解除",
+      "selected_all_category_facets": "すべての {category} ファセットを選択しました",
+      "deselected_all_category_facets": "{category} ファセットをすべて解除しました",
       "coming_soon": "近日公開",
       "select_all": "すべての項目を選択",
       "deselect_all": "すべての項目の選択を解除",
@@ -1393,15 +1393,15 @@
         },
         "githubStars": {
           "label": "GitHub Stars",
-          "description": "Number of stars on the GitHub repository"
+          "description": "GitHubリポジトリのスター数"
         },
         "githubIssues": {
           "label": "GitHub Issues",
-          "description": "Number of issues on the GitHub repository"
+          "description": "GitHubリポジトリのIssues数"
         },
         "createdAt": {
-          "label": "Created At",
-          "description": "When the package was created"
+          "label": "作成日",
+          "description": "パッケージが作成された日時"
         }
       },
       "values": {
@@ -1426,15 +1426,15 @@
     "file_size_warning": "{size} は比較制限の250KBを超えています",
     "compare_versions": "diff",
     "compare_versions_title": "最新バージョンと比較",
-    "comparing_versions_label": "Comparing versions...",
-    "version_back_to_package": "Back to package",
-    "version_error_message": "Failed to compare versions.",
+    "comparing_versions_label": "バージョンを比較中...",
+    "version_back_to_package": "パッケージに戻る",
+    "version_error_message": "バージョンの比較に失敗しました。",
     "version_invalid_url_format": {
-      "hint": "Invalid comparison URL. Use format: {0}",
-      "from_version": "from",
-      "to_version": "to"
+      "hint": "無効な比較URLです。形式: {0}",
+      "from_version": "比較元",
+      "to_version": "比較先"
     },
-    "version_selector_title": "Compare with version",
+    "version_selector_title": "バージョンと比較",
     "summary": "要約",
     "deps_count": "依存関係 {count} 件",
     "dependencies": "依存関係",
@@ -1461,17 +1461,17 @@
     "select_file_prompt": "サイドバーからファイルを選択してdiffを表示",
     "close_files_panel": "ファイルパネルを閉じる",
     "filter_files_label": "変更タイプでファイルをフィルタリング",
-    "change_ratio": "Change ratio",
-    "char_edits": "Char edits",
-    "diff_distance": "Diff distance",
-    "loading_diff": "Loading diff...",
-    "loading_diff_error": "Failed to load diff",
-    "merge_modified_lines": "Merge modified lines",
-    "no_content_changes": "No content changes detected",
-    "options": "Options",
-    "view_file": "View file",
-    "view_in_code_browser": "View in code browser",
-    "word_wrap": "Word wrap"
+    "change_ratio": "変更率",
+    "char_edits": "文字編集数",
+    "diff_distance": "差分距離",
+    "loading_diff": "差分を読み込み中...",
+    "loading_diff_error": "差分の読み込みに失敗しました",
+    "merge_modified_lines": "変更行をマージ",
+    "no_content_changes": "コンテンツの変更は検出されませんでした",
+    "options": "オプション",
+    "view_file": "ファイルを表示",
+    "view_in_code_browser": "コードブラウザで表示",
+    "word_wrap": "右端で折り返す"
   },
   "pds": {
     "title": "npmx.social",
@@ -1612,26 +1612,26 @@
     }
   },
   "translation_status": {
-    "title": "translation status",
-    "generated_at": "Generation date: {date}",
-    "welcome": "If you're interested in helping us to translate {npmx} into one of the languages listed below, you've come to the right place! This auto-updating page always lists all the content that could use your help right now.",
-    "p1": "We use {lang} as the default language, with a total of {count}. If you'd like to help add translations, locate the language in {bylang} and expand the details.",
-    "p1_lang": "American English (en-US)",
-    "p1_count": "0 messages | 1 message |{count} messages",
-    "p2": "Before starting, please read our {guide} to learn about our translation process and how you can get involved.",
-    "guide": "localization (i18n) guide",
-    "by_locale": "Translation progress by locale",
-    "by_file": "Translation progress by file",
-    "complete_text": "This translation is complete, amazing job!",
-    "missing_text": "missing",
-    "missing_keys": "There is no missing translations | Missing translation | Missing translations",
-    "progress_label": "Progress status for {locale}",
+    "title": "翻訳状況",
+    "generated_at": "生成日: {date}",
+    "welcome": "あなたが {npmx} の翻訳に興味があるのだとしたら、ここは最適な場所です！このページは自動的に更新され、あなたが今すぐ翻訳に協力できるすべてのコンテンツがリスト化されています。",
+    "p1": "npmx はデフォルト言語として {lang} を使用しており、合計 {count} 件あります。翻訳に協力したい場合は、{bylang} から言語を探して、詳細情報を展開してください。",
+    "p1_lang": "アメリカ英語 (en-US)",
+    "p1_count": "0 メッセージ | 1 メッセージ | {count} メッセージ",
+    "p2": "開始する前に、翻訳プロセスと参加方法について説明した {guide} を読んでください。",
+    "guide": "ローカライズ (i18n) ガイド",
+    "by_locale": "言語別の翻訳進捗",
+    "by_file": "ファイル別の翻訳進捗",
+    "complete_text": "この言語の翻訳は完了しています。素晴らしい！",
+    "missing_text": "未翻訳",
+    "missing_keys": "未翻訳はありません | 未翻訳 1 件 | 未翻訳 {count} 件",
+    "progress_label": "{locale} の進捗状況",
     "table": {
-      "file": "File",
-      "status": "Status",
-      "error": "Error while loading file list.",
-      "empty": "No files found",
-      "file_link": "Edit {file} ({lang}) on GitHub"
+      "file": "ファイル",
+      "status": "ステータス",
+      "error": "ファイルリストの読み込み中にエラーが発生しました。",
+      "empty": "ファイルが見つかりません",
+      "file_link": "GitHubで {file} ({lang}) を編集"
     }
   },
   "vacations": {
@@ -1669,71 +1669,71 @@
     }
   },
   "action_bar": {
-    "title": "action bar",
-    "selection": "0 selected | 1 selected | {count} selected",
-    "shortcut": "Press \"{key}\" to focus actions",
-    "button_close_aria_label": "Close action bar"
+    "title": "アクションバー",
+    "selection": "0 選択済み | 1 選択済み | {count} 選択済み",
+    "shortcut": "\"\"\"{key}\"\" を押してアクションにフォーカス\"",
+    "button_close_aria_label": "アクションバーを閉じる"
   },
   "logo_menu": {
-    "copy_svg": "Copy logo as SVG",
-    "copied": "Copied!",
-    "browse_brand": "Browse brand kit"
+    "copy_svg": "ロゴを SVG としてコピー",
+    "copied": "コピーしました！",
+    "browse_brand": "ブランドキットを見る"
   },
   "brand": {
-    "title": "Brand",
-    "heading": "brand",
-    "meta_description": "npmx brand guidelines, logos, colors, and typography for use in press and media.",
-    "intro": "Resources and guidelines for using the npmx brand in your projects, articles, and media.",
+    "title": "ブランド",
+    "heading": "ブランド",
+    "meta_description": "報道・メディア向けのnpmxブランドガイドライン、ロゴ、カラー、タイポグラフィ。",
+    "intro": "プロジェクト、記事、メディアでnpmxブランドを使用するためのリソースとガイドライン。",
     "logos": {
-      "title": "logos",
-      "description": "Download npmx logos in SVG and PNG formats. Use the appropriate variant for your background.",
-      "wordmark": "FULL WORDMARK",
-      "wordmark_alt": "npmx full wordmark logo with blue slash on dark background",
-      "wordmark_light_alt": "npmx full wordmark logo with accent slash on light background",
-      "mark": "LOGO MARK",
-      "mark_alt": "npmx logo mark with dot and slash on dark background",
-      "mark_light_alt": "npmx logo mark with dot and slash on light background",
-      "on_dark": "on dark",
-      "on_light": "on light",
+      "title": "ロゴ",
+      "description": "npmxロゴをSVGおよびPNG形式でダウンロードできます。背景に合わせて適切なバリアントを使用してください。",
+      "wordmark": "フルワードマーク",
+      "wordmark_alt": "ダーク背景の青いスラッシュ付きnpmxフルワードマークロゴ",
+      "wordmark_light_alt": "ライト背景のアクセントスラッシュ付きnpmxフルワードマークロゴ",
+      "mark": "ロゴマーク",
+      "mark_alt": "ダーク背景のドットとスラッシュ付きnpmxロゴマーク",
+      "mark_light_alt": "ライト背景のドットとスラッシュ付きnpmxロゴマーク",
+      "on_dark": "ダーク背景用",
+      "on_light": "ライト背景用",
       "download_svg": "SVG",
       "download_png": "PNG",
-      "download_svg_aria": "Download {name} as SVG",
-      "download_png_aria": "Download {name} as PNG"
+      "download_svg_aria": "{name} をSVGとしてダウンロード",
+      "download_png_aria": "{name} をPNGとしてダウンロード"
     },
     "customize": {
-      "title": "customize your logo",
-      "description": "Preview the npmx logo with your accent color and background. The preview reflects your current settings — pick a color, toggle the background, and download.",
-      "accent_label": "accent",
-      "bg_label": "background",
-      "download_svg_aria": "Download customized logo as SVG",
-      "download_png_aria": "Download customized logo as PNG"
+      "title": "ロゴのカスタマイズ",
+      "description": "アクセントカラーと背景を使用してnpmxロゴをプレビューできます。プレビューには現在の設定が反映されます。色を選択し、背景を切り替えてダウンロードしてください。",
+      "accent_label": "アクセント",
+      "bg_label": "背景",
+      "download_svg_aria": "カスタマイズしたロゴをSVGとしてダウンロード",
+      "download_png_aria": "カスタマイズしたロゴをPNGとしてダウンロード"
     },
     "typography": {
-      "title": "typography",
-      "description": "npmx uses the Geist font family by Vercel for both interface text and code.",
+      "title": "タイポグラフィ",
+      "description": "npmxはインターフェースのテキストとコードの両方にVercelのGeistフォントファミリーを使用しています。",
       "sans": "Geist Sans",
-      "sans_desc": "Used for body text and UI elements.",
+      "sans_desc": "本文やUI要素に使用されます。",
       "mono": "Geist Mono",
-      "mono_desc": "Used for code, headings, and technical content.",
+      "mono_desc": "コード、見出し、技術的なコンテンツに使用されます。",
       "pangram": "The quick brown fox jumps over the lazy dog",
       "numbers": "0123456789"
     },
     "guidelines": {
-      "title": "just a note",
-      "message": "Accessibility matters to us, and we would love you to follow us in this vision. When using mentioned media, ensure there is enough contrast against the background, and don't go smaller than 24px. If you need any other resources or additional information about the project, feel free to reach us at {link}.",
+      "title": "注意点",
+      "message": "私たちにとってアクセシビリティはとても重要です。あなたもこのビジョンにぜひ協力してください。メディアを使用する際は、背景に対して十分なコントラストを確保し、24px未満にならないようにしてください。その他のリソースやプロジェクトに関する追加情報が必要な場合は、{link}までご連絡ください。",
       "discord_link_text": "chat.npmx.dev"
     }
   },
-  "alt_logo_kawaii": "A cute, rounded, and colorful version of the npmx logo.",
+  "alt_logo_kawaii": "npmxロゴのキュートで丸みのあるカラフルなバージョン",
   "changelog": {
-    "pre_release": "Pre-release",
-    "draft": "Draft",
-    "no_logs": "Sorry, this package does not publish changelogs or its changelog format is not supported.",
+    "pre_release": "プレリリース",
+    "draft": "下書き",
+    "no_logs": "このパッケージはchangelogを公開していないか、形式がサポートされていません。",
     "error": {
-      "p1": "Sorry, the changelog for {package} couldn't be loaded",
-      "p2": "Please try again later or {viewon}"
+      "p1": "{package} のchangelogを読み込めませんでした",
+      "p2": "後でもう一度試すか、{viewon} を確認してください"
     },
-    "rate_limit_ungh": "Sorry, Github's rate limit has been hit, try again in a moment",
-    "version_unavailable": "The requested version is not available."
+    "rate_limit_ungh": "GitHubのレート制限に達しました。しばらくしてから再度試してください。",
+    "version_unavailable": "リクエストされたバージョンは利用できません。"
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
N/A

### 🧭 Context

<!-- Brief background and why this change is needed -->
Updated overdue Japanese translation for new strings (+326 keys!)
<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
- Translated all new strings
- I skipped `vacation.*` keys since there was actually my previous translations here: https://github.com/npmx-dev/npmx.dev/pull/1461#issuecomment-3895689133 I'll revive them later 🪦🙂

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
