### PR TITLE
fix(ui): improve layout of line charts

### DIFF
--- a/app/components/Package/TimelineChart.vue
+++ b/app/components/Package/TimelineChart.vue
@@ -293,6 +293,7 @@ const config = computed<VueUiXyConfig>(() => {
         color: colors.value.accent,
       },
       grid: {
+        position: 'start',
         showHorizontalLines: true,
         stroke: colors.value.border,
         labels: {

--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -1462,6 +1462,7 @@ const chartConfig = computed<VueUiXyConfig>(() => {
         },
       },
       grid: {
+        position: 'start',
         stroke: colors.value.border,
         showHorizontalLines: true,
         labels: {
@@ -1995,9 +1996,9 @@ watch([selectedGranularity, startDate, endDate], async () => {
               <!-- Overlay covering the chart area to hide line resizing when switching granularities recalculates VueUiXy scaleMax when estimation lines are necessary -->
               <rect
                 v-if="pending"
-                :x="svg.drawingArea.left"
+                :x="svg.drawingArea.left - 3"
                 :y="svg.drawingArea.top - 12"
-                :width="svg.drawingArea.width + 12"
+                :width="svg.drawingArea.width + 15"
                 :height="svg.drawingArea.height + 48"
                 :fill="colors.bg"
               />

--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -1392,7 +1392,7 @@ const chartConfig = computed<VueUiXyConfig>(() => {
     chart: {
       height: chartHeight.value,
       backgroundColor: colors.value.bg,
-      padding: { bottom: displayedGranularity.value === 'yearly' ? 84 : 64, right: 128 }, // padding right is set to leave space of last datapoint label(s)
+      padding: { bottom: displayedGranularity.value === 'yearly' ? 84 : 64, right: 145 }, // padding right is set to leave space of last datapoint label(s)
       userOptions: {
         buttons: {
           pdf: false,

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "0.1.20",
     "vue": "3.5.34",
-    "vue-data-ui": "3.19.6",
+    "vue-data-ui": "3.19.7",
     "vue-router": "5.0.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "0.1.20",
     "vue": "3.5.34",
-    "vue-data-ui": "3.19.7",
+    "vue-data-ui": "3.19.8",
     "vue-router": "5.0.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,8 +254,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@6.0.2)
       vue-data-ui:
-        specifier: 3.19.6
-        version: 3.19.6(vue@3.5.34)
+        specifier: 3.19.7
+        version: 3.19.7(vue@3.5.34)
       vue-router:
         specifier: 5.0.4
         version: 5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.34)
@@ -11362,8 +11362,11 @@ packages:
   vue-component-type-helpers@3.2.8:
     resolution: {integrity: sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==}
 
-  vue-data-ui@3.19.6:
-    resolution: {integrity: sha512-b2S9RjAqWSdPmdSb0TjBNXkto1xfw5UwVZmsuQsTV8qOatAhsGnDnoMIvgcfw2kzJ54IRSZauoFOQ9g9V/bdbg==}
+  vue-component-type-helpers@3.2.9:
+    resolution: {integrity: sha512-S3BiWYaLSzHxTpln665ELSrMR9UYmrIDUmhik7nVZxmJjTKL2/a+ew1hvGxksKelivm0ujjWfG1fYOiU/2e8rA==}
+
+  vue-data-ui@3.19.7:
+    resolution: {integrity: sha512-4ZpYg5SDpo11EyV59jvwa/cAFe6Oiz+LtwcAC60LTBANZO6x8F1GLo0i22TuZo3kKOxXN5TQFbVfwIQhg62i5w==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -16194,7 +16197,7 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
       type-fest: 2.19.0
       vue: 3.5.34(typescript@6.0.2)
-      vue-component-type-helpers: 3.2.8
+      vue-component-type-helpers: 3.2.9
 
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
@@ -24135,7 +24138,9 @@ snapshots:
 
   vue-component-type-helpers@3.2.8: {}
 
-  vue-data-ui@3.19.6(vue@3.5.34):
+  vue-component-type-helpers@3.2.9: {}
+
+  vue-data-ui@3.19.7(vue@3.5.34):
     dependencies:
       vue: 3.5.34(typescript@6.0.2)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,8 +254,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@6.0.2)
       vue-data-ui:
-        specifier: 3.19.7
-        version: 3.19.7(vue@3.5.34)
+        specifier: 3.19.8
+        version: 3.19.8(vue@3.5.34)
       vue-router:
         specifier: 5.0.4
         version: 5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.34)
@@ -11365,8 +11365,8 @@ packages:
   vue-component-type-helpers@3.2.9:
     resolution: {integrity: sha512-S3BiWYaLSzHxTpln665ELSrMR9UYmrIDUmhik7nVZxmJjTKL2/a+ew1hvGxksKelivm0ujjWfG1fYOiU/2e8rA==}
 
-  vue-data-ui@3.19.7:
-    resolution: {integrity: sha512-4ZpYg5SDpo11EyV59jvwa/cAFe6Oiz+LtwcAC60LTBANZO6x8F1GLo0i22TuZo3kKOxXN5TQFbVfwIQhg62i5w==}
+  vue-data-ui@3.19.8:
+    resolution: {integrity: sha512-jgJQijh1McxKyj9G71ddFEO0OyZ+vbN7GB9lcNxmwSlgEZqRpj3mEWWpYun7G61Ow4dMYj/xbWIsBxuPqaB4wg==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -24140,7 +24140,7 @@ snapshots:
 
   vue-component-type-helpers@3.2.9: {}
 
-  vue-data-ui@3.19.7(vue@3.5.34):
+  vue-data-ui@3.19.8(vue@3.5.34):
     dependencies:
       vue: 3.5.34(typescript@6.0.2)
 


### PR DESCRIPTION
This update allows to use the full real estate of the chart area for line charts.

The previous implementation used `config.chart.grid.position: 'middle'`, which positions datapoints in the middle of x slots, resulting in empty space when there are only a few periods to show. This layout is designed to have lines and bars coexist on a same chart, but is not ideal when there is only line types.

The `3.19.8` patch fixes layout issues when `config.chart.grid.position: 'start'`, now allowing its usage, and preventing white space on the sides.

| Before | After |
|-------|-------|
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/94d04214-d721-4806-b3d7-373c97838f7a" />|<img width="400" alt="image" src="https://github.com/user-attachments/assets/152b953e-78ef-42d6-b857-b7b289efa5de" />|
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/bba83db5-66fd-4ebb-b205-8a5be79309d8" />|<img width="400"  alt="image" src="https://github.com/user-attachments/assets/5c66ab7a-9553-45cc-a1c4-e3f644d9cc8f" />|

This change was made to the following components:
- TrendsChart (downloads modal, compare page)
- TimelineChart