### PR TITLE
feat: set cursor-pointer on buttons

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -452,7 +452,7 @@ The command palette is a first-class navigation surface. When you add a new user
 
 ### Cursor and navigation
 
-**npmx** uses `cursor: pointer` only for links to match users’ everyday experience. For all other interactive elements, including buttons, use the default cursor (_or another appropriate cursor to indicate state_).
+**npmx** uses `cursor: pointer` for links and buttons to match users’ everyday experience. For all other interactive elements, use the default cursor (_or another appropriate cursor to indicate state_).
 
 > [!NOTE]
 > A link is any element that leads to another content (_go to another page, authorize_)

--- a/app/components/Button/Base.vue
+++ b/app/components/Button/Base.vue
@@ -44,7 +44,7 @@ defineExpose({
 <template>
   <button
     ref="el"
-    class="group gap-x-1 items-center justify-center font-mono border border-border rounded-md transition-all duration-200 disabled:(opacity-40 cursor-not-allowed border-transparent)"
+    class="group gap-x-1 items-center justify-center font-mono border border-border rounded-md transition-all duration-200 cursor-pointer disabled:(opacity-40 cursor-not-allowed border-transparent)"
     :class="{
       'inline-flex': !block,
       'flex': block,

--- a/app/components/Compare/FacetBarChart.vue
+++ b/app/components/Compare/FacetBarChart.vue
@@ -152,6 +152,7 @@ const config = computed<VueUiHorizontalBarConfig>(() => {
           })
         },
       },
+      useCursorPointer: true,
     },
     skeletonDataset: skeletonDataset.value,
     skeletonConfig: {

--- a/app/components/Compare/FacetScatterChart.vue
+++ b/app/components/Compare/FacetScatterChart.vue
@@ -166,6 +166,7 @@ const config = computed<VueUiScatterConfig>(() => {
           })
         },
       },
+      useCursorPointer: true,
     },
     style: {
       backgroundColor: colors.value.bg,

--- a/app/components/InstantSearch.vue
+++ b/app/components/InstantSearch.vue
@@ -29,7 +29,11 @@ onPrehydrate(el => {
           <strong>{{ $t('search.instant_search_on') }}</strong>
         </template>
         <template #action>
-          <button type="button" class="underline" @click="settings.instantSearch = false">
+          <button
+            type="button"
+            class="underline cursor-pointer"
+            @click="settings.instantSearch = false"
+          >
             {{ $t('search.instant_search_turn_off') }}
           </button>
         </template>
@@ -44,7 +48,11 @@ onPrehydrate(el => {
           <strong>{{ $t('search.instant_search_off') }}</strong>
         </template>
         <template #action>
-          <button type="button" class="underline" @click="settings.instantSearch = true">
+          <button
+            type="button"
+            class="underline cursor-pointer"
+            @click="settings.instantSearch = true"
+          >
             {{ $t('search.instant_search_turn_on') }}
           </button>
         </template>

--- a/app/components/Package/TimelineChart.vue
+++ b/app/components/Package/TimelineChart.vue
@@ -411,6 +411,7 @@ const config = computed<VueUiXyConfig>(() => {
               },
             }),
         },
+        useCursorPointer: true,
       },
       zoom: {
         show: settings.value.timelineChart.showZoom,

--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -1460,6 +1460,7 @@ const chartConfig = computed<VueUiXyConfig>(() => {
               },
             }),
         },
+        useCursorPointer: true,
       },
       grid: {
         position: 'start',

--- a/app/components/Package/VersionDistribution.vue
+++ b/app/components/Package/VersionDistribution.vue
@@ -238,6 +238,7 @@ const chartConfig = computed<VueUiXyConfig>(() => {
               },
             }),
         },
+        useCursorPointer: true,
       },
       grid: {
         stroke: colors.value.border,


### PR DESCRIPTION
### 🔗 Linked issue

Partially resolves #1760

### 🧭 Context

[This commit](https://github.com/thegreatalxx/npmx.dev/commit/391d28e215c5b22dfab3812877f3ed8480349a12) removed `cursor: pointer` from `ButtonBase`. The reason being, [the W3C spec says](https://www.w3.org/TR/css-ui-3/#ref-for-valdef-cursor-pointer):

> The cursor is a pointer that indicates a link.

The commit was on Valentine's Day, but it is far from being something I love.

`CONTRIBUTING.md` says:

> **npmx** uses `cursor: pointer` only for links to match users’ everyday experience. For all other interactive elements, including buttons, use the default cursor (_or another appropriate cursor to indicate state_).

And the linked issue states in its conclusion:

> Based on all this, we're returning the pointer cursor for all interactive elements (without any distinction or definition of what a link is and what a button is). This needs to be updated in the contributing guide and updated throughout our site.

There was [a similar PR (#2303)](https://github.com/npmx-dev/npmx.dev/pull/2303) that attempted to do this only for the Download button.
And [another PR (#2202)](https://github.com/npmx-dev/npmx.dev/pull/2303) which was closed for potential spam.

To make things worse, at the moment some buttons and dropdowns arbitrarily have `cursor: pointer` enabled, while more deserving buttons don't:

<img width="312" height="441" alt="image" src="https://github.com/user-attachments/assets/fa204ae0-a26c-4930-b5ab-3d0a79fb0190" />

1. Download button - ❌No pointer cursor
2. Package manager dropdown button - ✔`cursor: pointer` AND a fancy mousepress animation
3. Copy button - ❌No pointer cursor
4. Sections dropdown button - ❌No pointer cursor

If we're being inconsistent, let's at least err on the side of a better user experience.

I get that the plan was to adhere to the specification / default behaviour, but consider this: if I cared about being "official" more than the UX, I would be using npmjs.com instead of this awesome site.

### 📚 Description

This PR adds `cursor: pointer` to some of the pure buttons that one is likely to encounter in the first few pages. Normal buttons + the command palette. My philosophy being, "A pointer cursor indicates that something will happen on clicking the element".

I specifically didn't add it to the dropdowns in case that's another point of contention. I just wanna get this shipped soon so I can enjoy it as an end-user.

_W3C this, W3C that. WHO CARES, THE POINTER IS WATCHING. I feel like I'm taking crazy pills, but I'm not because I ran out of crazy pills, I need more._