### PR TITLE
fix(i18n): add missing Dutch translations

### DIFF
--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -1634,36 +1634,36 @@
     }
   },
   "vacations": {
-    "title": "EN TEXT TO REPLACE: on vacation",
-    "meta_description": "EN TEXT TO REPLACE: The npmx team was recharging. Discord reopened after a week.",
-    "heading": "EN TEXT TO REPLACE: recharging",
-    "subtitle": "EN TEXT TO REPLACE: we were building npmx at a pace that was costing {some} of us sleep. we didn't want that to be the norm! so we took a week off. together.",
-    "illustration_alt": "EN TEXT TO REPLACE: a single row of cosy icons",
-    "poke_log": "EN TEXT TO REPLACE: Poke the campfire",
+    "title": "op vakantie",
+    "meta_description": "Het npmx-team was aan het opladen. Discord is na een week weer geopend.",
+    "heading": "even opladen",
+    "subtitle": "we bouwden aan npmx in een tempo dat {some} van ons hun nachtrust kostte. we wilden niet dat het de norm werd! dus namen we een weekje vrij. samen.",
+    "illustration_alt": "een enkele rij met gezellige icoontjes",
+    "poke_log": "Pook het kampvuur op",
     "what": {
-      "title": "EN TEXT TO REPLACE: what happened",
-      "p1": "EN TEXT TO REPLACE: discord was closed {dates}.",
-      "dates": "EN TEXT TO REPLACE: February 14 – 21",
-      "p2": "EN TEXT TO REPLACE: all invite links were gone and channels were locked – except {garden}, which stayed open for folks who wanted to keep hanging out.",
-      "garden": "EN TEXT TO REPLACE: #garden"
+      "title": "wat er is gebeurd",
+      "p1": "discord was gesloten van {dates}.",
+      "dates": "14 – 21 februari",
+      "p2": "alle uitnodigingslinks waren weg en de kanalen waren vergrendeld – behalve {garden}, dat open bleef voor mensen die gezellig wilden blijven hangen.",
+      "garden": "#garden"
     },
     "meantime": {
-      "title": "EN TEXT TO REPLACE: in the meantime",
-      "p1": "EN TEXT TO REPLACE: {site} and {repo} stayed open – people still dug in, filed some issues, opened a few PRs, but mainly everyone spent time somewhere near a cosy fireplace.",
-      "repo_link": "EN TEXT TO REPLACE: the repo"
+      "title": "in de tussentijd",
+      "p1": "{site} en {repo} bleven open – er werd nog steeds hard gewerkt, issues aangemaakt en een paar PR's geopend, dat wel, maar de meesten brachten hun tijd door in de buurt van een gezellige open haard.",
+      "repo_link": "de repository"
     },
     "return": {
-      "title": "EN TEXT TO REPLACE: we came back!",
-      "p1": "EN TEXT TO REPLACE: we came back recharged and ready for the final push to March 3rd. {social} for updates.",
-      "social_link": "EN TEXT TO REPLACE: follow us on Bluesky"
+      "title": "we zijn weer terug!",
+      "p1": "we zijn weer terug, helemaal opgeladen en klaar voor de eindsprint naar 3 maart. {social} voor updates.",
+      "social_link": "volg ons op Bluesky"
     },
     "stats": {
-      "contributors": "EN TEXT TO REPLACE: Contributors",
-      "commits": "EN TEXT TO REPLACE: Commits",
-      "pr": "EN TEXT TO REPLACE: PRs Merged",
+      "contributors": "Bijdragers",
+      "commits": "Commits",
+      "pr": "Samengevoegde PR's",
       "subtitle": {
-        "some": "EN TEXT TO REPLACE: some",
-        "all": "EN TEXT TO REPLACE: all"
+        "some": "sommigen",
+        "all": "iedereen"
       }
     }
   },

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -384,14 +384,14 @@
     "size_increase": {
       "title_size": "Aanzienlijke toenamen in grootte sinds v{version}",
       "title_deps": "Aanzienlijke toename van het aantal dependencies sinds versie {version}",
-      "title_both": "Aanzienlijke toename in omvang en depen sinds v{version}",
+      "title_both": "Aanzienlijke toename in omvang en dependencies sinds v{version}",
       "size": "De installatiegrootte is toegenomen met {percent} ({size} groter)",
       "deps": "{count} meer dependencies"
     },
     "size_decrease": {
       "title_size": "Pakketgrootte is afgenomen sinds v{version}!",
       "title_deps": "Aantal dependencies is afgenomen sinds v{version}!",
-      "title_both": "De pakketgrootte en het aantal dependecies zijn sindsdien afgenomen v{version}!",
+      "title_both": "De pakketgrootte en het aantal dependencies zijn sindsdien afgenomen v{version}!",
       "size": "De installatiegrootte is met {percent} verminderd ({size} kleiner)",
       "deps": "{count} minder dependencies"
     },

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -1503,82 +1503,81 @@
   },
   "privacy_policy": {
     "title": "privacybeleid",
-    "last_updated": "EN TEXT TO REPLACE: Last updated: {date}",
-    "welcome": "EN TEXT TO REPLACE: Welcome to {app}. We are committed to protecting your privacy. This policy explains what data we collect, how we use it, and your rights regarding your information.",
+    "last_updated": "Laatst bijgewerkt: {date}",
+    "welcome": "Welkom bij {app}. Wij hechten veel waarde aan de bescherming van uw privacy. In dit beleid wordt uitgelegd welke gegevens wij verzamelen, hoe wij deze gebruiken en welke rechten u heeft met betrekking tot uw gegevens.",
     "cookies": {
       "what_are": {
-        "title": "EN TEXT TO REPLACE: What are cookies?",
-        "p1": "EN TEXT TO REPLACE: Cookies are small text files stored on your device when you visit a website. Their purpose is to enhance your browsing experience by remembering certain preferences and settings."
+        "title": "Wat zijn cookies?",
+        "p1": "Cookies zijn kleine tekstbestanden die op uw apparaat worden opgeslagen wanneer u een website bezoekt. Ze zijn bedoeld om uw surfervaring te verbeteren door bepaalde voorkeuren en instellingen te onthouden."
       },
       "types": {
-        "title": "EN TEXT TO REPLACE: What cookies do we use?",
-        "p1": "EN TEXT TO REPLACE: We only use {bold} for purposes strictly necessary for the site's functionality. We do not use third-party or advertising cookies.",
-        "bold": "EN TEXT TO REPLACE: essential technical cookies",
-        "li1": "EN TEXT TO REPLACE: {li11}{separator} {li12}",
-        "li2": "EN TEXT TO REPLACE: {li21}{separator} {li22}",
-        "separator": "EN TEXT TO REPLACE: :",
-        "cookie_vdpl": "EN TEXT TO REPLACE: __vdpl",
-        "cookie_vdpl_desc": "EN TEXT TO REPLACE: This cookie is used by our hosting provider (Vercel) for skew protection. It ensures you fetch assets from the correct deployment version if a new update is released while you are browsing. It does not track you.",
-        "cookie_h3": "EN TEXT TO REPLACE: h3",
-        "cookie_h3_desc": "EN TEXT TO REPLACE: This is our secure session cookie. It stores the OAuth access token when you connect your Atmosphere account. It is essential for maintaining your authenticated session."
+        "title": "Welke cookies gebruiken wij?",
+        "p1": "We gebruiken uitsluitend {bold} voor doeleinden die strikt noodzakelijk zijn voor de werking van de website. We maken geen gebruik van cookies van derden of advertentiecookies.",
+        "bold": "essentiële technische cookies",
+        "li1": "{li11}{separator} {li12}",
+        "li2": "{li21}{separator} {li22}",
+        "separator": ":",
+        "cookie_vdpl": "__vdpl",
+        "cookie_vdpl_desc": "Dit cookie wordt door onze hostingprovider (Vercel) gebruikt voor 'skew protection' (versiebeveiliging). Het zorgt ervoor dat je de juiste bestanden van de website laadt als er een nieuwe update wordt uitgebracht terwijl je de site bezoekt. Het volgt je niet.",
+        "cookie_h3": "h3",
+        "cookie_h3_desc": "Dit is ons beveiligde sessiecookie. Het slaat het OAuth-toegangstoken op wanneer je verbinding maakt met je Atmosphere-account. Dit cookie is essentieel om je ingelogde sessie te behouden."
       },
       "local_storage": {
-        "title": "EN TEXT TO REPLACE: Local storage",
-        "p1": "EN TEXT TO REPLACE: In addition to session cookies, we use your browser's {bold} to save your display preferences. This allows us to remember the theme (light/dark) and some other {settings} you have selected, so you don't have to reconfigure them on each visit.",
-        "bold": "EN TEXT TO REPLACE: Local Storage",
-        "p2": "EN TEXT TO REPLACE: This information is purely functional, stored only on your device, and {bold2}. We use it exclusively to improve your experience on our website.",
-        "bold2": "EN TEXT TO REPLACE: contains no personal data nor is it used to track you",
-        "settings": "EN TEXT TO REPLACE: settings"
+        "title": "Lokale opslag",
+        "p1": "Naast sessiecookies gebruiken we de {bold} van uw browser om uw weergavevoorkeuren op te slaan. Hierdoor kunnen we het thema (licht/donker) en enkele andere gekozen {settings} onthouden, zodat deze bij elk bezoek direct goed staan.",
+        "bold": "lokale opslag",
+        "p2": "Deze informatie is puur functional, wordt alleen op uw eigen apparaat opgeslagen en {bold2}. We gebruiken dit uitsluitend om uw ervaring op onze website te verbeteren.",
+        "bold2": "bevat geen persoonlijke gegevens en wordt niet gebruikt om u te volgen"
       },
       "management": {
-        "title": "EN TEXT TO REPLACE: Managing cookies",
-        "p1": "EN TEXT TO REPLACE: You can configure your browser to accept, reject, or delete cookies according to your preferences. However, please note that {bold}.",
-        "bold": "EN TEXT TO REPLACE: rejecting essential cookies may prevent full access to the application",
-        "p2": "EN TEXT TO REPLACE: Below are links with instructions for cookie management in the most commonly used browsers:",
-        "chrome": "EN TEXT TO REPLACE: Google Chrome (opens in a new window)",
-        "firefox": "EN TEXT TO REPLACE: Mozilla Firefox (opens in a new window)",
-        "edge": "EN TEXT TO REPLACE: Microsoft Edge (opens in a new window)"
+        "title": "Cookies beheren",
+        "p1": "U kunt uw browser zo instellen dat cookies naar uw voorkeur worden geaccepteerd, geweigerd of verwijderd. Houd er echter rekening mee dat {bold}.",
+        "bold": "het weigeren van essentiële cookies ertoe kan leiden dat u geen volledige toegang tot de applicatie heeft",
+        "p2": "Hieronder vindt u links met instructies voor het beheren van cookies in de meest gebruikte browsers:",
+        "chrome": "Google Chrome (opent in een nieuw venster)",
+        "firefox": "Mozilla Firefox (opent in een nieuw venster)",
+        "edge": "Microsoft Edge (opent in een nieuw venster)"
       }
     },
     "analytics": {
-      "title": "EN TEXT TO REPLACE: Analytics",
-      "p1": "EN TEXT TO REPLACE: We use {bold} to understand how visitors use our website. This helps us improve the user experience and identify issues.",
-      "bold": "EN TEXT TO REPLACE: Vercel Web Analytics",
-      "p2": "EN TEXT TO REPLACE: Vercel Analytics is designed with privacy in mind:",
-      "li1": "EN TEXT TO REPLACE: It does not use cookies",
-      "li2": "EN TEXT TO REPLACE: It does not collect personal identifiers",
-      "li3": "EN TEXT TO REPLACE: It does not track users across websites",
-      "li4": "EN TEXT TO REPLACE: All data is aggregated and anonymised",
-      "p3": "EN TEXT TO REPLACE: The only information collected includes: page URLs, referrer, country/region, device type, browser, and operating system. This data cannot be used to identify individual users."
+      "title": "Analyses",
+      "p1": "We gebruiken {bold} om te begrijpen hoe bezoekers onze website gebruiken. Dit helpt ons om de gebruikerservaring te verbeteren en problemen op te sporen.",
+      "bold": "Vercel Web Analytics",
+      "p2": "Vercel Analytics is ontworpen met het oog op privacy:",
+      "li1": "Het maakt geen gebruik van cookies",
+      "li2": "Het verzamelt geen persoonlijke identificatiegegevens",
+      "li3": "Het volgt gebruikers niet over verschillende websites",
+      "li4": "Alle gegevens worden samengevoegd en geanonimiseerd",
+      "p3": "De enige informatie die wordt verzameld omvat: pagina-URL's, de herkomstpagina (referrer), land/regio, apparaattype, browser en het besturingssysteem. Deze gegevens kunnen niet worden gebruikt om individuele gebruikers te identificeren."
     },
     "authenticated": {
-      "title": "EN TEXT TO REPLACE: Authenticated users",
-      "p1": "EN TEXT TO REPLACE: When you connect your {bold} account to npmx, we store your OAuth access token in a secure, HTTP-only session cookie. This token is used solely to authenticate requests on your behalf.",
-      "bold": "EN TEXT TO REPLACE: Atmosphere",
-      "p2": "EN TEXT TO REPLACE: We do not store your credentials, and we do not access any data beyond what is necessary to provide the features you use. You can disconnect your account at any time from the {settings} page.",
-      "settings": "EN TEXT TO REPLACE: settings"
+      "title": "Ingelogde gebruikers",
+      "p1": "Wanneer u uw {bold}-account koppelt aan npmx, slaan we uw OAuth-toegangstoken op in een beveiligde, HTTP-only sessiecookie. Dit token wordt uitsluitend gebruikt om namens u verzoeken te verifiëren.",
+      "bold": "Atmosphere",
+      "p2": "We slaan uw inloggegevens niet op en we bekijken geen andere gegevens dan die strikt noodzakelijk zijn om de functies te bieden die u gebruikt. U kunt uw account op elk gewenst moment ontkoppelen via de pagina {settings}.",
+      "settings": "instellingen"
     },
     "data_retention": {
-      "title": "EN TEXT TO REPLACE: Data retention",
-      "p1": "EN TEXT TO REPLACE: Session cookies are automatically deleted when you close your browser or after a period of inactivity. Local storage preferences remain on your device until you clear your browser data. Analytics data is retained in aggregate form and cannot be linked to individual users."
+      "title": "Gegevensbewaring",
+      "p1": "Sessiecookies worden automatisch verwijderd wanneer u uw browser sluit of na een periode van inactiviteit. Voorkeuren in de lokale opslag blijven op uw apparaat staan totdat u uw browsergegevens wist. Analysegegevens worden in samengevoegde vorm bewaard en kunnen niet aan individuele gebruikers worden gekoppeld."
     },
     "your_rights": {
-      "title": "EN TEXT TO REPLACE: Your rights",
-      "p1": "EN TEXT TO REPLACE: You have the right to:",
-      "li1": "EN TEXT TO REPLACE: Access information about what data we collect",
-      "li2": "EN TEXT TO REPLACE: Clear your local storage and cookies at any time",
-      "li3": "EN TEXT TO REPLACE: Disconnect your authenticated session",
-      "li4": "EN TEXT TO REPLACE: Request information about our data practices",
-      "p2": "EN TEXT TO REPLACE: Since we do not collect personal data, there is typically no personal information to delete or export."
+      "title": "Uw rechten",
+      "p1": "U heeft het recht om:",
+      "li1": "Informatie in te zien over welke gegevens wij verzamelen",
+      "li2": "Uw lokale opslag en cookies op elk gewenst moment te wissen",
+      "li3": "Uw ingelogde sessie te beëindigen",
+      "li4": "Informatie op te vragen over onze gegevensverwerking",
+      "p2": "Aangezien wij geen persoonsgegevens verzamelen, zijn er doorgaans geen persoonlijke gegevens om te verwijderen of te exporteren."
     },
     "contact": {
-      "title": "EN TEXT TO REPLACE: Contact us",
-      "p1": "EN TEXT TO REPLACE: For any questions or concerns about this privacy policy, you can contact us by opening an issue on our {link}.",
-      "link": "EN TEXT TO REPLACE: GitHub repository"
+      "title": "Contact met ons opnemen",
+      "p1": "Voor vragen of opmerkingen over dit privacybeleid kunt u contact met ons opnemen door een 'issue' te openen in onze {link}.",
+      "link": "GitHub-repository"
     },
     "changes": {
-      "title": "EN TEXT TO REPLACE: Changes to this policy",
-      "p1": "EN TEXT TO REPLACE: We may update this privacy policy from time to time. Any changes will be published on this page with an updated revision date."
+      "title": "Wijzigingen in dit beleid",
+      "p1": "Wij kunnen dit privacybeleid van tijd tot tijd bijwerken. Eventuele wijzigingen worden op deze pagina gepubliceerd met een bijgewerkte herzieningsdatum."
     }
   },
   "a11y": {

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -1527,7 +1527,8 @@
         "p1": "Naast sessiecookies gebruiken we de {bold} van uw browser om uw weergavevoorkeuren op te slaan. Hierdoor kunnen we het thema (licht/donker) en enkele andere gekozen {settings} onthouden, zodat deze bij elk bezoek direct goed staan.",
         "bold": "lokale opslag",
         "p2": "Deze informatie is puur functional, wordt alleen op uw eigen apparaat opgeslagen en {bold2}. We gebruiken dit uitsluitend om uw ervaring op onze website te verbeteren.",
-        "bold2": "bevat geen persoonlijke gegevens en wordt niet gebruikt om u te volgen"
+        "bold2": "bevat geen persoonlijke gegevens en wordt niet gebruikt om u te volgen",
+        "settings": "instellingen"
       },
       "management": {
         "title": "Cookies beheren",

--- a/i18n/locales/nl.json
+++ b/i18n/locales/nl.json
@@ -20,7 +20,10 @@
     "chat": "chat",
     "builders_chat": "bouwers",
     "keyboard_shortcuts": "toetsenbordnavigatie",
-    "brand": "merk"
+    "brand": "merk",
+    "resources": "Informatie",
+    "features": "Functies",
+    "other": "Overig"
   },
   "shortcuts": {
     "section": {
@@ -42,7 +45,8 @@
     "open_docs": "Open documentatie",
     "disable_shortcuts": "U kunt toetsenbordnavigatie uitschakelen in {instellingen}.",
     "open_main": "Open pakket overzicht",
-    "open_diff": "Open versie verschillen"
+    "open_diff": "Open versie verschillen",
+    "open_timeline": "Open tijdlijn"
   },
   "search": {
     "label": "Zoek npm pakketten",
@@ -316,6 +320,7 @@
     "warnings": "Waarschuwingen:",
     "go_back_home": "Ga terug naar startpagina",
     "per_week": "/ week",
+    "per_week_short": "/wk",
     "vanity_downloads_hint": "Totaaloverzicht: geen pakketten weergegeven | Totaaloverzicht: voor het weergegeven pakket | Totaaloverzicht: som van {count} weergegeven pakketten",
     "sort": {
       "name": "naam",
@@ -383,9 +388,18 @@
       "size": "De installatiegrootte is toegenomen met {percent} ({size} groter)",
       "deps": "{count} meer dependencies"
     },
+    "size_decrease": {
+      "title_size": "Pakketgrootte is afgenomen sinds v{version}!",
+      "title_deps": "Aantal dependencies is afgenomen sinds v{version}!",
+      "title_both": "De pakketgrootte en het aantal dependecies zijn sindsdien afgenomen v{version}!",
+      "size": "De installatiegrootte is met {percent} verminderd ({size} kleiner)",
+      "deps": "{count} minder dependencies"
+    },
     "replacement": {
       "title": "U heeft waarschijnlijk dit niet nodig",
+      "example": "Voorbeeld:",
       "native": "Dit kan vervangen worden door {replacement}, Beschikbaar sinds node {nodeVersion}.",
+      "native_no_version": "Dit pakket kan vervangen worden door {replacement}.",
       "simple": "De {community} heeft dit pakket als overbodig gemarkeerd, met het advies: {replacement}.",
       "documented": "De {community} heeft aangegeven dat er voor dit pakket beter presterende alternatieven zijn.",
       "none": "Dit pakket is gemarkeerd als overbodig en de functionaliteit ervan is waarschijnlijk standaard beschikbaar in alle omgevingen.",
@@ -436,13 +450,16 @@
       "docs": "docs",
       "fund": "Steunen",
       "compare": "vergelijk",
+      "timeline": "tijdlijn",
       "compare_this_package": "Vergelijk dit pakket",
-      "changelog": "wijzigingenoverzicht",
-      "timeline": "tijdlijn"
+      "changelog": "wijzigingenoverzicht"
     },
     "likes": {
       "like": "Dit pakket leuk vinden",
-      "unlike": "Dit pakket niet meer leuk vinden"
+      "unlike": "Dit pakket niet meer leuk vinden",
+      "top_rank_tooltip": "Dit is een van de 10 populairste pakketten op npmx! (#{rank})",
+      "top_rank_label": "#{rank}",
+      "top_rank_link_label": "Bekijk klassement van vind-leuks. Dit pakket staat op plaats #{rank}."
     },
     "docs": {
       "contents": "Inhoud",
@@ -554,6 +571,9 @@
       "filter_help": "Semver bereikfilter hulp",
       "filter_tooltip": "Filter versie bij {link}. bijvoorbeeld, ^3.0.0 laat zien 3.x versies.",
       "filter_tooltip_link": "semver bereik",
+      "license_change_help": "Details over licentiewijziging",
+      "license_change_warning": "Licentie is gewijzigd sinds vorige versie.",
+      "license_change_record": "De licentie van dit pakket is gewijzigd van \"{from}\" naar \"{to}\".",
       "no_matches": "Geen versies in dit bereik",
       "copy_alt": {
         "per_version_analysis": "{version} versie was gedownload {downloads} keren",
@@ -562,6 +582,35 @@
       "page_title": "Versie geschiedenis",
       "current_tags": "Huidige tags",
       "no_match_filter": "Geen versies die voldoen aan {filter}"
+    },
+    "timeline": {
+      "load_more": "Laad meer",
+      "load_error": "De tijdlijn kan niet worden geladen. Probeer het later nog eens.",
+      "size_increase": "De installatiegrootte is toegenomen met {percent}% ({size})",
+      "size_decrease": "De installatiegrootte is afgenomen met {percent}% ({size})",
+      "dep_increase": "{count} dependencies toegevoegd",
+      "dep_decrease": "{count} dependencies verwijderd",
+      "license_change": "Licentie gewijzigd van {from} naar {to}",
+      "esm_added": "Moduletype is gewijzigd naar ESM",
+      "esm_removed": "Moduletype is gewijzigd van ESM naar CJS",
+      "types_added": "TypeScript types toegevoegd",
+      "types_removed": "TypeScript types verwijderd",
+      "trusted_publisher_added": "Vertrouwd publiceren geactiveerd",
+      "trusted_publisher_removed": "Vertrouwd publiceren gedeactiveerd",
+      "provenance_added": "Herkomst verificatie geactiveerd",
+      "provenance_removed": "Herkomst verificatie gedeactiveerd",
+      "chart": {
+        "tab_aria_label": "Selecteer statistiek",
+        "base_scale": "y-as op nul beginnen",
+        "zoom": "zoom",
+        "reset_minimap": "minimap resetten",
+        "ordered_versions": "Alleen stabiele versies",
+        "copy_alt": {
+          "key_changes": "Belangrijkste wijzigingen: {version_events}.",
+          "version_events": "versie {version}: {events}",
+          "general_description": "Lijngrafiek die de {metric} toont van het pakket {package}, van versie {first} tot {last}. De {metric} in versie {first} is {first_value}, in versie {last} is dat {last_value} (in totaal {overall_progress_percentage}%). {key_changes} {watermark}."
+        }
+      }
     },
     "dependencies": {
       "title": "Dependency ({count}) | Dependencies ({count})",
@@ -763,6 +812,16 @@
     "download": {
       "button": "Download",
       "tarball": "Download Tarball als .tar.gz"
+    }
+  },
+  "leaderboard": {
+    "likes": {
+      "title": "Vind leuk klassement",
+      "description": "De 10 pakketten met de meeste vind-leuks op npmx van dit moment.",
+      "rank": "Plaats",
+      "likes": "Vind leuk",
+      "unavailable_title": "Nog geen vind-leuks klassement",
+      "unavailable_description": "We hebben op dit moment nog geen klassement van vind-leuks om te tonen."
     }
   },
   "connector": {
@@ -1243,7 +1302,15 @@
       "add_hint": "Voeg tenminste 2 pakketten toe om te vergelijken"
     },
     "scatter_chart": {
-      "copy_alt": {}
+      "title": "Vergelijk {x} met {y}",
+      "freshness_score": "recentheid score",
+      "copy_alt": {
+        "analysis": "{package} : {x_name} ({x_value}) en {y_name} ({y_value})",
+        "description": "Spreidingsdiagram met een weergave van {x_name} tegenover {y_name} voor de {packages} pakketten. {analysis}. {watermark}"
+      },
+      "filename": "{x}-vs-{y}-spreidingsdiagram",
+      "x_axis": "X-AS ↦",
+      "y_axis": "Y-AS ↥"
     },
     "no_dependency": {
       "label": "(Geen dependency)",
@@ -1435,19 +1502,84 @@
     }
   },
   "privacy_policy": {
-    "title": "privacy beleid",
+    "title": "privacybeleid",
+    "last_updated": "EN TEXT TO REPLACE: Last updated: {date}",
+    "welcome": "EN TEXT TO REPLACE: Welcome to {app}. We are committed to protecting your privacy. This policy explains what data we collect, how we use it, and your rights regarding your information.",
     "cookies": {
-      "what_are": {},
-      "types": {},
-      "local_storage": {},
-      "management": {}
+      "what_are": {
+        "title": "EN TEXT TO REPLACE: What are cookies?",
+        "p1": "EN TEXT TO REPLACE: Cookies are small text files stored on your device when you visit a website. Their purpose is to enhance your browsing experience by remembering certain preferences and settings."
+      },
+      "types": {
+        "title": "EN TEXT TO REPLACE: What cookies do we use?",
+        "p1": "EN TEXT TO REPLACE: We only use {bold} for purposes strictly necessary for the site's functionality. We do not use third-party or advertising cookies.",
+        "bold": "EN TEXT TO REPLACE: essential technical cookies",
+        "li1": "EN TEXT TO REPLACE: {li11}{separator} {li12}",
+        "li2": "EN TEXT TO REPLACE: {li21}{separator} {li22}",
+        "separator": "EN TEXT TO REPLACE: :",
+        "cookie_vdpl": "EN TEXT TO REPLACE: __vdpl",
+        "cookie_vdpl_desc": "EN TEXT TO REPLACE: This cookie is used by our hosting provider (Vercel) for skew protection. It ensures you fetch assets from the correct deployment version if a new update is released while you are browsing. It does not track you.",
+        "cookie_h3": "EN TEXT TO REPLACE: h3",
+        "cookie_h3_desc": "EN TEXT TO REPLACE: This is our secure session cookie. It stores the OAuth access token when you connect your Atmosphere account. It is essential for maintaining your authenticated session."
+      },
+      "local_storage": {
+        "title": "EN TEXT TO REPLACE: Local storage",
+        "p1": "EN TEXT TO REPLACE: In addition to session cookies, we use your browser's {bold} to save your display preferences. This allows us to remember the theme (light/dark) and some other {settings} you have selected, so you don't have to reconfigure them on each visit.",
+        "bold": "EN TEXT TO REPLACE: Local Storage",
+        "p2": "EN TEXT TO REPLACE: This information is purely functional, stored only on your device, and {bold2}. We use it exclusively to improve your experience on our website.",
+        "bold2": "EN TEXT TO REPLACE: contains no personal data nor is it used to track you",
+        "settings": "EN TEXT TO REPLACE: settings"
+      },
+      "management": {
+        "title": "EN TEXT TO REPLACE: Managing cookies",
+        "p1": "EN TEXT TO REPLACE: You can configure your browser to accept, reject, or delete cookies according to your preferences. However, please note that {bold}.",
+        "bold": "EN TEXT TO REPLACE: rejecting essential cookies may prevent full access to the application",
+        "p2": "EN TEXT TO REPLACE: Below are links with instructions for cookie management in the most commonly used browsers:",
+        "chrome": "EN TEXT TO REPLACE: Google Chrome (opens in a new window)",
+        "firefox": "EN TEXT TO REPLACE: Mozilla Firefox (opens in a new window)",
+        "edge": "EN TEXT TO REPLACE: Microsoft Edge (opens in a new window)"
+      }
     },
-    "analytics": {},
-    "authenticated": {},
-    "data_retention": {},
-    "your_rights": {},
-    "contact": {},
-    "changes": {}
+    "analytics": {
+      "title": "EN TEXT TO REPLACE: Analytics",
+      "p1": "EN TEXT TO REPLACE: We use {bold} to understand how visitors use our website. This helps us improve the user experience and identify issues.",
+      "bold": "EN TEXT TO REPLACE: Vercel Web Analytics",
+      "p2": "EN TEXT TO REPLACE: Vercel Analytics is designed with privacy in mind:",
+      "li1": "EN TEXT TO REPLACE: It does not use cookies",
+      "li2": "EN TEXT TO REPLACE: It does not collect personal identifiers",
+      "li3": "EN TEXT TO REPLACE: It does not track users across websites",
+      "li4": "EN TEXT TO REPLACE: All data is aggregated and anonymised",
+      "p3": "EN TEXT TO REPLACE: The only information collected includes: page URLs, referrer, country/region, device type, browser, and operating system. This data cannot be used to identify individual users."
+    },
+    "authenticated": {
+      "title": "EN TEXT TO REPLACE: Authenticated users",
+      "p1": "EN TEXT TO REPLACE: When you connect your {bold} account to npmx, we store your OAuth access token in a secure, HTTP-only session cookie. This token is used solely to authenticate requests on your behalf.",
+      "bold": "EN TEXT TO REPLACE: Atmosphere",
+      "p2": "EN TEXT TO REPLACE: We do not store your credentials, and we do not access any data beyond what is necessary to provide the features you use. You can disconnect your account at any time from the {settings} page.",
+      "settings": "EN TEXT TO REPLACE: settings"
+    },
+    "data_retention": {
+      "title": "EN TEXT TO REPLACE: Data retention",
+      "p1": "EN TEXT TO REPLACE: Session cookies are automatically deleted when you close your browser or after a period of inactivity. Local storage preferences remain on your device until you clear your browser data. Analytics data is retained in aggregate form and cannot be linked to individual users."
+    },
+    "your_rights": {
+      "title": "EN TEXT TO REPLACE: Your rights",
+      "p1": "EN TEXT TO REPLACE: You have the right to:",
+      "li1": "EN TEXT TO REPLACE: Access information about what data we collect",
+      "li2": "EN TEXT TO REPLACE: Clear your local storage and cookies at any time",
+      "li3": "EN TEXT TO REPLACE: Disconnect your authenticated session",
+      "li4": "EN TEXT TO REPLACE: Request information about our data practices",
+      "p2": "EN TEXT TO REPLACE: Since we do not collect personal data, there is typically no personal information to delete or export."
+    },
+    "contact": {
+      "title": "EN TEXT TO REPLACE: Contact us",
+      "p1": "EN TEXT TO REPLACE: For any questions or concerns about this privacy policy, you can contact us by opening an issue on our {link}.",
+      "link": "EN TEXT TO REPLACE: GitHub repository"
+    },
+    "changes": {
+      "title": "EN TEXT TO REPLACE: Changes to this policy",
+      "p1": "EN TEXT TO REPLACE: We may update this privacy policy from time to time. Any changes will be published on this page with an updated revision date."
+    }
   },
   "a11y": {
     "title": "toegankelijkheid",
@@ -1503,11 +1635,37 @@
     }
   },
   "vacations": {
-    "what": {},
-    "meantime": {},
-    "return": {},
+    "title": "EN TEXT TO REPLACE: on vacation",
+    "meta_description": "EN TEXT TO REPLACE: The npmx team was recharging. Discord reopened after a week.",
+    "heading": "EN TEXT TO REPLACE: recharging",
+    "subtitle": "EN TEXT TO REPLACE: we were building npmx at a pace that was costing {some} of us sleep. we didn't want that to be the norm! so we took a week off. together.",
+    "illustration_alt": "EN TEXT TO REPLACE: a single row of cosy icons",
+    "poke_log": "EN TEXT TO REPLACE: Poke the campfire",
+    "what": {
+      "title": "EN TEXT TO REPLACE: what happened",
+      "p1": "EN TEXT TO REPLACE: discord was closed {dates}.",
+      "dates": "EN TEXT TO REPLACE: February 14 – 21",
+      "p2": "EN TEXT TO REPLACE: all invite links were gone and channels were locked – except {garden}, which stayed open for folks who wanted to keep hanging out.",
+      "garden": "EN TEXT TO REPLACE: #garden"
+    },
+    "meantime": {
+      "title": "EN TEXT TO REPLACE: in the meantime",
+      "p1": "EN TEXT TO REPLACE: {site} and {repo} stayed open – people still dug in, filed some issues, opened a few PRs, but mainly everyone spent time somewhere near a cosy fireplace.",
+      "repo_link": "EN TEXT TO REPLACE: the repo"
+    },
+    "return": {
+      "title": "EN TEXT TO REPLACE: we came back!",
+      "p1": "EN TEXT TO REPLACE: we came back recharged and ready for the final push to March 3rd. {social} for updates.",
+      "social_link": "EN TEXT TO REPLACE: follow us on Bluesky"
+    },
     "stats": {
-      "subtitle": {}
+      "contributors": "EN TEXT TO REPLACE: Contributors",
+      "commits": "EN TEXT TO REPLACE: Commits",
+      "pr": "EN TEXT TO REPLACE: PRs Merged",
+      "subtitle": {
+        "some": "EN TEXT TO REPLACE: some",
+        "all": "EN TEXT TO REPLACE: all"
+      }
     }
   },
   "action_bar": {


### PR DESCRIPTION
### 🧭 Context

adds Dutch (NL) translations to be 100% complete at the moment of making this pr.

### 📚 Description

adds the followings translations to Dutch
- [x] likes (except likes.like)
- [x] size_decrease
- [x] timeline
- [x] leaderboard
- [x] compare.scatter_chart
- [x] privacy_policy
- [x] vacations
- [x] other smaller translations added between #2118 and this pr

#### terms
terms are tracked at #2118 to keep a single source of truth for Dutch, only added "cookie" as a new term

### AI & translator usage
I did use Gemini & Deepl to assist translating to Dutch (same reason as in #2118)