### PR TITLE
fix: use local font provider

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -277,27 +277,13 @@ export default defineNuxtConfig({
       {
         name: 'Geist',
         provider: 'local',
-        weight: 400,
-        preload: true,
-        global: true,
-      },
-      {
-        name: 'Geist',
-        provider: 'local',
-        weights: [500, 600],
+        weights: [400, 500, 600],
         global: true,
       },
       {
         name: 'Geist Mono',
         provider: 'local',
-        weight: 400,
-        preload: true,
-        global: true,
-      },
-      {
-        name: 'Geist Mono',
-        provider: 'local',
-        weight: 500,
+        weight: [400, 500],
         global: true,
       },
       {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -276,14 +276,34 @@ export default defineNuxtConfig({
     families: [
       {
         name: 'Geist',
-        weights: ['400', '500', '600'],
+        src: '/fonts/Geist-Regular.ttf',
+        weight: 400,
+        preload: true,
+        global: true,
+      },
+      {
+        name: 'Geist',
+        src: '/fonts/Geist-Medium.ttf',
+        weight: 500,
+        global: true,
+      },
+      {
+        name: 'Geist',
+        src: '/fonts/Geist-SemiBold.ttf',
+        weight: 600,
+        global: true,
+      },
+      {
+        name: 'Geist Mono',
+        src: '/fonts/GeistMono-Regular.ttf',
+        weight: 400,
         preload: true,
         global: true,
       },
       {
         name: 'Geist Mono',
-        weights: ['400', '500'],
-        preload: true,
+        src: '/fonts/GeistMono-Medium.ttf',
+        weight: 500,
         global: true,
       },
       {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -283,7 +283,7 @@ export default defineNuxtConfig({
       {
         name: 'Geist Mono',
         provider: 'local',
-        weight: [400, 500],
+        weights: [400, 500],
         global: true,
       },
       {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -276,33 +276,33 @@ export default defineNuxtConfig({
     families: [
       {
         name: 'Geist',
-        src: '/fonts/Geist-Regular.ttf',
+        provider: 'local',
         weight: 400,
         preload: true,
         global: true,
       },
       {
         name: 'Geist',
-        src: '/fonts/Geist-Medium.ttf',
+        provider: 'local',
         weight: 500,
         global: true,
       },
       {
         name: 'Geist',
-        src: '/fonts/Geist-SemiBold.ttf',
+        provider: 'local',
         weight: 600,
         global: true,
       },
       {
         name: 'Geist Mono',
-        src: '/fonts/GeistMono-Regular.ttf',
+        provider: 'local',
         weight: 400,
         preload: true,
         global: true,
       },
       {
         name: 'Geist Mono',
-        src: '/fonts/GeistMono-Medium.ttf',
+        provider: 'local',
         weight: 500,
         global: true,
       },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -284,13 +284,7 @@ export default defineNuxtConfig({
       {
         name: 'Geist',
         provider: 'local',
-        weight: 500,
-        global: true,
-      },
-      {
-        name: 'Geist',
-        provider: 'local',
-        weight: 600,
+        weights: [500, 600],
         global: true,
       },
       {


### PR DESCRIPTION
### 🧭 Context

The Geist Mono font recently broke. Because of this, ligatures (-->, ==, !=, ..., --, etc.) no longer displayed correctly. This has already been fixed - https://github.com/google/fonts/pull/10540 - but due to several other services and caching issues font continues to be broken.

### 📚 Description

I used local fonts, as they are already configured in our repository. This will be more stable and should not impact performance overall, as users connect to our servers and wit ha few locations