### PR TITLE
fix: package sub-banner no longer blocks "connect" dropdown

### DIFF
--- a/app/components/Package/Header.vue
+++ b/app/components/Package/Header.vue
@@ -243,7 +243,7 @@ useShortcuts({
   </header>
   <div
     ref="header"
-    class="w-full bg-bg sticky top-14 z-50 border-b border-border pt-2"
+    class="w-full bg-bg sticky top-14 z-40 border-b border-border pt-2"
     :class="[$style.packageHeader]"
     data-testid="package-subheader"
   >

--- a/test/e2e/interactions.spec.ts
+++ b/test/e2e/interactions.spec.ts
@@ -139,6 +139,40 @@ test.describe('Package Page', () => {
       ).toBe(true)
     }
   })
+
+  test('AccountMenu dropdown items are clickable on package pages', async ({ page, goto }) => {
+    await goto('/package/vue', { waitUntil: 'hydration' })
+
+    await page.getByRole('button', { name: /^connect$/i }).click()
+    const items = page.getByRole('menuitem')
+    await expect(items.first()).toBeVisible()
+
+    // Verify each menu item is the topmost element at its own center.
+    for (const item of await items.all()) {
+      const box = await item.boundingBox()
+      if (!box) throw new Error('Menu item has no bounding box')
+      const cx = box.x + box.width / 2
+      const cy = box.y + box.height / 2
+
+      const hit = await page.evaluate(
+        ({ x, y }) => {
+          const el = document.elementFromPoint(x, y)
+          return {
+            insideMenuitem: el?.closest('[role="menuitem"]') !== null,
+            occluderTag: el?.tagName,
+            occluderClass: typeof el?.className === 'string' ? el.className.slice(0, 100) : '',
+            occluderText: el?.textContent?.trim().slice(0, 60),
+          }
+        },
+        { x: cx, y: cy },
+      )
+
+      expect(
+        hit.insideMenuitem,
+        `Menu item center (${cx.toFixed(0)}, ${cy.toFixed(0)}) is occluded by <${hit.occluderTag} class="${hit.occluderClass}">${hit.occluderText ? ` "${hit.occluderText}"` : ''}`,
+      ).toBe(true)
+    }
+  })
 })
 
 test.describe('Search Pages', () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Fixes https://github.com/npmx-dev/npmx.dev/issues/2747

### 🧭 Context

<!-- Brief background and why this change is needed -->

The "connect" dropdown menu items were obscured by the banner on the package page:

<img width="443" height="193" alt="image" src="https://github.com/user-attachments/assets/e7347412-60bc-44d4-abe5-7991d0109672" />

<img width="468" height="221" alt="image" src="https://github.com/user-attachments/assets/ae28d82d-ab2b-433f-877e-942729dffada" />


<!-- High-level summary of what changed -->



### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

This change adjusted the z-index of the banner from z-50 to z-40 to ensure the dropdown is drawn above the banner.
As requested in #2747, I also added a new test case to catch regressions of this (it fails w/o 
the change and passes with it).

Please let me know if there are any issues, thanks!

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
