### PR TITLE
feat: stream recently liked packages on the homepage

### DIFF
--- a/app/components/DateTime.vue
+++ b/app/components/DateTime.vue
@@ -15,6 +15,8 @@ const props = withDefaults(
     title?: string
     /** Date style for absolute display */
     dateStyle?: 'full' | 'long' | 'medium' | 'short'
+    /** Time style for absolute display */
+    timeStyle?: 'full' | 'long' | 'medium' | 'short'
     /** Individual date parts for absolute display (alternative to dateStyle) */
     year?: 'numeric' | '2-digit'
     month?: 'numeric' | '2-digit' | 'long' | 'short' | 'narrow'
@@ -23,6 +25,7 @@ const props = withDefaults(
   {
     title: undefined,
     dateStyle: undefined,
+    timeStyle: undefined,
     year: undefined,
     month: undefined,
     day: undefined,
@@ -65,6 +68,7 @@ const titleValue = computed(() => {
         :datetime="datetime"
         :title="titleValue"
         :date-style="dateStyle"
+        :time-style="timeStyle"
         :year="year"
         :month="month"
         :day="day"
@@ -75,6 +79,7 @@ const titleValue = computed(() => {
           :datetime="datetime"
           :title="titleValue"
           :date-style="dateStyle"
+          :time-style="timeStyle"
           :year="year"
           :month="month"
           :day="day"

--- a/app/components/Landing/RecentlyLiked.vue
+++ b/app/components/Landing/RecentlyLiked.vue
@@ -1,0 +1,268 @@
+<script setup lang="ts">
+import type { RecentPackageLike } from '~/utils/recent-package-likes'
+import { RECENT_PACKAGE_LIKES_LIMIT } from '~/utils/recent-package-likes'
+
+const props = defineProps<{
+  isLoading?: boolean
+  likes: readonly RecentPackageLike[]
+}>()
+
+const LIKE_CARD_CLASSES = [
+  'grid h-full min-h-[7rem] content-start grid-cols-[minmax(0,1fr)_auto]',
+  'gap-x-3 gap-y-1 rounded-md border border-border bg-bg/70 px-3.5 py-3',
+  'text-start text-base text-fg shadow-sm transition-colors duration-200',
+  'hover:border-border-hover hover:bg-bg-elevated focus-within:border-accent',
+]
+
+const SKELETON_CARD_CLASSES = [
+  'grid min-h-[7rem] grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-3',
+  'rounded-md border border-border bg-bg/70 px-3.5 py-3',
+]
+
+const compactNumberFormatter = useCompactNumberFormatter()
+
+const skeletonRows = Array.from({ length: RECENT_PACKAGE_LIKES_LIMIT }, (_, index) => index)
+const hasLiveLike = computed(() => props.likes.some(like => like.origin === 'live'))
+const liveRegionPackageName = shallowRef('')
+const loadingPlaceholderRows = computed(() => {
+  if (!props.isLoading || props.likes.length === 0) return []
+  return Array.from(
+    { length: Math.max(0, RECENT_PACKAGE_LIKES_LIMIT - props.likes.length) },
+    (_, index) => index,
+  )
+})
+
+function formatCompactStat(value: number | null | undefined): string | null {
+  if (value == null) return null
+  return compactNumberFormatter.value.format(value)
+}
+
+watch(
+  () => props.likes,
+  (likes, previousLikes = []) => {
+    const previousLikeIds = new Set(previousLikes.map(like => like.id))
+    const newLike = likes.find(
+      like => like.origin === 'live' && like.animateEntry && !previousLikeIds.has(like.id),
+    )
+    if (!newLike) return
+
+    liveRegionPackageName.value = newLike.packageName
+  },
+  { flush: 'post' },
+)
+</script>
+
+<template>
+  <section
+    class="w-full max-w-4xl motion-safe:animate-slide-up motion-safe:animate-fill-both"
+    aria-labelledby="recently-liked-title"
+    data-testid="recently-liked-packages"
+  >
+    <p class="sr-only" role="status" aria-live="polite" aria-atomic="true">
+      {{
+        liveRegionPackageName
+          ? $t('home.recently_liked.announcement', { packageName: liveRegionPackageName })
+          : ''
+      }}
+    </p>
+
+    <div
+      class="relative overflow-hidden rounded-lg border border-border bg-bg-subtle/85 backdrop-blur"
+      :aria-busy="isLoading ? 'true' : undefined"
+    >
+      <div
+        class="absolute inset-bs-0 inset-is-0 h-px w-full bg-gradient-to-r from-transparent via-accent/70 to-transparent"
+        aria-hidden="true"
+      />
+      <div class="border-b border-border/70 px-3 py-2.5 sm:px-3.5">
+        <div class="flex items-center gap-2 text-start">
+          <span
+            class="relative flex size-2.5"
+            :class="hasLiveLike ? 'text-[var(--badge-green)]' : 'text-[var(--badge-blue)]'"
+            aria-hidden="true"
+          >
+            <span
+              class="absolute inline-flex size-full animate-ping rounded-full bg-current opacity-60 motion-reduce:animate-none"
+            />
+            <span class="relative inline-flex size-2.5 rounded-full bg-current" />
+          </span>
+          <h2 id="recently-liked-title" class="text-sm font-mono uppercase text-fg-muted">
+            {{ $t('home.recently_liked.title') }}
+          </h2>
+        </div>
+      </div>
+
+      <TransitionGroup
+        v-if="likes.length > 0"
+        tag="ul"
+        name="recently-liked-list"
+        class="grid list-none m-0 gap-2 p-2.5"
+      >
+        <li v-for="like in likes" :key="like.id" class="min-w-0">
+          <article
+            :class="[
+              LIKE_CARD_CLASSES,
+              like.animateEntry || like.origin === 'live' ? 'recently-liked-entry' : undefined,
+            ]"
+          >
+            <NuxtLink
+              :to="packageRoute(like.packageName)"
+              class="block min-w-0 text-fg no-underline hover:text-fg hover:no-underline"
+              data-testid="recently-liked-package"
+            >
+              <div class="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                <span
+                  class="min-w-0 truncate font-mono leading-6"
+                  dir="ltr"
+                  :title="like.packageName"
+                >
+                  {{ like.packageName }}
+                </span>
+                <span class="shrink-0 text-xs text-fg-subtle" data-testid="recently-liked-time">
+                  {{ $t('home.recently_liked.liked_prefix') }}
+                  <DateTime
+                    :datetime="new Date(like.likedAt)"
+                    date-style="short"
+                    time-style="short"
+                  />
+                </span>
+              </div>
+
+              <p
+                v-if="like.packageDescription"
+                class="mt-0.5 mb-0 line-clamp-2 text-sm text-fg-muted"
+              >
+                {{ like.packageDescription }}
+              </p>
+            </NuxtLink>
+
+            <div class="flex items-start justify-end">
+              <PackageLikes :package-name="like.packageName" />
+            </div>
+
+            <dl
+              v-if="like.repositoryStars != null || like.weeklyDownloads != null"
+              class="col-start-1 m-0 grid grid-cols-[6.25rem_minmax(0,1fr)] items-center gap-x-2 gap-y-1 text-sm text-fg-muted"
+            >
+              <div class="min-w-0">
+                <template v-if="like.repositoryStars != null">
+                  <dt class="sr-only">{{ $t('command_palette.package_links.stars') }}</dt>
+                  <dd class="m-0 flex min-w-0 items-center gap-1.5">
+                    <span aria-hidden="true" class="i-lucide:star size-4 shrink-0" />
+                    <span class="truncate font-mono">
+                      {{ formatCompactStat(like.repositoryStars) }}
+                    </span>
+                  </dd>
+                </template>
+              </div>
+              <div v-if="like.weeklyDownloads != null" class="flex items-center gap-1.5">
+                <dt class="sr-only">{{ $t('package.card.weekly_downloads') }}</dt>
+                <dd class="m-0 flex items-center gap-1.5">
+                  <span aria-hidden="true" class="i-lucide:chart-line size-4" />
+                  <span class="font-mono">
+                    {{ formatCompactStat(like.weeklyDownloads) }}{{ $t('common.per_week_short') }}
+                  </span>
+                </dd>
+              </div>
+            </dl>
+          </article>
+        </li>
+        <li
+          v-for="row in loadingPlaceholderRows"
+          :key="`loading-placeholder-${row}`"
+          class="min-w-0"
+          aria-hidden="true"
+        >
+          <article :class="SKELETON_CARD_CLASSES">
+            <div class="min-w-0 space-y-2.5">
+              <div class="flex items-center gap-2">
+                <span
+                  class="h-5 w-[10.5rem] max-w-[55%] rounded bg-fg/12 motion-safe:animate-pulse"
+                />
+                <span class="h-3.5 w-[5.5rem] rounded bg-fg/8 motion-safe:animate-pulse" />
+              </div>
+              <span class="block h-3.5 w-11/12 rounded bg-fg/8 motion-safe:animate-pulse" />
+            </div>
+            <span class="h-8 w-14 rounded-md border border-border bg-bg-subtle" />
+            <span class="col-start-1 h-3.5 w-[9rem] rounded bg-fg/8 motion-safe:animate-pulse" />
+          </article>
+        </li>
+      </TransitionGroup>
+
+      <ul
+        v-else-if="isLoading"
+        class="grid list-none m-0 gap-2 p-2.5"
+        data-testid="recently-liked-skeleton"
+      >
+        <li v-for="row in skeletonRows" :key="row" class="min-w-0" aria-hidden="true">
+          <article :class="SKELETON_CARD_CLASSES">
+            <div class="min-w-0 space-y-2.5">
+              <div class="flex items-center gap-2">
+                <span
+                  class="h-5 w-[10.5rem] max-w-[55%] rounded bg-fg/12 motion-safe:animate-pulse"
+                />
+                <span class="h-3.5 w-[5.5rem] rounded bg-fg/8 motion-safe:animate-pulse" />
+              </div>
+              <span class="block h-3.5 w-11/12 rounded bg-fg/8 motion-safe:animate-pulse" />
+            </div>
+            <span class="h-8 w-14 rounded-md border border-border bg-bg-subtle" />
+            <span class="col-start-1 h-3.5 w-[9rem] rounded bg-fg/8 motion-safe:animate-pulse" />
+          </article>
+        </li>
+      </ul>
+
+      <div v-else class="p-2.5">
+        <div
+          class="flex min-h-[7rem] items-center gap-3 rounded-md border border-border bg-bg/70 px-3.5 py-3 text-start text-base text-fg-muted"
+          data-testid="recently-liked-empty"
+        >
+          <span class="i-lucide:radio-tower size-4 shrink-0 text-accent" aria-hidden="true" />
+          <p class="m-0">{{ $t('home.recently_liked.empty') }}</p>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.recently-liked-entry {
+  animation: recently-liked-entry 760ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.recently-liked-list-move {
+  transition: transform 680ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes recently-liked-entry {
+  0% {
+    opacity: 0;
+    transform: translateY(-0.5rem) scale(0.985);
+    border-color: color-mix(in oklab, var(--accent) 70%, var(--border));
+    background: color-mix(in oklab, var(--accent) 10%, var(--bg));
+  }
+
+  55% {
+    opacity: 1;
+    transform: translateY(0.125rem) scale(1.002);
+    border-color: color-mix(in oklab, var(--accent) 45%, var(--border));
+    background: color-mix(in oklab, var(--accent) 6%, var(--bg));
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    border-color: var(--border);
+    background: color-mix(in oklab, var(--bg) 70%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .recently-liked-entry {
+    animation: none;
+  }
+
+  .recently-liked-list-move {
+    transition: none;
+  }
+}
+</style>

--- a/app/composables/atproto/useRecentPackageLikes.ts
+++ b/app/composables/atproto/useRecentPackageLikes.ts
@@ -1,0 +1,190 @@
+import type { RecentPackageLike } from '~/utils/recent-package-likes'
+import { useWebSocket } from '@vueuse/core'
+import * as v from 'valibot'
+import { encodePackageName } from '#shared/utils/npm'
+import {
+  RECENT_PACKAGE_LIKES_LIMIT,
+  createPackageLikesSeedUrl,
+  createPackageLikesStreamUrl,
+  parseSpacedustPackageLikeEvent,
+  parseUfosPackageLikeRecords,
+} from '~/utils/recent-package-likes'
+
+const PackageMetaResponseSchema = v.object({
+  description: v.optional(v.string()),
+  weeklyDownloads: v.optional(v.nullable(v.number())),
+  repositoryStars: v.optional(v.nullable(v.number())),
+})
+
+const INITIAL_PACKAGE_LIKE_STAGGER_MS = 480
+
+type RecentPackageLikeMetadata = Pick<
+  RecentPackageLike,
+  'packageDescription' | 'weeklyDownloads' | 'repositoryStars'
+>
+
+export function useRecentPackageLikes(limit: number = RECENT_PACKAGE_LIKES_LIMIT) {
+  const likes = shallowRef<RecentPackageLike[]>([])
+  const isLoadingInitialLikes = shallowRef(true)
+  const metadataByPackageName = new Map<string, RecentPackageLikeMetadata>()
+  const metadataRequests = new Set<string>()
+  const initialLikeTimers = new Set<ReturnType<typeof setTimeout>>()
+
+  function clearInitialLikeTimers() {
+    for (const timer of initialLikeTimers) {
+      clearTimeout(timer)
+    }
+    initialLikeTimers.clear()
+  }
+
+  function addLikes(newLikes: RecentPackageLike[]) {
+    if (newLikes.length === 0) return
+
+    const enrichedLikes = newLikes.map(like => {
+      const metadata = metadataByPackageName.get(like.packageName)
+      return metadata ? { ...like, ...metadata } : like
+    })
+
+    const seen = new Set<string>()
+    likes.value = [...enrichedLikes, ...likes.value]
+      .filter(like => {
+        if (seen.has(like.id)) return false
+        seen.add(like.id)
+        return true
+      })
+      .sort((a, b) => b.likedAt - a.likedAt)
+      .slice(0, limit)
+
+    for (const like of likes.value) {
+      void loadLikeMetadata(like.packageName)
+    }
+  }
+
+  function addLike(like: RecentPackageLike) {
+    addLikes([{ ...like, animateEntry: true }])
+  }
+
+  function addInitialLikes(newLikes: RecentPackageLike[]) {
+    clearInitialLikeTimers()
+
+    const stagedLikes = [...newLikes]
+      .sort((a, b) => b.likedAt - a.likedAt)
+      .slice(0, limit)
+      .sort((a, b) => a.likedAt - b.likedAt)
+
+    if (stagedLikes.length === 0) {
+      isLoadingInitialLikes.value = false
+      return
+    }
+
+    stagedLikes.forEach((like, index) => {
+      const timer = setTimeout(() => {
+        initialLikeTimers.delete(timer)
+        addLikes([{ ...like, animateEntry: true }])
+
+        if (index === stagedLikes.length - 1) {
+          isLoadingInitialLikes.value = false
+        }
+      }, index * INITIAL_PACKAGE_LIKE_STAGGER_MS)
+
+      initialLikeTimers.add(timer)
+    })
+  }
+
+  async function loadInitialLikes() {
+    try {
+      const response = await fetch(createPackageLikesSeedUrl())
+      if (!response.ok) {
+        isLoadingInitialLikes.value = false
+        return
+      }
+
+      addInitialLikes(parseUfosPackageLikeRecords(await response.json()))
+    } catch (error) {
+      // The live Spacedust stream remains useful even if the UFOs seed request fails.
+      if (import.meta.dev && !import.meta.test) {
+        // oxlint-disable-next-line no-console
+        console.warn('[recent-package-likes] Failed to load initial likes:', error)
+      }
+      isLoadingInitialLikes.value = false
+    }
+  }
+
+  function applyLikeMetadata(packageName: string, metadata: RecentPackageLikeMetadata) {
+    likes.value = likes.value.map(like =>
+      like.packageName === packageName
+        ? {
+            ...like,
+            ...metadata,
+          }
+        : like,
+    )
+  }
+
+  async function loadLikeMetadata(packageName: string) {
+    if (metadataRequests.has(packageName)) return
+    metadataRequests.add(packageName)
+
+    const encodedPackageName = encodePackageName(packageName)
+    const parsedMeta = await $fetch<unknown>(`/api/registry/package-meta/${encodedPackageName}`, {
+      query: { includeRepositoryStars: 'true' },
+    })
+      .then(payload => v.safeParse(PackageMetaResponseSchema, payload))
+      .catch(error => {
+        if (import.meta.dev && !import.meta.test) {
+          // oxlint-disable-next-line no-console
+          console.warn(`[recent-package-likes] Failed to load metadata for ${packageName}:`, error)
+        }
+        return null
+      })
+
+    const output = parsedMeta?.success ? parsedMeta.output : null
+    const metadata: RecentPackageLikeMetadata = {
+      packageDescription: output?.description || null,
+      weeklyDownloads: output?.weeklyDownloads ?? null,
+      repositoryStars: output?.repositoryStars ?? null,
+    }
+
+    metadataByPackageName.set(packageName, metadata)
+    applyLikeMetadata(packageName, metadata)
+  }
+
+  function handleMessage(event: MessageEvent) {
+    if (typeof event.data !== 'string') return
+
+    let payload: unknown
+    try {
+      payload = JSON.parse(event.data)
+    } catch {
+      return
+    }
+
+    const like = parseSpacedustPackageLikeEvent(payload)
+    if (like?.origin === 'live') addLike(like)
+  }
+
+  const { open: openLikesStream } = useWebSocket(createPackageLikesStreamUrl(), {
+    autoConnect: false,
+    autoReconnect: {
+      delay: retried => Math.min(30_000, 1_000 * 2 ** Math.max(0, retried - 1)),
+    },
+    immediate: false,
+    onError: ws => {
+      ws.close()
+    },
+    onMessage: (_ws, event) => {
+      handleMessage(event)
+    },
+  })
+
+  onMounted(() => {
+    void loadInitialLikes()
+    if (import.meta.client) openLikesStream()
+  })
+  onScopeDispose(clearInitialLikeTimers)
+
+  return {
+    isLoadingInitialLikes: readonly(isLoadingInitialLikes),
+    likes: readonly(likes),
+  }
+}

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -3,6 +3,8 @@ import { SHOWCASED_FRAMEWORKS } from '~/utils/frameworks'
 
 const { model: searchQuery, startSearch } = useGlobalSearch()
 const isSearchFocused = shallowRef(false)
+const { isLoadingInitialLikes: isLoadingRecentPackageLikes, likes: recentPackageLikes } =
+  useRecentPackageLikes()
 
 async function search() {
   startSearch()
@@ -88,6 +90,11 @@ defineOgImage('Splash.takumi', {}, { alt: () => $t('seo.home.description') })
         </search>
 
         <BuildEnvironment class="mt-4" />
+        <LandingRecentlyLiked
+          :is-loading="isLoadingRecentPackageLikes"
+          :likes="recentPackageLikes"
+          class="mt-8"
+        />
       </header>
 
       <nav

--- a/app/utils/recent-package-likes.ts
+++ b/app/utils/recent-package-likes.ts
@@ -1,0 +1,123 @@
+import * as v from 'valibot'
+import { SPACEDUST_HOST, UFOS_API_HOST } from '#shared/utils/constants'
+
+export const PACKAGE_LIKE_COLLECTION = 'dev.npmx.feed.like'
+export const SPACEDUST_PACKAGE_LIKE_SOURCE = `${PACKAGE_LIKE_COLLECTION}:subjectRef`
+export const RECENT_PACKAGE_LIKES_LIMIT = 5
+
+const SpacedustPackageLikeEventSchema = v.object({
+  kind: v.literal('link'),
+  origin: v.optional(v.literal('live')),
+  link: v.object({
+    operation: v.literal('create'),
+    source: v.literal(SPACEDUST_PACKAGE_LIKE_SOURCE),
+    source_record: v.optional(v.string()),
+    subject: v.string(),
+  }),
+})
+
+const UfosPackageLikeRecordSchema = v.object({
+  did: v.string(),
+  collection: v.literal(PACKAGE_LIKE_COLLECTION),
+  rkey: v.string(),
+  record: v.object({
+    createdAt: v.optional(v.string()),
+    subjectRef: v.string(),
+  }),
+  time_us: v.optional(v.number()),
+})
+
+const UfosPackageLikeRecordsSchema = v.array(UfosPackageLikeRecordSchema)
+
+export type RecentPackageLikeOrigin = 'live' | 'recent'
+
+export type RecentPackageLike = {
+  id: string
+  packageName: string
+  origin: RecentPackageLikeOrigin
+  subjectRef: string
+  likedAt: number
+  packageDescription?: string | null
+  weeklyDownloads?: number | null
+  repositoryStars?: number | null
+  animateEntry?: boolean
+}
+
+export function createPackageLikesStreamUrl(): string {
+  const url = new URL(`wss://${SPACEDUST_HOST}/subscribe`)
+  url.searchParams.set('instant', 'true')
+  url.searchParams.append('wantedSources', SPACEDUST_PACKAGE_LIKE_SOURCE)
+  return url.toString()
+}
+
+export function createPackageLikesSeedUrl(): string {
+  const url = new URL(`https://${UFOS_API_HOST}/records`)
+  url.searchParams.set('collection', PACKAGE_LIKE_COLLECTION)
+  return url.toString()
+}
+
+export function packageNameFromSubjectRef(subjectRef: string): string | null {
+  if (!URL.canParse(subjectRef)) return null
+  const url = new URL(subjectRef)
+
+  if (url.origin !== 'https://npmx.dev') return null
+
+  const packagePathPrefix = '/package/'
+  if (!url.pathname.startsWith(packagePathPrefix)) return null
+
+  const packageName = url.pathname.slice(packagePathPrefix.length)
+  if (!packageName) return null
+
+  try {
+    return decodeURIComponent(packageName)
+  } catch {
+    return packageName
+  }
+}
+
+function likedAtFromUfosRecord(record: v.InferOutput<typeof UfosPackageLikeRecordSchema>): number {
+  const createdAt = record.record.createdAt ? Date.parse(record.record.createdAt) : NaN
+  if (Number.isFinite(createdAt)) return createdAt
+  if (record.time_us !== undefined) return Math.floor(record.time_us / 1000)
+  return Date.now()
+}
+
+export function parseSpacedustPackageLikeEvent(
+  payload: unknown,
+  likedAt: number = Date.now(),
+): RecentPackageLike | null {
+  const parsedPayload = v.safeParse(SpacedustPackageLikeEventSchema, payload)
+  if (!parsedPayload.success) return null
+
+  const { subject, source_record: sourceRecord } = parsedPayload.output.link
+  const packageName = packageNameFromSubjectRef(subject)
+  if (!packageName) return null
+
+  return {
+    id: sourceRecord ?? `${subject}:${likedAt}`,
+    packageName,
+    origin: 'live',
+    subjectRef: subject,
+    likedAt,
+  }
+}
+
+export function parseUfosPackageLikeRecords(payload: unknown): RecentPackageLike[] {
+  const parsedPayload = v.safeParse(UfosPackageLikeRecordsSchema, payload)
+  if (!parsedPayload.success) return []
+
+  return parsedPayload.output.flatMap((record): RecentPackageLike[] => {
+    const packageName = packageNameFromSubjectRef(record.record.subjectRef)
+    if (!packageName) return []
+
+    return [
+      {
+        id: `at://${record.did}/${record.collection}/${record.rkey}`,
+        packageName,
+        origin: 'recent',
+        subjectRef: record.record.subjectRef,
+        likedAt: likedAtFromUfosRecord(record),
+      },
+    ]
+  })
+}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -9,6 +9,14 @@
   "built_at": "built {0}",
   "alt_logo": "npmx logo",
   "tagline": "a fast, modern browser for the npm registry",
+  "home": {
+    "recently_liked": {
+      "title": "Recently liked packages",
+      "liked_prefix": "liked",
+      "announcement": "{packageName} was liked",
+      "empty": "listening for package likes..."
+    }
+  },
   "non_affiliation_disclaimer": "not affiliated with npm, Inc.",
   "trademark_disclaimer": "npm is a registered trademark of npm, Inc. This site is not affiliated with npm, Inc.",
   "footer": {

--- a/i18n/locales/fr-FR.json
+++ b/i18n/locales/fr-FR.json
@@ -9,6 +9,14 @@
   "built_at": "compilé le {0}",
   "alt_logo": "Logo npmx",
   "tagline": "un explorateur rapide et moderne du registre npm",
+  "home": {
+    "recently_liked": {
+      "title": "Paquets récemment aimés",
+      "liked_prefix": "aimé",
+      "announcement": "{packageName} a été aimé",
+      "empty": "en attente des mentions J'aime de paquets..."
+    }
+  },
   "non_affiliation_disclaimer": "non affilié à npm, Inc.",
   "trademark_disclaimer": "npm est une marque déposée de npm, Inc. Ce site n'est pas affilié à npm, Inc.",
   "footer": {

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -31,6 +31,30 @@
     "tagline": {
       "type": "string"
     },
+    "home": {
+      "type": "object",
+      "properties": {
+        "recently_liked": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "liked_prefix": {
+              "type": "string"
+            },
+            "announcement": {
+              "type": "string"
+            },
+            "empty": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "non_affiliation_disclaimer": {
       "type": "string"
     },

--- a/modules/runtime/server/cache.ts
+++ b/modules/runtime/server/cache.ts
@@ -187,6 +187,13 @@ function getMockForUrl(url: string): MockResult | null {
     return null
   }
 
+  if (
+    host === 'npmx-likes-leaderboard-api-production.up.railway.app' &&
+    pathname === '/api/leaderboard/likes'
+  ) {
+    return { data: [] }
+  }
+
   // npm API: downloads range → synthetic daily data for sparklines
   if (host === 'api.npmjs.org') {
     const rangeMatch = decodeURIComponent(pathname).match(/^\/downloads\/range\/([^/]+)\/(.+)$/)

--- a/modules/security-headers.ts
+++ b/modules/security-headers.ts
@@ -1,6 +1,6 @@
 import process from 'node:process'
 import { defineNuxtModule, useNuxt } from 'nuxt/kit'
-import { BLUESKY_API } from '#shared/utils/constants'
+import { BLUESKY_API, SPACEDUST_HOST, UFOS_API_HOST } from '#shared/utils/constants'
 import { ALL_KNOWN_GIT_API_ORIGINS } from '#shared/utils/git-providers'
 import { TRUSTED_IMAGE_DOMAINS } from '#server/utils/image-proxy'
 
@@ -51,6 +51,8 @@ export default defineNuxtModule({
       'https://api.npmjs.org',
       'https://npm.antfu.dev',
       BLUESKY_API,
+      `https://${UFOS_API_HOST}`,
+      `wss://${SPACEDUST_HOST}`,
       ...ALL_KNOWN_GIT_API_ORIGINS,
       // Local CLI connector (npmx CLI communicates via localhost)
       'http://127.0.0.1:*',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -133,7 +133,13 @@ export default defineNuxtConfig({
     '/api/registry/file/**': { isr: true, cache: { maxAge: 365 * 24 * 60 * 60 } },
     '/api/registry/provenance/**': { isr: true, cache: { maxAge: 365 * 24 * 60 * 60 } },
     '/api/registry/files/**': { isr: true, cache: { maxAge: 365 * 24 * 60 * 60 } },
-    '/api/registry/package-meta/**': { isr: 300 },
+    '/api/registry/package-meta/**': {
+      isr: {
+        expiration: 300,
+        passQuery: true,
+        allowQuery: ['includeRepositoryStars'],
+      },
+    },
     '/:pkg/.well-known/skills/**': { isr: 3600 },
     '/:scope/:pkg/.well-known/skills/**': { isr: 3600 },
     '/_avatar/**': { isr: 3600, proxy: 'https://www.gravatar.com/avatar/**' },

--- a/server/api/registry/package-meta/[...pkg].get.ts
+++ b/server/api/registry/package-meta/[...pkg].get.ts
@@ -20,6 +20,7 @@ export default defineCachedEventHandler(
 
     const packageName = decodeURIComponent(pkgParam)
     const encodedName = encodePackageName(packageName)
+    const includeRepositoryStars = shouldIncludeRepositoryStars(getQuery(event))
 
     try {
       const [packument, downloads] = await Promise.all([
@@ -49,6 +50,16 @@ export default defineCachedEventHandler(
             .replace(/\.git$/, '')
         }
       }
+      const cachedFetch = event.context.cachedFetch
+      if (includeRepositoryStars && !cachedFetch) {
+        console.error('[package-meta] Missing cachedFetch in request context')
+      }
+
+      const repositoryRef = repositoryUrl ? parseRepoUrl(repositoryUrl) : null
+      const repositoryStars =
+        includeRepositoryStars && cachedFetch && repositoryRef
+          ? await getRepositoryStars(cachedFetch, repositoryRef)
+          : null
 
       // Extract bugs URL
       // TODO: @npm/types types bugs as { email?: string; url?: string } on
@@ -86,6 +97,7 @@ export default defineCachedEventHandler(
         author,
         maintainers: packument.maintainers,
         weeklyDownloads: downloads?.downloads,
+        ...(includeRepositoryStars ? { repositoryStars } : {}),
       }
     } catch (error: unknown) {
       handleApiError(error, {
@@ -99,7 +111,7 @@ export default defineCachedEventHandler(
     swr: true,
     getKey: event => {
       const pkg = getRouterParam(event, 'pkg') ?? ''
-      return `package-meta:v1:${pkg}`
+      return getPackageMetaCacheKey(pkg, shouldIncludeRepositoryStars(getQuery(event)))
     },
   },
 )

--- a/server/utils/package-meta.ts
+++ b/server/utils/package-meta.ts
@@ -1,0 +1,13 @@
+function isTruthyQueryValue(value: unknown): boolean {
+  const normalizedValue = Array.isArray(value) ? value[0] : value
+  return normalizedValue === 'true' || normalizedValue === '1'
+}
+
+export function shouldIncludeRepositoryStars(query: Record<string, unknown>): boolean {
+  return isTruthyQueryValue(query.includeRepositoryStars)
+}
+
+export function getPackageMetaCacheKey(pkg: string, includeRepositoryStars: boolean): string {
+  const starsCacheKey = includeRepositoryStars ? 'stars:1' : 'stars:0'
+  return `package-meta:v2:${starsCacheKey}:${pkg}`
+}

--- a/shared/utils/constants.ts
+++ b/shared/utils/constants.ts
@@ -56,7 +56,9 @@ export const ERROR_UNGH_API_KEY_EXHAUSTED =
 
 // microcosm services
 export const CONSTELLATION_HOST = 'constellation.microcosm.blue'
+export const SPACEDUST_HOST = 'spacedust.microcosm.blue'
 export const SLINGSHOT_HOST = 'slingshot.microcosm.blue'
+export const UFOS_API_HOST = 'ufos-api.microcosm.blue'
 
 // ATProtocol
 // References used to link packages to things that are not inherently atproto

--- a/test/e2e/recent-package-likes.spec.ts
+++ b/test/e2e/recent-package-likes.spec.ts
@@ -1,0 +1,38 @@
+import { createRequire } from 'node:module'
+import { expect, test } from './test-utils'
+
+const require = createRequire(import.meta.url)
+const spacedustPackageLikeEvents =
+  require('../fixtures/spacedust/package-like-events.json') as unknown[]
+
+test.use({ spacedustPackageLikeEvents: [spacedustPackageLikeEvents, { scope: 'test' }] })
+
+test('homepage streams recently liked packages from backfill and Spacedust', async ({
+  page,
+  goto,
+  spacedustWebSocketUrls,
+}) => {
+  await goto('/', { waitUntil: 'hydration' })
+
+  const widget = page.getByTestId('recently-liked-packages')
+  await expect(widget.getByRole('heading', { name: 'Recently liked packages' })).toBeVisible()
+
+  const packageLinks = widget.getByTestId('recently-liked-package')
+  await expect(packageLinks).toHaveCount(3, { timeout: 10_000 })
+  await expect(packageLinks.nth(0)).toContainText('is-odd')
+  await expect(packageLinks.nth(1)).toContainText('ufo')
+  await expect(packageLinks.nth(2)).toContainText('vue')
+
+  await expect(widget).toContainText('Returns true if the given number is odd')
+  await expect(widget).toContainText('URL utils for humans')
+  await expect(widget).toContainText('The progressive JavaScript framework')
+  await expect(widget).toContainText('/wk')
+  await expect(widget.getByRole('button', { name: 'Like this package' })).toHaveCount(3)
+
+  expect(spacedustWebSocketUrls).toHaveLength(1)
+  const spacedustUrl = new URL(spacedustWebSocketUrls[0]!)
+  expect(spacedustUrl.searchParams.get('instant')).toBe('true')
+  expect(spacedustUrl.searchParams.getAll('wantedSources')).toEqual([
+    'dev.npmx.feed.like:subjectRef',
+  ])
+})

--- a/test/e2e/security-headers.spec.ts
+++ b/test/e2e/security-headers.spec.ts
@@ -13,6 +13,8 @@ test.describe('security headers', () => {
     expect(cspContent).toContain('https://api.star-history.com')
     expect(cspContent).toContain('https://cdn.bsky.app')
     expect(cspContent).toContain('https://public.api.bsky.app')
+    expect(cspContent).toContain('https://ufos-api.microcosm.blue')
+    expect(cspContent).toContain('wss://spacedust.microcosm.blue')
 
     // Other security headers via route rules
     expect(headers['x-content-type-options']).toBe('nosniff')

--- a/test/e2e/test-utils.ts
+++ b/test/e2e/test-utils.ts
@@ -49,6 +49,28 @@ async function setupRouteMocking(page: Page): Promise<void> {
   }
 }
 
+async function setupSpacedustMocking(
+  page: Page,
+  messages: readonly unknown[],
+  routedUrls: string[],
+): Promise<void> {
+  await page.routeWebSocket(
+    url => url.hostname === 'spacedust.microcosm.blue' && url.pathname === '/subscribe',
+    ws => {
+      routedUrls.push(ws.url())
+
+      messages.forEach((message, index) => {
+        setTimeout(
+          () => {
+            ws.send(JSON.stringify(message))
+          },
+          200 + index * 500,
+        )
+      })
+    },
+  )
+}
+
 /**
  * Patterns that indicate a Vue hydration mismatch in console output.
  *
@@ -98,6 +120,8 @@ function isCspViolation(message: ConsoleMessage): boolean {
  */
 export const test = base.extend<{
   mockExternalApis: void
+  spacedustPackageLikeEvents: readonly unknown[]
+  spacedustWebSocketUrls: string[]
   hydrationErrors: string[]
   cspViolations: string[]
 }>({
@@ -105,6 +129,17 @@ export const test = base.extend<{
     async ({ page }, use) => {
       await setupRouteMocking(page)
       await use()
+    },
+    { auto: true },
+  ],
+
+  spacedustPackageLikeEvents: [[], { option: true }],
+
+  spacedustWebSocketUrls: [
+    async ({ page, spacedustPackageLikeEvents }, use) => {
+      const routedUrls: string[] = []
+      await setupSpacedustMocking(page, spacedustPackageLikeEvents, routedUrls)
+      await use(routedUrls)
     },
     { auto: true },
   ],

--- a/test/fixtures/mock-routes.cjs
+++ b/test/fixtures/mock-routes.cjs
@@ -500,6 +500,34 @@ function matchConstellationApi(urlString) {
   return json(null)
 }
 
+/**
+ * @param {string} urlString
+ * @returns {MockResponse | null}
+ */
+function matchUfosApi(urlString) {
+  const url = new URL(urlString)
+
+  if (url.pathname === '/records' && url.searchParams.get('collection') === 'dev.npmx.feed.like') {
+    return json(readFixture('ufos/package-like-records.json') || [])
+  }
+
+  return null
+}
+
+/**
+ * @param {string} urlString
+ * @returns {MockResponse | null}
+ */
+function matchLikesLeaderboardApi(urlString) {
+  const url = new URL(urlString)
+
+  if (url.pathname === '/api/leaderboard/likes') {
+    return json([])
+  }
+
+  return null
+}
+
 const BLUESKY_EMBED_DID = 'did:plc:2gkh62xvzokhlf6li4ol3b3d'
 
 /**
@@ -675,6 +703,12 @@ const routes = [
     name: 'Constellation API',
     pattern: 'https://constellation.microcosm.blue/**',
     match: matchConstellationApi,
+  },
+  { name: 'UFOs API', pattern: 'https://ufos-api.microcosm.blue/**', match: matchUfosApi },
+  {
+    name: 'Likes Leaderboard API',
+    pattern: 'https://npmx-likes-leaderboard-api-production.up.railway.app/**',
+    match: matchLikesLeaderboardApi,
   },
   { name: 'Bluesky API', pattern: 'https://public.api.bsky.app/**', match: matchBlueskyApi },
   { name: 'Bluesky CDN', pattern: 'https://cdn.bsky.app/**', match: matchBlueskyCdn },

--- a/test/fixtures/spacedust/package-like-events.json
+++ b/test/fixtures/spacedust/package-like-events.json
@@ -1,0 +1,22 @@
+[
+  {
+    "kind": "link",
+    "origin": "live",
+    "link": {
+      "operation": "create",
+      "source": "dev.npmx.feed.like:subjectRef",
+      "source_record": "at://did:plc:e2e-live/dev.npmx.feed.like/live-ufo",
+      "subject": "https://npmx.dev/package/ufo"
+    }
+  },
+  {
+    "kind": "link",
+    "origin": "live",
+    "link": {
+      "operation": "create",
+      "source": "dev.npmx.feed.like:subjectRef",
+      "source_record": "at://did:plc:e2e-live/dev.npmx.feed.like/live-is-odd",
+      "subject": "https://npmx.dev/package/is-odd"
+    }
+  }
+]

--- a/test/fixtures/ufos/package-like-records.json
+++ b/test/fixtures/ufos/package-like-records.json
@@ -1,0 +1,12 @@
+[
+  {
+    "did": "did:plc:e2e-seed",
+    "collection": "dev.npmx.feed.like",
+    "rkey": "seed-vue",
+    "record": {
+      "createdAt": "2024-01-01T12:00:00.000Z",
+      "subjectRef": "https://npmx.dev/package/vue"
+    },
+    "time_us": 1704110400000000
+  }
+]

--- a/test/nuxt/a11y.spec.ts
+++ b/test/nuxt/a11y.spec.ts
@@ -268,6 +268,7 @@ import {
 import LogoNuxt from '~/assets/logos/oss-partners/nuxt.svg'
 import CommandPaletteComponent from '~/components/CommandPalette.client.vue'
 import HeaderAccountMenuServer from '~/components/Header/AccountMenu.server.vue'
+import LandingRecentlyLiked from '~/components/Landing/RecentlyLiked.vue'
 import ToggleServer from '~/components/Settings/Toggle.server.vue'
 import SearchProviderToggleServer from '~/components/SearchProviderToggle.server.vue'
 import PackageTrendsChart from '~/components/Package/TrendsChart.vue'
@@ -362,6 +363,40 @@ describe('component accessibility audits', () => {
   describe('LandingIntroHeader', () => {
     it('should have no accessibility violations', async () => {
       const component = await mountSuspended(LandingIntroHeader)
+      const results = await runAxe(component)
+      expect(results.violations).toEqual([])
+    })
+  })
+
+  describe('LandingRecentlyLiked', () => {
+    it('should have no accessibility violations', async () => {
+      registerEndpoint('/api/social/likes/vue', () => ({
+        totalLikes: 42,
+        userHasLiked: false,
+        topLikedRank: null,
+      }))
+
+      const component = await mountSuspended(LandingRecentlyLiked, {
+        props: {
+          likes: [
+            {
+              id: 'at://did:plc:test/dev.npmx.feed.like/3mtest',
+              packageName: 'vue',
+              origin: 'live',
+              subjectRef: 'https://npmx.dev/package/vue',
+              likedAt: Date.parse('2026-05-09T12:28:11.127Z'),
+              packageDescription: 'The progressive JavaScript framework',
+              weeklyDownloads: 5_000_000,
+              repositoryStars: 55_555,
+            },
+          ],
+        },
+        global: {
+          stubs: {
+            TransitionGroup: false,
+          },
+        },
+      })
       const results = await runAxe(component)
       expect(results.violations).toEqual([])
     })

--- a/test/nuxt/components/Landing/RecentlyLiked.spec.ts
+++ b/test/nuxt/components/Landing/RecentlyLiked.spec.ts
@@ -1,0 +1,140 @@
+import type { RecentPackageLike } from '~/utils/recent-package-likes'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import RecentlyLiked from '~/components/Landing/RecentlyLiked.vue'
+
+const packageLikesStub = {
+  template: '<button type="button" data-testid="package-likes-stub">Like</button>',
+}
+
+function like(overrides: Partial<RecentPackageLike> = {}): RecentPackageLike {
+  const packageName = overrides.packageName ?? 'vue'
+  const rkey = packageName.replaceAll('/', '-')
+
+  return {
+    id: `at://did:plc:test/dev.npmx.feed.like/${rkey}`,
+    packageName,
+    origin: 'recent',
+    subjectRef: `https://npmx.dev/package/${packageName}`,
+    likedAt: Date.parse('2026-05-09T12:28:11.127Z'),
+    ...overrides,
+  }
+}
+
+describe('LandingRecentlyLiked', () => {
+  it('reserves space while the startup seed is loading', async () => {
+    const wrapper = await mountSuspended(RecentlyLiked, {
+      props: { isLoading: true, likes: [] },
+      global: { stubs: { PackageLikes: packageLikesStub } },
+    })
+
+    expect(wrapper.find('[data-testid="recently-liked-packages"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="recently-liked-skeleton"]').exists()).toBe(true)
+    expect(wrapper.findAll('[data-testid="recently-liked-skeleton"] li')).toHaveLength(5)
+  })
+
+  it('renders recent package likes as package links', async () => {
+    const wrapper = await mountSuspended(RecentlyLiked, {
+      props: {
+        isLoading: false,
+        likes: [
+          like({
+            packageDescription: 'The progressive JavaScript framework',
+            weeklyDownloads: 12_345,
+            repositoryStars: 55_555,
+          }),
+        ],
+      },
+      global: { stubs: { PackageLikes: packageLikesStub } },
+    })
+
+    const link = wrapper.find('[data-testid="recently-liked-package"]')
+
+    expect(wrapper.text()).toContain('Recently liked')
+    expect(link.text()).toContain('vue')
+    expect(link.text()).toContain('liked')
+    expect(link.text()).toContain('The progressive JavaScript framework')
+    expect(wrapper.text()).toContain('55.6K')
+    expect(wrapper.text()).toContain('12.3K/wk')
+    expect(wrapper.find('[data-testid="recently-liked-time"]').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('recent package love')
+    expect(wrapper.find('[data-testid="package-likes-stub"]').exists()).toBe(true)
+    expect(link.attributes('href')).toBe('/package/vue')
+  })
+
+  it('applies the entry animation to live and staged likes', async () => {
+    const wrapper = await mountSuspended(RecentlyLiked, {
+      props: {
+        isLoading: false,
+        likes: [
+          like({
+            origin: 'live',
+          }),
+          like({
+            id: 'at://did:plc:test/dev.npmx.feed.like/staged',
+            packageName: 'nuxt',
+            likedAt: Date.parse('2026-05-09T12:24:11.127Z'),
+            animateEntry: true,
+          }),
+          like({
+            id: 'at://did:plc:test/dev.npmx.feed.like/recent',
+            packageName: 'nuxt',
+            likedAt: Date.parse('2026-05-09T12:20:11.127Z'),
+          }),
+        ],
+      },
+      global: { stubs: { PackageLikes: packageLikesStub } },
+    })
+
+    const cards = wrapper.findAll('article')
+    expect(cards[0]?.classes()).toContain('recently-liked-entry')
+    expect(cards[1]?.classes()).toContain('recently-liked-entry')
+    expect(cards[2]?.classes()).not.toContain('recently-liked-entry')
+  })
+
+  it('scopes screen reader announcements to newly inserted live likes', async () => {
+    const wrapper = await mountSuspended(RecentlyLiked, {
+      props: { isLoading: false, likes: [] },
+      global: { stubs: { PackageLikes: packageLikesStub } },
+    })
+
+    const section = wrapper.find('[data-testid="recently-liked-packages"]')
+    const status = wrapper.find('[role="status"][aria-live="polite"]')
+
+    expect(section.attributes('aria-live')).toBeUndefined()
+    expect(status.text()).toBe('')
+
+    await wrapper.setProps({
+      likes: [
+        like({
+          id: 'at://did:plc:test/dev.npmx.feed.like/recent',
+          packageName: 'nuxt',
+          likedAt: Date.parse('2026-05-09T12:20:11.127Z'),
+          animateEntry: true,
+        }),
+      ],
+    })
+    await nextTick()
+
+    expect(status.text()).toBe('')
+
+    await wrapper.setProps({
+      likes: [
+        like({
+          origin: 'live',
+          animateEntry: true,
+        }),
+        like({
+          id: 'at://did:plc:test/dev.npmx.feed.like/recent',
+          packageName: 'nuxt',
+          likedAt: Date.parse('2026-05-09T12:20:11.127Z'),
+          animateEntry: true,
+        }),
+      ],
+    })
+    await nextTick()
+
+    expect(status.text()).toBe('vue was liked')
+  })
+})

--- a/test/unit/app/utils/recent-package-likes.spec.ts
+++ b/test/unit/app/utils/recent-package-likes.spec.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SPACEDUST_PACKAGE_LIKE_SOURCE,
+  createPackageLikesSeedUrl,
+  createPackageLikesStreamUrl,
+  packageNameFromSubjectRef,
+  parseSpacedustPackageLikeEvent,
+  parseUfosPackageLikeRecords,
+} from '~/utils/recent-package-likes'
+
+describe('createPackageLikesStreamUrl', () => {
+  it('connects to the filtered Spacedust package-like stream', () => {
+    const url = new URL(createPackageLikesStreamUrl())
+
+    expect(url.protocol).toBe('wss:')
+    expect(url.host).toBe('spacedust.microcosm.blue')
+    expect(url.pathname).toBe('/subscribe')
+    expect(url.searchParams.get('instant')).toBe('true')
+    expect(url.searchParams.getAll('wantedSources')).toEqual([SPACEDUST_PACKAGE_LIKE_SOURCE])
+  })
+})
+
+describe('createPackageLikesSeedUrl', () => {
+  it('connects to the UFOs recent package-like records feed', () => {
+    const url = new URL(createPackageLikesSeedUrl())
+
+    expect(url.protocol).toBe('https:')
+    expect(url.host).toBe('ufos-api.microcosm.blue')
+    expect(url.pathname).toBe('/records')
+    expect(url.searchParams.get('collection')).toBe('dev.npmx.feed.like')
+  })
+})
+
+describe('packageNameFromSubjectRef', () => {
+  it('extracts package names from npmx package subject refs', () => {
+    expect(packageNameFromSubjectRef('https://npmx.dev/package/vue')).toBe('vue')
+    expect(packageNameFromSubjectRef('https://npmx.dev/package/@nuxt/kit')).toBe('@nuxt/kit')
+    expect(packageNameFromSubjectRef('https://example.com/package/vue')).toBeNull()
+  })
+})
+
+describe('parseSpacedustPackageLikeEvent', () => {
+  it('parses Spacedust create events for package likes', () => {
+    expect(
+      parseSpacedustPackageLikeEvent(
+        {
+          kind: 'link',
+          origin: 'live',
+          link: {
+            operation: 'create',
+            source: SPACEDUST_PACKAGE_LIKE_SOURCE,
+            source_record: 'at://did:plc:test/dev.npmx.feed.like/3mtest',
+            source_rev: '3mtest',
+            subject: 'https://npmx.dev/package/vue',
+          },
+        },
+        123,
+      ),
+    ).toEqual({
+      id: 'at://did:plc:test/dev.npmx.feed.like/3mtest',
+      packageName: 'vue',
+      origin: 'live',
+      subjectRef: 'https://npmx.dev/package/vue',
+      likedAt: 123,
+    })
+  })
+
+  it('ignores deletes, other link sources, non-package links, and non-live origins', () => {
+    expect(
+      parseSpacedustPackageLikeEvent({
+        kind: 'link',
+        link: {
+          operation: 'delete',
+          source: SPACEDUST_PACKAGE_LIKE_SOURCE,
+          subject: 'https://npmx.dev/package/vue',
+        },
+      }),
+    ).toBeNull()
+
+    expect(
+      parseSpacedustPackageLikeEvent({
+        kind: 'link',
+        link: {
+          operation: 'create',
+          source: 'app.bsky.graph.follow:subject',
+          subject: 'https://npmx.dev/package/vue',
+        },
+      }),
+    ).toBeNull()
+
+    expect(
+      parseSpacedustPackageLikeEvent({
+        kind: 'link',
+        link: {
+          operation: 'create',
+          source: SPACEDUST_PACKAGE_LIKE_SOURCE,
+          subject: 'https://example.com/package/vue',
+        },
+      }),
+    ).toBeNull()
+
+    expect(
+      parseSpacedustPackageLikeEvent({
+        kind: 'link',
+        origin: 'batch',
+        link: {
+          operation: 'create',
+          source: SPACEDUST_PACKAGE_LIKE_SOURCE,
+          subject: 'https://npmx.dev/package/vue',
+        },
+      }),
+    ).toBeNull()
+
+    expect(
+      parseSpacedustPackageLikeEvent({
+        kind: 'link',
+        origin: 'replay',
+        link: {
+          operation: 'create',
+          source: SPACEDUST_PACKAGE_LIKE_SOURCE,
+          subject: 'https://npmx.dev/package/vue',
+        },
+      }),
+    ).toBeNull()
+
+    expect(
+      parseSpacedustPackageLikeEvent({
+        kind: 'link',
+        origin: 'backfill',
+        link: {
+          operation: 'create',
+          source: SPACEDUST_PACKAGE_LIKE_SOURCE,
+          subject: 'https://npmx.dev/package/@nuxt/kit',
+        },
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('parseUfosPackageLikeRecords', () => {
+  it('parses UFOs recent package like records for the startup seed', () => {
+    expect(
+      parseUfosPackageLikeRecords([
+        {
+          did: 'did:plc:test',
+          collection: 'dev.npmx.feed.like',
+          rkey: '3mtest',
+          record: {
+            $type: 'dev.npmx.feed.like',
+            createdAt: '2026-05-09T12:28:11.127Z',
+            subjectRef: 'https://npmx.dev/package/@tanstack/solid-start',
+          },
+          time_us: 1778329691492023,
+        },
+        {
+          did: 'did:plc:test',
+          collection: 'dev.npmx.feed.like',
+          rkey: '3mignored',
+          record: {
+            $type: 'dev.npmx.feed.like',
+            subjectRef: 'https://example.com/package/vue',
+          },
+        },
+      ]),
+    ).toEqual([
+      {
+        id: 'at://did:plc:test/dev.npmx.feed.like/3mtest',
+        packageName: '@tanstack/solid-start',
+        origin: 'recent',
+        subjectRef: 'https://npmx.dev/package/@tanstack/solid-start',
+        likedAt: Date.parse('2026-05-09T12:28:11.127Z'),
+      },
+    ])
+  })
+})

--- a/test/unit/modules/security-headers.spec.ts
+++ b/test/unit/modules/security-headers.spec.ts
@@ -78,6 +78,8 @@ describe('security headers module', () => {
     const csp = getCsp(nuxt)
 
     expect(csp).toContain('ws://localhost:*')
+    expect(csp).toContain('https://ufos-api.microcosm.blue')
+    expect(csp).toContain('wss://spacedust.microcosm.blue')
     expect(csp).toContain(
       "frame-src https://bsky.app https://pdsmoover.com https://www.youtube-nocookie.com/ 'self'",
     )

--- a/test/unit/server/utils/package-meta.spec.ts
+++ b/test/unit/server/utils/package-meta.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { getPackageMetaCacheKey, shouldIncludeRepositoryStars } from '#server/utils/package-meta'
+
+describe('shouldIncludeRepositoryStars', () => {
+  it('requires an explicit truthy repository-stars opt-in', () => {
+    expect(shouldIncludeRepositoryStars({})).toBe(false)
+    expect(shouldIncludeRepositoryStars({ includeRepositoryStars: 'false' })).toBe(false)
+    expect(shouldIncludeRepositoryStars({ includeRepositoryStars: '0' })).toBe(false)
+    expect(shouldIncludeRepositoryStars({ includeRepositoryStars: true })).toBe(false)
+    expect(shouldIncludeRepositoryStars({ includeRepositoryStars: 'true' })).toBe(true)
+    expect(shouldIncludeRepositoryStars({ includeRepositoryStars: '1' })).toBe(true)
+  })
+})
+
+describe('getPackageMetaCacheKey', () => {
+  it('partitions cached responses by package name', () => {
+    expect(getPackageMetaCacheKey('vue', false)).not.toBe(getPackageMetaCacheKey('nuxt', false))
+  })
+
+  it('partitions cached responses by `includeRepositoryStars`', () => {
+    expect(getPackageMetaCacheKey('@scope/pkg', false)).not.toBe(
+      getPackageMetaCacheKey('@scope/pkg', true),
+    )
+  })
+
+  it('keeps cache keys stable for the same inputs', () => {
+    expect(getPackageMetaCacheKey('@scope/pkg', true)).toBe(
+      getPackageMetaCacheKey('@scope/pkg', true),
+    )
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

N/A 😁

### 🧭 Context

The homepage is minimal at the moment. There's an opportunity to use that highly visible real estate to lean into social features while providing value through package discovery. As a bonus, this makes our package like feature more discoverable.

### 📚 Description

https://github.com/user-attachments/assets/e82e7349-b985-4bae-a33a-91873668872b

This adds a Recently Liked Packages feed to the homepage, powered by [Spacedust](https://www.microcosm.blue/) package like events.

The feed loads deferred on the client so the home page load stays non-blocking.

Because the npmx package like throughput is quite low at the moment (<10/day 🥹), just about no one would ever see anything if we truly only showed _live_ events here. Thus, to keep things engaging, we first fetch the 5 most recent likes (from the [UFOs](https://ufos.microcosm.blue/) service) and "replay" them, then start listening to the live stream. (🤞🏼 Perhaps someday we'll be able to remove this seeding!)