### PR TITLE
fix: always color replaceable packages as orange

### DIFF
--- a/app/components/Package/Dependencies.vue
+++ b/app/components/Package/Dependencies.vue
@@ -79,8 +79,8 @@ function getDepVersionTooltip(dep: string, version: string) {
 function getDepVersionClass(dep: string) {
   const outdated = outdatedDeps.value[dep]
   if (outdated) return getVersionClass(outdated)
-  if (getVulnerableDepInfo(dep) || getDeprecatedDepInfo(dep)) return getVersionClass(undefined)
   if (replacementDeps.value[dep]) return 'text-amber-700 dark:text-amber-500'
+  if (getVulnerableDepInfo(dep) || getDeprecatedDepInfo(dep)) return getVersionClass(undefined)
   return getVersionClass(undefined)
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

Before:

<img width="408" height="122" alt="image" src="https://github.com/user-attachments/assets/9cd4f6cb-bcde-4b0f-9526-3452f7284b44" />

After:

<img width="390" height="117" alt="image" src="https://github.com/user-attachments/assets/ccd9a6cc-02af-4511-b3ba-f5c13cd56742" />





<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
