### PR TITLE
feat: support npmjs versions redirect

### DIFF
--- a/server/middleware/canonical-redirects.global.ts
+++ b/server/middleware/canonical-redirects.global.ts
@@ -38,21 +38,26 @@ const cacheControl = 's-maxage=3600, stale-while-revalidate=36000'
 export default defineEventHandler(async event => {
   const [path = '/', query] = event.path.split('?')
 
-  // /package/name?activeTab=versions → /package/name/versions
-  // /package/@scope/name?activeTab=versions → /package/@scope/name/versions
   if (query) {
     const params = new URLSearchParams(query)
-    if (params.get('activeTab') === 'versions') {
-      const pkgPathMatch = path.match(/^\/package\/((?:@[^/]+\/)?[^/]+)$/)
-      if (pkgPathMatch) {
-        params.delete('activeTab')
-        const remaining = params.toString()
-        setHeader(event, 'cache-control', cacheControl)
-        return sendRedirect(
-          event,
-          `/package/${pkgPathMatch[1]}/versions` + (remaining ? '?' + remaining : ''),
-          301,
-        )
+
+    switch (params.get('activeTab')) {
+      case 'versions': {
+        // /package/name?activeTab=versions → /package/name/versions
+        // /package/@scope/name?activeTab=versions → /package/@scope/name/versions
+
+        const pkgPathMatch = path.match(/^\/package\/((?:@[^/]+\/)?[^/]+)$/)
+        if (pkgPathMatch) {
+          params.delete('activeTab')
+          const remaining = params.toString()
+          setHeader(event, 'cache-control', cacheControl)
+          return sendRedirect(
+            event,
+            `/package/${pkgPathMatch[1]}/versions` + (remaining ? '?' + remaining : ''),
+            301,
+          )
+        }
+        break
       }
     }
   }

--- a/server/middleware/canonical-redirects.global.ts
+++ b/server/middleware/canonical-redirects.global.ts
@@ -36,12 +36,31 @@ const pages = [
 const cacheControl = 's-maxage=3600, stale-while-revalidate=36000'
 
 export default defineEventHandler(async event => {
+  const [path = '/', query] = event.path.split('?')
+
+  // /package/name?activeTab=versions → /package/name/versions
+  // /package/@scope/name?activeTab=versions → /package/@scope/name/versions
+  if (query) {
+    const params = new URLSearchParams(query)
+    if (params.get('activeTab') === 'versions') {
+      const pkgPathMatch = path.match(/^\/package\/((?:@[^/]+\/)?[^/]+)$/)
+      if (pkgPathMatch) {
+        params.delete('activeTab')
+        const remaining = params.toString()
+        setHeader(event, 'cache-control', cacheControl)
+        return sendRedirect(
+          event,
+          `/package/${pkgPathMatch[1]}/versions` + (remaining ? '?' + remaining : ''),
+          301,
+        )
+      }
+    }
+  }
+
   const routeRules = getRouteRules(event)
   if (Object.keys(routeRules).length > 1) {
     return
   }
-
-  const [path = '/', query] = event.path.split('?')
 
   // username
   if (path.startsWith('/~') || path.startsWith('/_')) {

--- a/test/e2e/url-compatibility.spec.ts
+++ b/test/e2e/url-compatibility.spec.ts
@@ -120,6 +120,25 @@ test.describe('npmjs.com URL Compatibility', () => {
     })
   })
 
+  test.describe('npmjs.com activeTab=versions Compatibility', () => {
+    test('/package/vue?activeTab=versions → /package/vue/versions', async ({ page, goto }) => {
+      await goto('/package/vue?activeTab=versions', { waitUntil: 'domcontentloaded' })
+
+      await expect(page).toHaveURL(/\/package\/vue\/versions$/)
+      await expect(page.locator('h1')).toContainText('vue')
+    })
+
+    test('/package/@nuxt/kit?activeTab=versions → /package/@nuxt/kit/versions', async ({
+      page,
+      goto,
+    }) => {
+      await goto('/package/@nuxt/kit?activeTab=versions', { waitUntil: 'domcontentloaded' })
+
+      await expect(page).toHaveURL(/\/package\/@nuxt\/kit\/versions$/)
+      await expect(page.locator('h1')).toContainText('@nuxt/kit')
+    })
+  })
+
   test.describe('Edge Cases', () => {
     test('package name with dots: /package/lodash.merge', async ({ page, goto }) => {
       await goto('/package/lodash.merge', { waitUntil: 'domcontentloaded' })

--- a/test/e2e/url-compatibility.spec.ts
+++ b/test/e2e/url-compatibility.spec.ts
@@ -125,7 +125,7 @@ test.describe('npmjs.com URL Compatibility', () => {
       await goto('/package/vue?activeTab=versions', { waitUntil: 'domcontentloaded' })
 
       await expect(page).toHaveURL(/\/package\/vue\/versions$/)
-      await expect(page.locator('h1')).toContainText('vue')
+      await expect(page.locator('h1')).toContainText('Version History')
     })
 
     test('/package/@nuxt/kit?activeTab=versions → /package/@nuxt/kit/versions', async ({
@@ -135,7 +135,7 @@ test.describe('npmjs.com URL Compatibility', () => {
       await goto('/package/@nuxt/kit?activeTab=versions', { waitUntil: 'domcontentloaded' })
 
       await expect(page).toHaveURL(/\/package\/@nuxt\/kit\/versions$/)
-      await expect(page.locator('h1')).toContainText('@nuxt/kit')
+      await expect(page.locator('h1')).toContainText('Version History')
     })
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Resolves https://github.com/npmx-dev/npmx.dev/issues/2781

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

There's a good level of intentional URL compatibility between npmjs.com and npmx.dev. The idea being that if you swapped out the prefix you'd see the same feature on npmx.dev that you see on npmjs.com

This doesn't apply for versions. So if you go to:
https://www.npmjs.com/package/webpack?activeTab=versions

Then go to
https://www.npmx.dev/package/webpack?activeTab=versions

You do not see a versions view. However, a versions view does exist:
https://npmx.dev/package/webpack/versions

### 📚 Description

This PR changes npmx.dev such that https://www.npmx.dev/package/webpack?activeTab=versions would be 301'd to https://npmx.dev/package/webpack/versions 

This means that users swapping the prefix will see the versions view. The URL is a redirect, but that seems appropriate given there isn't a "tab" for versions in npmx

cc @gameroman