### PR TITLE
feat: strip version info from the search query

### DIFF
--- a/app/composables/useParsedSearchQuery.ts
+++ b/app/composables/useParsedSearchQuery.ts
@@ -1,0 +1,21 @@
+import type { ParsedSearchQuery } from '~/utils/search'
+import { parseSearchQuery } from '~/utils/search'
+
+type ParsedSearchQueryRef = {
+  [K in keyof Required<ParsedSearchQuery>]: Ref<ParsedSearchQuery[K]>
+}
+
+/**
+ * Wrapper around `parseSearchQuery` that makes it reactive.
+ */
+export function useParsedSearchQuery(query: MaybeRefOrGetter<string>): ParsedSearchQueryRef {
+  const parsed = computed(() => parseSearchQuery(toValue(query)))
+
+  return {
+    name: computed(() => parsed.value.name),
+    specifier: computed(() => parsed.value.specifier),
+    scope: computed(() => parsed.value.scope),
+    version: computed(() => parsed.value.version),
+    trailing: computed(() => parsed.value.trailing),
+  }
+}

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -39,10 +39,12 @@ const parsedQuery = computed(() => {
   const q = query.value.trim()
   // Regex matches a (un)scoped package and optionally extracts versioning info using the following syntax: @scope/specifier@version
   // It makes use of 4 capture groups to extract this info.
-  const match = q.match(/^(?:@([^/]+)\/)?([^/@ ]+)(?:@([^ ]*))?(.*)/)
+  const match = q.match(
+    /^(?:@(?<scope>[^/]+)\/)?(?<specifier>[^/@ ]+)(?:@(?<version>[^ ]*))?(?<trailing>.*)/,
+  )
   if (!match) return { scope: null, name: q, version: null, strippedQuery: q }
 
-  const [, scope, specifier, version, trailing] = match
+  const { scope, specifier, version, trailing } = match.groups ?? {}
   // Reconstruct the query without the version info, essentially stripping the version data:
   // anything directly after the @ for the version specifier is stripped.
   const name = scope ? `@${scope}/${specifier}` : (specifier ?? '')

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -51,6 +51,9 @@ const parsedQuery = computed(() => {
   return { scope: scope ?? null, name: name, version: version || null, strippedQuery }
 })
 
+const packageScope = computed(() => parsedQuery.value.scope)
+const strippedQuery = computed(() => parsedQuery.value.strippedQuery)
+
 // Track if page just loaded (for hiding "Searching..." during view transition)
 const hasInteracted = shallowRef(false)
 onMounted(() => {
@@ -210,7 +213,7 @@ const {
   suggestions: validatedSuggestions,
   packageAvailability,
 } = useSearch(
-  query,
+  strippedQuery,
   searchProvider,
   () => ({
     size: requestedSize.value,
@@ -304,14 +307,6 @@ const isValidPackageName = computed(() => isValidNewPackageName(query.value.trim
 
 // Get connector state
 const { isConnected, npmUser, listOrgUsers } = useConnector()
-
-// Check if this is a scoped package and extract scope
-const packageScope = computed(() => {
-  const q = query.value.trim()
-  if (!q.startsWith('@')) return null
-  const match = q.match(/^@([^/]+)\//)
-  return match ? match[1] : null
-})
 
 // Track org membership for scoped packages
 const orgMembership = ref<Record<string, boolean>>({})
@@ -685,7 +680,7 @@ defineOgImageComponent('Default', {
           <!-- No results found -->
           <div v-else-if="status === 'success' || status === 'error'" role="status" class="py-12">
             <p class="text-fg-muted font-mono mb-6 text-center">
-              {{ $t('search.no_results', { query }) }}
+              {{ $t('search.no_results', { query: strippedQuery }) }}
             </p>
 
             <!-- User/Org suggestions when no packages found -->

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -33,28 +33,15 @@ const updateUrlPage = debounce((page: number) => {
 const { model: searchQuery, provider: searchProvider } = useGlobalSearch()
 const query = computed(() => searchQuery.value)
 
-// Parses the raw search query to extract package info, such as scope, name, version.
-// Uses this info to provide a strippedQuery (the query, but without version info) that is used for searching.
-const parsedQuery = computed(() => {
-  const q = query.value.trim()
-  // Regex matches a (un)scoped package and optionally extracts versioning info using the following syntax: @scope/specifier@version
-  // It makes use of 4 capture groups to extract this info.
-  const match = q.match(
-    /^(?:@(?<scope>[^/]+)\/)?(?<specifier>[^/@ ]+)(?:@(?<version>[^ ]*))?(?<trailing>.*)/,
-  )
-  if (!match) return { scope: null, name: q, version: null, strippedQuery: q }
+const {
+  scope: packageScope,
+  name: packageName,
+  trailing: queryTrailing,
+} = useParsedSearchQuery(query)
 
-  const { scope, specifier, version, trailing } = match.groups ?? {}
-  // Reconstruct the query without the version info, essentially stripping the version data:
-  // anything directly after the @ for the version specifier is stripped.
-  const name = scope ? `@${scope}/${specifier}` : (specifier ?? '')
-  const strippedQuery = `${name} ${trailing ?? ''}`.trim()
-
-  return { scope: scope ?? null, name: name, version: version || null, strippedQuery }
-})
-
-const packageScope = computed(() => parsedQuery.value.scope)
-const strippedQuery = computed(() => parsedQuery.value.strippedQuery)
+const versionStrippedQuery = computed(() =>
+  `${packageName.value} ${queryTrailing.value ?? ''}`.trim(),
+)
 
 // Track if page just loaded (for hiding "Searching..." during view transition)
 const hasInteracted = shallowRef(false)
@@ -103,7 +90,7 @@ const visibleResults = computed(() => {
     objects = objects.filter(r => !isPlatformSpecificPackage(r.package.name))
   }
 
-  const q = query.value.trim().toLowerCase()
+  const q = versionStrippedQuery.value.trim().toLowerCase()
   if (!q) {
     return objects === raw.objects ? raw : { ...raw, objects }
   }
@@ -215,7 +202,7 @@ const {
   suggestions: validatedSuggestions,
   packageAvailability,
 } = useSearch(
-  strippedQuery,
+  versionStrippedQuery,
   searchProvider,
   () => ({
     size: requestedSize.value,
@@ -362,7 +349,7 @@ const claimPackageModalRef = useTemplateRef('claimPackageModalRef')
 
 /** Check if there's an exact package match in results */
 const hasExactPackageMatch = computed(() => {
-  const q = query.value.trim().toLowerCase()
+  const q = versionStrippedQuery.value.trim().toLowerCase()
   if (!q || !visibleResults.value) return false
   return visibleResults.value.objects.some(r => r.package.name.toLowerCase() === q)
 })
@@ -682,7 +669,7 @@ defineOgImageComponent('Default', {
           <!-- No results found -->
           <div v-else-if="status === 'success' || status === 'error'" role="status" class="py-12">
             <p class="text-fg-muted font-mono mb-6 text-center">
-              {{ $t('search.no_results', { query: strippedQuery }) }}
+              {{ $t('search.no_results', { query: versionStrippedQuery }) }}
             </p>
 
             <!-- User/Org suggestions when no packages found -->
@@ -718,7 +705,7 @@ defineOgImageComponent('Default', {
           <PackageList
             v-if="displayResults.length > 0 && !isRateLimited"
             :results="displayResults"
-            :search-query="query"
+            :search-query="versionStrippedQuery"
             :filters="filters"
             search-context
             heading-level="h2"

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -40,7 +40,7 @@ const {
 } = useParsedSearchQuery(query)
 
 const versionStrippedQuery = computed(() =>
-  `${packageName.value} ${queryTrailing.value ?? ''}`.trim(),
+  `${packageName.value}${queryTrailing.value ?? ''}`.trim(),
 )
 
 // Track if page just loaded (for hiding "Searching..." during view transition)

--- a/app/utils/search.ts
+++ b/app/utils/search.ts
@@ -1,0 +1,47 @@
+export interface ParsedSearchQuery {
+  /**
+   * The package name, in the format:
+   * - unscoped: `nuxt`
+   * - scoped: `@nuxt/devtools`
+   */
+  name: string
+  /**
+   * The package specifier, e.g.
+   * - `nuxt` -> `nuxt`
+   * - `@nuxt/devtools` -> `devtools`
+   */
+  specifier: string
+  /**
+   * The package scope (or org), e.g.
+   * - `nuxt` -> `undefined`
+   * - `@nuxt/devtools` -> `nuxt`
+   */
+  scope?: string
+  /**
+   * Optionally, the version info if specified using the syntax:
+   * - `nuxt@^4.0.0` -> `^4.0.0`
+   * - `@nuxt/devtools@latest` -> `latest`
+   */
+  version?: string
+  /**
+   * The untrimmed trailing text after the package query.
+   */
+  trailing?: string
+}
+
+export function parseSearchQuery(query: string): ParsedSearchQuery {
+  const q = query.trim()
+
+  // Regex matches a (un)scoped package and optionally extracts versioning info and trailing text using the following syntax: @scope/specifier@version
+  // It makes use of 4 capture groups to extract this info.
+  const match = q.match(
+    /^(?:@(?<scope>[^/]+)\/)?(?<specifier>[^/@ ]+)(?:@(?<version>[^ ]*))?(?<trailing>.*)/,
+  )
+  if (!match) return { name: q, specifier: q }
+
+  const { scope, specifier, version, trailing } = match.groups ?? {}
+  if (!specifier) return { name: q, specifier: q }
+
+  const name = scope ? `@${scope}/${specifier}` : specifier
+  return { name, specifier, scope, version, trailing }
+}

--- a/test/unit/app/utils/search.spec.ts
+++ b/test/unit/app/utils/search.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { parseSearchQuery } from '../../../../app/utils/search'
+
+describe('parseSearchQuery', () => {
+  it('parses unscoped package names', () => {
+    expect(parseSearchQuery('nuxt')).toEqual({
+      name: 'nuxt',
+      specifier: 'nuxt',
+      scope: undefined,
+      version: undefined,
+      trailing: '',
+    })
+  })
+
+  it('parses scoped package names', () => {
+    expect(parseSearchQuery('@nuxt/devtools')).toEqual({
+      name: '@nuxt/devtools',
+      specifier: 'devtools',
+      scope: 'nuxt',
+      version: undefined,
+      trailing: '',
+    })
+  })
+
+  it('parses unscoped package names with version', () => {
+    expect(parseSearchQuery('nuxt@^4.0.0')).toEqual({
+      name: 'nuxt',
+      specifier: 'nuxt',
+      scope: undefined,
+      version: '^4.0.0',
+      trailing: '',
+    })
+    expect(parseSearchQuery('next@15.3.0-canary.1')).toEqual({
+      name: 'next',
+      specifier: 'next',
+      scope: undefined,
+      version: '15.3.0-canary.1',
+      trailing: '',
+    })
+  })
+
+  it('parses scoped package names with version', () => {
+    expect(parseSearchQuery('@nuxt/devtools@latest')).toEqual({
+      name: '@nuxt/devtools',
+      specifier: 'devtools',
+      scope: 'nuxt',
+      version: 'latest',
+      trailing: '',
+    })
+  })
+
+  it('returns trailing text', () => {
+    expect(parseSearchQuery('nuxt keyword:frontend')).toEqual({
+      name: 'nuxt',
+      specifier: 'nuxt',
+      scope: undefined,
+      version: undefined,
+      trailing: ' keyword:frontend',
+    })
+    expect(parseSearchQuery('@nuxt/devtools@latest keyword:devtools')).toEqual({
+      name: '@nuxt/devtools',
+      specifier: 'devtools',
+      scope: 'nuxt',
+      version: 'latest',
+      trailing: ' keyword:devtools',
+    })
+  })
+})


### PR DESCRIPTION
See #1626

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Partially addresses #1416

### 🧭 Context

<!-- Brief background and why this change is needed -->

Currently, when searching for a package along with version info (e.g. when copying a package name from the output of a package manager) it just returns random results, instead of useful ones. (e.g. https://npmx.dev/search?q=nuxt@3.4.1)

This pr strips the version info from the query to improve search results.

<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This pr implements a new regex query to extract essential date from the search query on the search page, such as package scope (which replaces an existing method), package specifier and (optionally) version info. The query is then reconstructed without version info to support the existing search api. It can currently parse a package name in the following format:
```
@scope/specifier@version
```

An object containing the separate parts of the query is exposed as the `parsedQuery` ref and it is able to be used for other features. (Such as implementing the other part of the linked issue)

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
