### PR TITLE
test: re-work some brittle atproto mocks

### DIFF
--- a/app/composables/atproto/useAtproto.ts
+++ b/app/composables/atproto/useAtproto.ts
@@ -5,7 +5,6 @@ export const useAtproto = createSharedComposable(function useAtproto() {
     clear,
   } = useFetch('/api/auth/session', {
     server: false,
-    immediate: !import.meta.test,
   })
 
   async function logout() {

--- a/test/nuxt/components/Package/Likes.spec.ts
+++ b/test/nuxt/components/Package/Likes.spec.ts
@@ -1,26 +1,26 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 import Likes from '~/components/Package/Likes.vue'
 
-const { mockUseAtproto } = vi.hoisted(() => ({
-  mockUseAtproto: vi.fn(),
-}))
+function createAtprotoUser(handle: string) {
+  return {
+    did: `did:plc:${handle}`,
+    handle,
+    pds: 'https://bsky.social',
+  }
+}
 
-vi.mock('~/composables/atproto/useAtproto', () => ({
-  useAtproto: mockUseAtproto,
-}))
+let authSessionHandler: () => unknown = () => null
+
+registerEndpoint('/api/auth/session', () => authSessionHandler())
 
 describe('PackageLikes', () => {
   let wrapper: VueWrapper | undefined
 
   beforeEach(() => {
-    mockUseAtproto.mockReturnValue({
-      user: ref(null),
-      pending: ref(false),
-      logout: vi.fn(),
-    })
+    clearNuxtData()
+    authSessionHandler = () => null
   })
 
   afterEach(() => {
@@ -74,27 +74,29 @@ describe('PackageLikes', () => {
   })
 
   it('keeps the top liked badge when a like response omits the rank', async () => {
+    let authSessionRequests = 0
     let likeRequests = 0
-
-    mockUseAtproto.mockReturnValue({
-      user: ref({ handle: 'tester.test' }),
-      pending: ref(false),
-      logout: vi.fn(),
-    })
+    authSessionHandler = () => {
+      authSessionRequests++
+      return createAtprotoUser('tester.test')
+    }
 
     registerEndpoint('/api/social/likes/svelte', () => ({
       totalLikes: 42,
       userHasLiked: false,
       topLikedRank: 3,
     }))
-    registerEndpoint('/api/social/like', () => {
-      likeRequests++
+    registerEndpoint('/api/social/like', {
+      method: 'POST',
+      handler: () => {
+        likeRequests++
 
-      return {
-        totalLikes: 43,
-        userHasLiked: true,
-        topLikedRank: null,
-      }
+        return {
+          totalLikes: 43,
+          userHasLiked: true,
+          topLikedRank: null,
+        }
+      },
     })
 
     wrapper = await mountSuspended(Likes, {
@@ -104,6 +106,7 @@ describe('PackageLikes', () => {
 
     await vi.waitFor(() => {
       expect(wrapper?.find('[data-testid="top-liked-badge"]').text()).toContain('#3')
+      expect(authSessionRequests).toBeGreaterThan(0)
     })
 
     await wrapper.get('button').trigger('click')

--- a/test/nuxt/components/ProfileInviteSection.spec.ts
+++ b/test/nuxt/components/ProfileInviteSection.spec.ts
@@ -1,15 +1,24 @@
+import type { VueWrapper } from '@vue/test-utils'
 import { mockNuxtImport, mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockUseAtproto, mockUseProfileLikes } = vi.hoisted(() => ({
-  mockUseAtproto: vi.fn(),
+const { mockUseProfileLikes } = vi.hoisted(() => ({
   mockUseProfileLikes: vi.fn(),
 }))
 
-mockNuxtImport('useAtproto', () => mockUseAtproto)
 mockNuxtImport('useProfileLikes', () => mockUseProfileLikes)
 
 import ProfilePage from '~/pages/profile/[identity]/index.vue'
+
+function createAtprotoUser(handle: string) {
+  return {
+    did: `did:plc:${handle}`,
+    handle,
+    pds: 'https://bsky.social',
+  }
+}
+
+let authSessionHandler: () => unknown | Promise<unknown> = () => null
 
 registerEndpoint('/api/social/profile/test-handle', () => ({
   displayName: 'Test User',
@@ -19,66 +28,81 @@ registerEndpoint('/api/social/profile/test-handle', () => ({
   recordExists: false,
 }))
 
+registerEndpoint('/api/auth/session', () => authSessionHandler())
+
 describe('Profile invite section', () => {
+  let wrapper: VueWrapper | undefined
+
   beforeEach(() => {
-    mockUseAtproto.mockReset()
+    clearNuxtData()
+    authSessionHandler = () => null
     mockUseProfileLikes.mockReset()
   })
 
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = undefined
+  })
+
   it('does not show invite section while auth is still loading', async () => {
-    mockUseAtproto.mockReturnValue({
-      user: ref(null),
-      pending: ref(true),
-      logout: vi.fn(),
-    })
+    let resolveAuthSession!: () => void
+    authSessionHandler = () =>
+      new Promise(resolve => {
+        resolveAuthSession = () => resolve(null)
+      })
 
     mockUseProfileLikes.mockReturnValue({
       data: ref({ records: [] }),
       status: ref('success'),
     })
 
-    const wrapper = await mountSuspended(ProfilePage, {
+    const component = await mountSuspended(ProfilePage, {
       route: '/profile/test-handle',
     })
+    wrapper = component
 
-    expect(wrapper.text()).not.toContain("It doesn't look like they're using npmx yet")
+    expect(component.text()).not.toContain("It doesn't look like they're using npmx yet")
+    resolveAuthSession()
   })
 
   it('shows invite section after auth resolves for non-owner', async () => {
-    mockUseAtproto.mockReturnValue({
-      user: ref({ handle: 'other-user' }),
-      pending: ref(false),
-      logout: vi.fn(),
-    })
+    authSessionHandler = () => createAtprotoUser('other-user')
 
     mockUseProfileLikes.mockReturnValue({
       data: ref({ records: [] }),
       status: ref('success'),
     })
 
-    const wrapper = await mountSuspended(ProfilePage, {
+    const component = await mountSuspended(ProfilePage, {
       route: '/profile/test-handle',
     })
+    wrapper = component
 
-    expect(wrapper.text()).toContain("It doesn't look like they're using npmx yet")
+    await vi.waitFor(() => {
+      expect(component.text()).toContain("It doesn't look like they're using npmx yet")
+    })
   })
 
   it('does not show invite section for profile owner', async () => {
-    mockUseAtproto.mockReturnValue({
-      user: ref({ handle: 'test-handle' }),
-      pending: ref(false),
-      logout: vi.fn(),
-    })
+    let authSessionRequests = 0
+    authSessionHandler = () => {
+      authSessionRequests++
+      return createAtprotoUser('test-handle')
+    }
 
     mockUseProfileLikes.mockReturnValue({
       data: ref({ records: [] }),
       status: ref('success'),
     })
 
-    const wrapper = await mountSuspended(ProfilePage, {
+    const component = await mountSuspended(ProfilePage, {
       route: '/profile/test-handle',
     })
+    wrapper = component
 
-    expect(wrapper.text()).not.toContain("It doesn't look like they're using npmx yet")
+    await vi.waitFor(() => {
+      expect(authSessionRequests).toBeGreaterThan(0)
+    })
+    expect(component.text()).not.toContain("It doesn't look like they're using npmx yet")
   })
 })

--- a/test/nuxt/composables/use-command-palette-commands.spec.ts
+++ b/test/nuxt/composables/use-command-palette-commands.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { computed, defineComponent, h, ref, watchEffect, type Ref } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
-import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { mockNuxtImport, mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
 import { downloadPackageTarball } from '~/utils/package-download'
 import type {
   CommandPaletteCommand,
@@ -23,9 +23,16 @@ const mockConnectorState = ref<{
   npmUser: null,
 })
 
-const mockAtprotoHandle = ref<string | null>(null)
 const mockDisconnectNpm = vi.fn()
-const mockLogout = vi.fn(async () => {})
+let authSessionHandler: () => unknown = () => null
+
+function createAtprotoUser(handle: string) {
+  return {
+    did: `did:plc:${handle}`,
+    handle,
+    pds: 'https://bsky.social',
+  }
+}
 
 mockNuxtImport('useConnector', () => {
   return () => ({
@@ -35,12 +42,7 @@ mockNuxtImport('useConnector', () => {
   })
 })
 
-mockNuxtImport('useAtproto', () => {
-  return () => ({
-    user: computed(() => (mockAtprotoHandle.value ? { handle: mockAtprotoHandle.value } : null)),
-    logout: mockLogout,
-  })
-})
+registerEndpoint('/api/auth/session', () => authSessionHandler())
 
 async function captureCommandPalette(options?: {
   route?: string
@@ -62,7 +64,8 @@ async function captureCommandPalette(options?: {
     connected: !!options?.npmUser,
     npmUser: options?.npmUser ?? null,
   }
-  mockAtprotoHandle.value = options?.atprotoHandle ?? null
+  authSessionHandler = () =>
+    options?.atprotoHandle ? createAtprotoUser(options.atprotoHandle) : null
 
   const WrapperComponent = defineComponent({
     setup() {
@@ -122,7 +125,8 @@ afterEach(() => {
     connected: false,
     npmUser: null,
   }
-  mockAtprotoHandle.value = null
+  clearNuxtData()
+  authSessionHandler = () => null
   vi.clearAllMocks()
 })
 
@@ -312,6 +316,12 @@ describe('useCommandPaletteCommands', () => {
   })
 
   it('adds atproto account commands and disconnect support when a profile is connected', async () => {
+    const deleteSession = vi.fn(() => null)
+    registerEndpoint('/api/auth/session', {
+      method: 'DELETE',
+      handler: deleteSession,
+    })
+
     const { wrapper, flatCommands } = await captureCommandPalette({
       route: '/profile/alice.bsky.social',
       atprotoHandle: 'alice.bsky.social',
@@ -319,12 +329,14 @@ describe('useCommandPaletteCommands', () => {
     const commandPalette = useCommandPalette()
     commandPalette.open()
 
-    expect(flatCommands.value.find(command => command.id === 'atproto-disconnect')).toBeTruthy()
-    expect(flatCommands.value.find(command => command.id === 'my-profile')?.active).toBe(true)
+    await vi.waitFor(() => {
+      expect(flatCommands.value.find(command => command.id === 'atproto-disconnect')).toBeTruthy()
+      expect(flatCommands.value.find(command => command.id === 'my-profile')?.active).toBe(true)
+    })
 
     await flatCommands.value.find(command => command.id === 'atproto-disconnect')?.action?.()
 
-    expect(mockLogout).toHaveBeenCalledTimes(1)
+    expect(deleteSession).toHaveBeenCalledTimes(1)
     expect(commandPalette.isOpen.value).toBe(false)
 
     wrapper.unmount()


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

I dunno, these started failing on a completely unrelated branch and simplifying them like this fixed it 😅.

### 📚 Description

- Don't configure different behaviour in test than elsewhere.
- Stop mocking `useAtproto` in a few tests, instead mocking the auth endpoint. These tests were brittle because they mocked with partial or otherwise not-quite-valid data, leading to difficult to debug failures.