### PR TITLE
refactor: switch to packumeta for trust levels

### DIFF
--- a/app/components/Package/Versions.vue
+++ b/app/components/Package/Versions.vue
@@ -185,7 +185,7 @@ const allTagRows = computed(() => {
         tags,
         trustStatus: versionData?.trustStatus,
         deprecated: versionData?.deprecated,
-      } as VersionDisplay,
+      },
     }))
     .sort((a, b) => compare(b.primaryVersion.version, a.primaryVersion.version))
 })

--- a/app/components/Package/Versions.vue
+++ b/app/components/Package/Versions.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { compare, validRange } from 'semver'
 import type { RouteLocationRaw } from 'vue-router'
+import type { TrustStatus } from 'packumeta'
 import { fetchAllPackageVersions } from '~/utils/npm/api'
 
 const props = defineProps<{
@@ -86,7 +87,7 @@ interface VersionDisplay {
   version: string
   time?: string
   tags?: string[]
-  hasProvenance: boolean
+  trustStatus?: TrustStatus
   deprecated?: string
 }
 
@@ -182,7 +183,7 @@ const allTagRows = computed(() => {
         version,
         time: props.time[version],
         tags,
-        hasProvenance: versionData?.hasProvenance,
+        trustStatus: versionData?.trustStatus,
         deprecated: versionData?.deprecated,
       } as VersionDisplay,
     }))
@@ -328,7 +329,7 @@ function processLoadedVersions(allVersions: PackageVersionInfo[]) {
         version: v.version,
         time: v.time,
         tags: versionToTags.value.get(v.version),
-        hasProvenance: v.hasProvenance,
+        trustStatus: v.trustStatus,
         deprecated: v.deprecated,
       }))
 
@@ -355,7 +356,7 @@ function processLoadedVersions(allVersions: PackageVersionInfo[]) {
       version: v.version,
       time: v.time,
       tags: versionToTags.value.get(v.version),
-      hasProvenance: v.hasProvenance,
+      trustStatus: v.trustStatus,
       deprecated: v.deprecated,
     })
   }
@@ -699,7 +700,7 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
                 class="text-xs text-fg-subtle"
               />
               <ProvenanceBadge
-                v-if="row.primaryVersion.hasProvenance"
+                v-if="row.primaryVersion.trustStatus?.provenance"
                 :package-name="packageName"
                 :version="row.primaryVersion.version"
                 compact
@@ -753,7 +754,7 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
                   day="numeric"
                 />
                 <ProvenanceBadge
-                  v-if="v.hasProvenance"
+                  v-if="v.trustStatus?.provenance"
                   :package-name="packageName"
                   :version="v.version"
                   compact
@@ -957,7 +958,7 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
                       day="numeric"
                     />
                     <ProvenanceBadge
-                      v-if="group.versions[0]?.hasProvenance"
+                      v-if="group.versions[0]?.trustStatus?.provenance"
                       :package-name="packageName"
                       :version="group.versions[0]?.version"
                       compact
@@ -1024,7 +1025,7 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
                       day="numeric"
                     />
                     <ProvenanceBadge
-                      v-if="group.versions[0]?.hasProvenance"
+                      v-if="group.versions[0]?.trustStatus?.provenance"
                       :package-name="packageName"
                       :version="group.versions[0]?.version"
                       compact
@@ -1091,7 +1092,7 @@ function majorGroupContainsCurrent(group: (typeof otherMajorGroups.value)[0]): b
                         day="numeric"
                       />
                       <ProvenanceBadge
-                        v-if="v.hasProvenance"
+                        v-if="v.trustStatus?.provenance"
                         :package-name="packageName"
                         :version="v.version"
                         compact

--- a/app/composables/npm/usePackage.ts
+++ b/app/composables/npm/usePackage.ts
@@ -1,20 +1,7 @@
+import { getTrustLevel, getTrustStatus } from 'packumeta'
+
 /** Number of recent versions to include in initial payload */
 const RECENT_VERSIONS_COUNT = 5
-
-function hasAttestations(version: PackumentVersion): boolean {
-  return Boolean(version.dist.attestations)
-}
-
-function hasTrustedPublisher(version: PackumentVersion): boolean {
-  return Boolean(version._npmUser?.trustedPublisher)
-}
-
-function getTrustLevel(version: PackumentVersion): PublishTrustLevel {
-  // trusted publishing automatically generates provenance attestations
-  if (hasTrustedPublisher(version)) return 'trustedPublisher'
-  if (hasAttestations(version)) return 'provenance'
-  return 'none'
-}
 
 function normalizeLicense(license?: PackumentLicense): string | undefined {
   if (!license) return undefined
@@ -59,17 +46,16 @@ export function transformPackument(
   // Build security metadata for all versions, but only include in payload
   // when the package has mixed trust levels (i.e. a downgrade could exist)
   const securityVersionEntries = Object.entries(pkg.versions).map(([version, metadata]) => {
-    const trustLevel = getTrustLevel(metadata)
+    const trustStatus = getTrustStatus(metadata)
     return {
       version,
       time: pkg.time[version],
-      hasProvenance: trustLevel !== 'none',
-      trustLevel,
+      trustStatus,
       deprecated: metadata.deprecated,
     }
   })
 
-  const trustLevels = new Set(securityVersionEntries.map(v => v.trustLevel))
+  const trustLevels = new Set(securityVersionEntries.map(v => getTrustLevel(v.trustStatus)))
   const hasMixedTrust = trustLevels.size > 1
   const securityVersions = hasMixedTrust ? securityVersionEntries : undefined
 
@@ -92,12 +78,9 @@ export function transformPackument(
           installScripts: installScripts ?? undefined,
         }
       }
-      const trustLevel = getTrustLevel(version)
-      const hasProvenance = trustLevel !== 'none'
 
       filteredVersions[v] = {
-        hasProvenance,
-        trustLevel,
+        trustStatus: getTrustStatus(version),
         version: version.version,
         deprecated: version.deprecated,
         tags: version.tags as string[],

--- a/app/pages/package/[[org]]/[name].vue
+++ b/app/pages/package/[[org]]/[name].vue
@@ -274,8 +274,7 @@ const versionSecurityMetadata = computed<PackageVersionInfo[]>(() => {
   return Object.entries(pkg.value.versions).map(([version, metadata]) => ({
     version,
     time: pkg.value?.time?.[version],
-    hasProvenance: !!metadata.hasProvenance,
-    trustLevel: metadata.trustLevel,
+    trustStatus: metadata.trustStatus,
     deprecated: metadata.deprecated,
   }))
 })

--- a/app/pages/package/[[org]]/[name]/versions.vue
+++ b/app/pages/package/[[org]]/[name]/versions.vue
@@ -126,10 +126,7 @@ function getDownloadsAriaLabel(downloads: number): string {
 // ─── Phase 2: full metadata (fired automatically after phase 1 completes) ────
 // Fetches deprecated status, provenance, and exact times needed for version rows.
 
-const fullVersionMap = shallowRef<Map<
-  string,
-  { time?: string; deprecated?: string; hasProvenance: boolean }
-> | null>(null)
+const fullVersionMap = shallowRef<Map<string, PackageVersionInfo> | null>(null)
 
 async function ensureFullDataLoaded() {
   if (fullVersionMap.value) return
@@ -363,7 +360,7 @@ const flatItems = computed<FlatItem[]>(() => {
                 >v{{ latestTagRow!.version }}</LinkBase
               >
               <ProvenanceBadge
-                v-if="fullVersionMap?.get(latestTagRow!.version)?.hasProvenance"
+                v-if="fullVersionMap?.get(latestTagRow!.version)?.trustStatus?.provenance"
                 :package-name="packageName"
                 :version="latestTagRow!.version"
                 compact
@@ -427,7 +424,7 @@ const flatItems = computed<FlatItem[]>(() => {
                 v{{ row.version }}
               </LinkBase>
               <ProvenanceBadge
-                v-if="fullVersionMap?.get(row.version)?.hasProvenance"
+                v-if="fullVersionMap?.get(row.version)?.trustStatus?.provenance"
                 :package-name="packageName"
                 :version="row.version"
                 compact
@@ -593,7 +590,7 @@ const flatItems = computed<FlatItem[]>(() => {
                           v{{ item.version }}
                         </LinkBase>
                         <ProvenanceBadge
-                          v-if="fullVersionMap?.get(item.version)?.hasProvenance"
+                          v-if="fullVersionMap?.get(item.version)?.trustStatus?.provenance"
                           :package-name="packageName"
                           :version="item.version"
                           compact

--- a/app/utils/publish-security.ts
+++ b/app/utils/publish-security.ts
@@ -1,33 +1,21 @@
+import { getTrustLevel, getTrustLevelName, type TrustLevelName } from 'packumeta'
 import { compare, major } from 'semver'
 
 export interface PublishSecurityDowngrade {
   downgradedVersion: string
   downgradedPublishedAt?: string
-  downgradedTrustLevel: PublishTrustLevel
+  downgradedTrustLevel: TrustLevelName
   /** Recommended trusted version within the same major, if one exists */
   trustedVersion?: string
   trustedPublishedAt?: string
-  trustedTrustLevel: PublishTrustLevel
+  trustedTrustLevel: TrustLevelName
 }
 
 type VersionWithIndex = PackageVersionInfo & {
   index: number
   timestamp: number
   trustRank: number
-  resolvedTrustLevel: PublishTrustLevel
-}
-
-const TRUST_RANK: Record<PublishTrustLevel, number> = {
-  none: 0,
-  provenance: 1,
-  trustedPublisher: 2,
-}
-
-function resolveTrustLevel(version: PackageVersionInfo): PublishTrustLevel {
-  if (version.trustLevel) return version.trustLevel
-  // Fallback for legacy data: hasProvenance only indicates non-'none' trust,
-  // so map it to provenance (the lower rank) to avoid over-ranking
-  return version.hasProvenance ? 'provenance' : 'none'
+  trustLevelName: TrustLevelName
 }
 
 function toTimestamp(time?: string): number {
@@ -68,13 +56,12 @@ export function detectPublishSecurityDowngradeForVersion(
 
   const sorted = versions
     .map((version, index) => {
-      const resolvedTrustLevel = resolveTrustLevel(version)
       return {
         ...version,
         index,
         timestamp: toTimestamp(version.time),
-        trustRank: TRUST_RANK[resolvedTrustLevel],
-        resolvedTrustLevel,
+        trustRank: version.trustStatus ? getTrustLevel(version.trustStatus) : 0,
+        trustLevelName: version.trustStatus ? getTrustLevelName(version.trustStatus) : 'none',
       }
     })
     .sort(sortByRecency)
@@ -114,9 +101,9 @@ export function detectPublishSecurityDowngradeForVersion(
   return {
     downgradedVersion: current.version,
     downgradedPublishedAt: current.time,
-    downgradedTrustLevel: current.resolvedTrustLevel,
+    downgradedTrustLevel: current.trustLevelName,
     trustedVersion: recommendation?.version,
     trustedPublishedAt: recommendation?.time,
-    trustedTrustLevel: strongestOlder.resolvedTrustLevel,
+    trustedTrustLevel: strongestOlder.trustLevelName,
   }
 }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "nuxt-og-image": "^6.4.3",
     "ofetch": "1.5.1",
     "ohash": "2.0.11",
+    "packumeta": "0.3.0",
     "perfect-debounce": "2.1.0",
     "sanitize-html": "2.17.1",
     "semver": "7.7.4",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "nuxt-og-image": "^6.4.3",
     "ofetch": "1.5.1",
     "ohash": "2.0.11",
-    "packumeta": "0.3.0",
+    "packumeta": "0.4.0",
     "perfect-debounce": "2.1.0",
     "sanitize-html": "2.17.1",
     "semver": "7.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       ohash:
         specifier: 2.0.11
         version: 2.0.11
+      packumeta:
+        specifier: 0.3.0
+        version: 0.3.0
       perfect-debounce:
         specifier: 2.1.0
         version: 2.1.0
@@ -9138,6 +9141,10 @@ packages:
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  packumeta@0.3.0:
+    resolution: {integrity: sha512-b+Mawn0OBuoYMJKwOrOr0pr3Z/iCENdc1g84I/xMgDENUd4YXVZSsS7+gCMXGZSIYt+TW7jWzSf3ggiSkn4zmQ==}
+    engines: {node: '>=20.0.0'}
 
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
@@ -21279,6 +21286,8 @@ snapshots:
   package-json-from-dist@1.0.1: {}
 
   package-manager-detector@1.6.0: {}
+
+  packumeta@0.3.0: {}
 
   pako@0.2.9: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,8 +205,8 @@ importers:
         specifier: 2.0.11
         version: 2.0.11
       packumeta:
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.4.0
+        version: 0.4.0
       perfect-debounce:
         specifier: 2.1.0
         version: 2.1.0
@@ -9142,8 +9142,8 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
-  packumeta@0.3.0:
-    resolution: {integrity: sha512-b+Mawn0OBuoYMJKwOrOr0pr3Z/iCENdc1g84I/xMgDENUd4YXVZSsS7+gCMXGZSIYt+TW7jWzSf3ggiSkn4zmQ==}
+  packumeta@0.4.0:
+    resolution: {integrity: sha512-RU9vc7pe32iMpUZGIkWac5gdKAUuKB4Ix77HL+Fy4Cow/W/IwO7bmHf/OhVPA9bMueU+XPzf5vm6GG9tw+sKSg==}
     engines: {node: '>=20.0.0'}
 
   pako@0.2.9:
@@ -11164,8 +11164,8 @@ packages:
   vue-component-type-helpers@3.2.8:
     resolution: {integrity: sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==}
 
-  vue-component-type-helpers@3.3.1:
-    resolution: {integrity: sha512-pu58kqxmVyEH6VfNYW1UyEfR3XAnJ27ZXT3yzXxxpjLxVzAbyC35Zk/nm/RMs7ijWnJNSd9fWkeex2OhUsx3MA==}
+  vue-component-type-helpers@3.3.2:
+    resolution: {integrity: sha512-l4Z2Y34m7nFMlx8vrslJaVtXxUpzgDMSESC7TakG/c5kwjYT/do+E0NcT2/vWDzaoIhsShg/2OKwX7Q4nbzC0g==}
 
   vue-data-ui@3.20.10:
     resolution: {integrity: sha512-w9RDQzyfMDIFdT2oFB9JyHebOKQww098KsLQ5fZtBGFAMEFTuSD72BEg2dYKD/UVQcu8WPV9xKSQAp7Kcjls3g==}
@@ -15857,7 +15857,7 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
       type-fest: 2.19.0
       vue: 3.5.34(typescript@6.0.2)
-      vue-component-type-helpers: 3.3.1
+      vue-component-type-helpers: 3.3.2
 
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
@@ -21287,7 +21287,7 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
-  packumeta@0.3.0: {}
+  packumeta@0.4.0: {}
 
   pako@0.2.9: {}
 
@@ -23687,7 +23687,7 @@ snapshots:
 
   vue-component-type-helpers@3.2.8: {}
 
-  vue-component-type-helpers@3.3.1: {}
+  vue-component-type-helpers@3.3.2: {}
 
   vue-data-ui@3.20.10(vue@3.5.34):
     dependencies:

--- a/shared/types/npm-registry.ts
+++ b/shared/types/npm-registry.ts
@@ -12,6 +12,7 @@ import type {
   Contact,
 } from '@npm/types'
 import type { ReadmeResponse } from './readme'
+import type { TrustStatus } from 'packumeta'
 
 // Re-export official npm types for packument/manifest
 export type { Manifest, ManifestVersion, PackageJSON } from '@npm/types'
@@ -44,11 +45,8 @@ export type SlimPackumentVersion = PackumentVersion & {
   installScripts?: InstallScriptsInfo
 }
 
-export type PublishTrustLevel = 'none' | 'trustedPublisher' | 'provenance'
-
 export type SlimVersion = Pick<SlimPackumentVersion, 'version' | 'deprecated' | 'tags'> & {
-  hasProvenance?: boolean
-  trustLevel?: PublishTrustLevel
+  trustStatus?: TrustStatus
   license?: string
   /** Package type field — "module" indicates ESM */
   type?: string
@@ -103,8 +101,7 @@ export interface SlimPackument {
 export interface PackageVersionInfo {
   version: string
   time?: string
-  hasProvenance: boolean
-  trustLevel?: PublishTrustLevel
+  trustStatus?: TrustStatus
   deprecated?: string
 }
 

--- a/test/nuxt/a11y.spec.ts
+++ b/test/nuxt/a11y.spec.ts
@@ -923,7 +923,11 @@ describe('component accessibility audits', () => {
             'versions': {
               '18.2.0': {
                 version: '18.2.0',
-                hasProvenance: false,
+                trustStatus: {
+                  provenance: false,
+                  trustedPublisher: false,
+                  stagedPublish: false,
+                },
                 tags: [],
               },
             },

--- a/test/nuxt/components/Package/Versions.spec.ts
+++ b/test/nuxt/components/Package/Versions.spec.ts
@@ -24,7 +24,9 @@ function createVersion(
     version,
     deprecated: options.deprecated,
     tags: undefined,
-    ...(options.hasProvenance ? { hasProvenance: true } : {}),
+    ...(options.hasProvenance
+      ? { trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false } }
+      : {}),
   } as SlimVersion
 }
 
@@ -442,8 +444,16 @@ describe('PackageVersions', () => {
 
     it('loads versions and toggles expanded state on click', async () => {
       mockFetchAllPackageVersions.mockResolvedValue([
-        { version: '1.0.0', time: '2024-01-15T12:00:00.000Z', hasProvenance: false },
-        { version: '0.9.0', time: '2024-01-10T12:00:00.000Z', hasProvenance: false },
+        {
+          version: '1.0.0',
+          time: '2024-01-15T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '0.9.0',
+          time: '2024-01-10T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
       ])
 
       const component = await mountSuspended(PackageVersions, {
@@ -469,9 +479,21 @@ describe('PackageVersions', () => {
     it('collapses when clicking expanded row', async () => {
       // Return multiple versions so the expand button stays visible after loading
       mockFetchAllPackageVersions.mockResolvedValue([
-        { version: '1.2.0', time: '2024-01-15T12:00:00.000Z', hasProvenance: false },
-        { version: '1.1.0', time: '2024-01-12T12:00:00.000Z', hasProvenance: false },
-        { version: '1.0.0', time: '2024-01-10T12:00:00.000Z', hasProvenance: false },
+        {
+          version: '1.2.0',
+          time: '2024-01-15T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.1.0',
+          time: '2024-01-12T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.0.0',
+          time: '2024-01-10T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
       ])
 
       const component = await mountSuspended(PackageVersions, {
@@ -566,8 +588,16 @@ describe('PackageVersions', () => {
 
     it('expands other versions section on click', async () => {
       mockFetchAllPackageVersions.mockResolvedValue([
-        { version: '1.0.0', time: '2024-01-15T12:00:00.000Z', hasProvenance: false },
-        { version: '0.5.0', time: '2024-01-01T12:00:00.000Z', hasProvenance: false },
+        {
+          version: '1.0.0',
+          time: '2024-01-15T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '0.5.0',
+          time: '2024-01-01T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
       ])
 
       const component = await mountSuspended(PackageVersions, {
@@ -597,7 +627,11 @@ describe('PackageVersions', () => {
 
     it('collapses other versions section when clicking again', async () => {
       mockFetchAllPackageVersions.mockResolvedValue([
-        { version: '1.0.0', time: '2024-01-15T12:00:00.000Z', hasProvenance: false },
+        {
+          version: '1.0.0',
+          time: '2024-01-15T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
       ])
 
       const component = await mountSuspended(PackageVersions, {
@@ -662,10 +696,26 @@ describe('PackageVersions', () => {
   describe('major version groups', () => {
     it('groups unclaimed versions by major version in other versions', async () => {
       mockFetchAllPackageVersions.mockResolvedValue([
-        { version: '2.0.0', time: '2024-01-15T12:00:00.000Z', hasProvenance: false },
-        { version: '1.1.0', time: '2024-01-10T12:00:00.000Z', hasProvenance: false },
-        { version: '1.0.0', time: '2024-01-05T12:00:00.000Z', hasProvenance: false },
-        { version: '0.9.0', time: '2024-01-01T12:00:00.000Z', hasProvenance: false },
+        {
+          version: '2.0.0',
+          time: '2024-01-15T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.1.0',
+          time: '2024-01-10T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.0.0',
+          time: '2024-01-05T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '0.9.0',
+          time: '2024-01-01T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
       ])
 
       const component = await mountSuspended(PackageVersions, {
@@ -694,9 +744,21 @@ describe('PackageVersions', () => {
 
     it('allows expanding major version groups', async () => {
       mockFetchAllPackageVersions.mockResolvedValue([
-        { version: '2.0.0', time: '2024-01-15T12:00:00.000Z', hasProvenance: false },
-        { version: '1.1.0', time: '2024-01-10T12:00:00.000Z', hasProvenance: false },
-        { version: '1.0.0', time: '2024-01-05T12:00:00.000Z', hasProvenance: false },
+        {
+          version: '2.0.0',
+          time: '2024-01-15T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.1.0',
+          time: '2024-01-10T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.0.0',
+          time: '2024-01-05T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
       ])
 
       const component = await mountSuspended(PackageVersions, {
@@ -726,8 +788,16 @@ describe('PackageVersions', () => {
 
     it('shows DateTime for major group versions', async () => {
       mockFetchAllPackageVersions.mockResolvedValue([
-        { version: '2.0.0', time: '2024-01-15T12:00:00.000Z', hasProvenance: false },
-        { version: '1.1.0', time: '2024-01-10T12:00:00.000Z', hasProvenance: false },
+        {
+          version: '2.0.0',
+          time: '2024-01-15T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.1.0',
+          time: '2024-01-10T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
       ])
 
       const component = await mountSuspended(PackageVersions, {
@@ -757,8 +827,16 @@ describe('PackageVersions', () => {
 
     it('shows ProvenanceBadge for major group versions with provenance', async () => {
       mockFetchAllPackageVersions.mockResolvedValue([
-        { version: '2.0.0', time: '2024-01-15T12:00:00.000Z', hasProvenance: true },
-        { version: '1.1.0', time: '2024-01-10T12:00:00.000Z', hasProvenance: true },
+        {
+          version: '2.0.0',
+          time: '2024-01-15T12:00:00.000Z',
+          trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.1.0',
+          time: '2024-01-10T12:00:00.000Z',
+          trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false },
+        },
       ])
 
       const component = await mountSuspended(PackageVersions, {
@@ -788,9 +866,21 @@ describe('PackageVersions', () => {
 
     it('renders major group header as clickable link', async () => {
       mockFetchAllPackageVersions.mockResolvedValue([
-        { version: '2.0.0', time: '2024-01-15T12:00:00.000Z', hasProvenance: false },
-        { version: '1.1.0', time: '2024-01-10T12:00:00.000Z', hasProvenance: false },
-        { version: '1.0.0', time: '2024-01-05T12:00:00.000Z', hasProvenance: false },
+        {
+          version: '2.0.0',
+          time: '2024-01-15T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.1.0',
+          time: '2024-01-10T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.0.0',
+          time: '2024-01-05T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
       ])
 
       const component = await mountSuspended(PackageVersions, {
@@ -821,8 +911,16 @@ describe('PackageVersions', () => {
 
     it('shows DateTime and ProvenanceBadge for single version in major group', async () => {
       mockFetchAllPackageVersions.mockResolvedValue([
-        { version: '2.0.0', time: '2024-01-15T12:00:00.000Z', hasProvenance: false },
-        { version: '1.0.0', time: '2024-01-05T12:00:00.000Z', hasProvenance: true },
+        {
+          version: '2.0.0',
+          time: '2024-01-15T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.0.0',
+          time: '2024-01-05T12:00:00.000Z',
+          trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false },
+        },
       ])
 
       const component = await mountSuspended(PackageVersions, {
@@ -1128,10 +1226,26 @@ describe('PackageVersions', () => {
 
     it('filters expanded tag child versions', async () => {
       mockFetchAllPackageVersions.mockResolvedValue([
-        { version: '3.0.0', time: '2024-04-01T00:00:00.000Z', hasProvenance: false },
-        { version: '2.1.0', time: '2024-03-01T00:00:00.000Z', hasProvenance: false },
-        { version: '2.0.0', time: '2024-02-01T00:00:00.000Z', hasProvenance: false },
-        { version: '1.0.0', time: '2024-01-01T00:00:00.000Z', hasProvenance: false },
+        {
+          version: '3.0.0',
+          time: '2024-04-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '2.1.0',
+          time: '2024-03-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '2.0.0',
+          time: '2024-02-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.0.0',
+          time: '2024-01-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
       ])
 
       const component = await mountSuspended(PackageVersions, { props: multiVersionProps })
@@ -1161,11 +1275,31 @@ describe('PackageVersions', () => {
 
     it('loads all versions when a valid semver filter is entered', async () => {
       mockFetchAllPackageVersions.mockResolvedValue([
-        { version: '3.5.0', time: '2024-04-01T00:00:00.000Z', hasProvenance: false },
-        { version: '3.4.0', time: '2024-03-01T00:00:00.000Z', hasProvenance: false },
-        { version: '3.3.0', time: '2024-02-01T00:00:00.000Z', hasProvenance: false },
-        { version: '2.0.0', time: '2024-01-15T00:00:00.000Z', hasProvenance: false },
-        { version: '1.0.0', time: '2024-01-01T00:00:00.000Z', hasProvenance: false },
+        {
+          version: '3.5.0',
+          time: '2024-04-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '3.4.0',
+          time: '2024-03-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '3.3.0',
+          time: '2024-02-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '2.0.0',
+          time: '2024-01-15T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.0.0',
+          time: '2024-01-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
       ])
 
       // Only provide latest in props (simulating initial SSR payload)
@@ -1218,9 +1352,21 @@ describe('PackageVersions', () => {
 
     it('only fetches versions once across multiple filter changes', async () => {
       mockFetchAllPackageVersions.mockResolvedValue([
-        { version: '3.0.0', time: '2024-04-01T00:00:00.000Z', hasProvenance: false },
-        { version: '2.0.0', time: '2024-02-01T00:00:00.000Z', hasProvenance: false },
-        { version: '1.0.0', time: '2024-01-01T00:00:00.000Z', hasProvenance: false },
+        {
+          version: '3.0.0',
+          time: '2024-04-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '2.0.0',
+          time: '2024-02-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.0.0',
+          time: '2024-01-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
       ])
 
       const component = await mountSuspended(PackageVersions, {
@@ -1252,11 +1398,31 @@ describe('PackageVersions', () => {
 
     it('filters other major version groups', async () => {
       mockFetchAllPackageVersions.mockResolvedValue([
-        { version: '3.0.0', time: '2024-04-01T00:00:00.000Z', hasProvenance: false },
-        { version: '2.1.0', time: '2024-03-01T00:00:00.000Z', hasProvenance: false },
-        { version: '2.0.0', time: '2024-02-01T00:00:00.000Z', hasProvenance: false },
-        { version: '1.0.0', time: '2024-01-01T00:00:00.000Z', hasProvenance: false },
-        { version: '0.5.0', time: '2023-06-01T00:00:00.000Z', hasProvenance: false },
+        {
+          version: '3.0.0',
+          time: '2024-04-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '2.1.0',
+          time: '2024-03-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '2.0.0',
+          time: '2024-02-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.0.0',
+          time: '2024-01-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '0.5.0',
+          time: '2023-06-01T00:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
       ])
 
       const component = await mountSuspended(PackageVersions, { props: multiVersionProps })
@@ -1331,8 +1497,16 @@ describe('PackageVersions', () => {
   describe('caching behavior', () => {
     it('only fetches versions once when expanding multiple tags', async () => {
       mockFetchAllPackageVersions.mockResolvedValue([
-        { version: '2.0.0', time: '2024-01-15T12:00:00.000Z', hasProvenance: false },
-        { version: '1.0.0', time: '2024-01-10T12:00:00.000Z', hasProvenance: false },
+        {
+          version: '2.0.0',
+          time: '2024-01-15T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+        {
+          version: '1.0.0',
+          time: '2024-01-10T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
       ])
 
       const component = await mountSuspended(PackageVersions, {

--- a/test/nuxt/components/VersionSelector.spec.ts
+++ b/test/nuxt/components/VersionSelector.spec.ts
@@ -604,7 +604,13 @@ describe('VersionSelector', () => {
 
       expect(mockFetchAllPackageVersions).toHaveBeenCalledTimes(1)
 
-      finishLoad!([{ version: '1.0.0', time: '2024-01-15T12:00:00.000Z', hasProvenance: false }])
+      finishLoad!([
+        {
+          version: '1.0.0',
+          time: '2024-01-15T12:00:00.000Z',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
+        },
+      ])
     })
   })
 

--- a/test/nuxt/composables/use-package-transform.spec.ts
+++ b/test/nuxt/composables/use-package-transform.spec.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest'
 
 function createVersion(version: string, hasAttestations = false): Packument['versions'][string] {
   return {
-    _id: `foo@${version}`,
     _npmVersion: '10.0.0',
+    // TODO (43081j): _id specifically cannot be the first key for now as it is used for determining through hackery
+    // if the package was staged or not. We should remove this comment once that hackery is removed upstream.
+    _id: `foo@${version}`,
     name: 'foo',
     version,
     dist: {

--- a/test/nuxt/composables/use-package-transform.spec.ts
+++ b/test/nuxt/composables/use-package-transform.spec.ts
@@ -192,7 +192,7 @@ describe('transformPackument', () => {
   it('treats trustedPublisher as trust evidence for downgrade checks', () => {
     const packument = createPackument(
       {
-        '1.0.0': createTrustedPublisherVersion('1.0.0'),
+        '1.0.0': createTrustedPublisherWithAttestationsVersion('1.0.0'),
         '1.0.1': createVersion('1.0.1'),
         '1.0.2': createVersion('1.0.2'),
       },
@@ -210,7 +210,7 @@ describe('transformPackument', () => {
     const infos = toVersionInfos(transformed)
 
     expect(infos.find(v => v.version === '1.0.0')?.trustStatus).toEqual({
-      provenance: false,
+      provenance: true,
       trustedPublisher: true,
       stagedPublish: false,
     })

--- a/test/nuxt/composables/use-package-transform.spec.ts
+++ b/test/nuxt/composables/use-package-transform.spec.ts
@@ -69,8 +69,7 @@ function toVersionInfos(packument: ReturnType<typeof transformPackument>): Packa
     Object.entries(packument.versions).map(([version, metadata]) => ({
       version,
       time: packument.time[version],
-      hasProvenance: !!metadata.hasProvenance,
-      trustLevel: metadata.trustLevel,
+      trustStatus: metadata.trustStatus,
       deprecated: metadata.deprecated,
     }))
   )
@@ -106,7 +105,11 @@ describe('transformPackument', () => {
 
     const transformed = transformPackument(packument, '1.0.0')
 
-    expect(transformed.versions['1.0.0']?.hasProvenance).toBe(true)
+    expect(transformed.versions['1.0.0']?.trustStatus).toEqual({
+      provenance: true,
+      trustedPublisher: false,
+      stagedPublish: false,
+    })
     expect(transformed.versions['1.0.1']).toBeUndefined()
     expect(transformed.versions['1.0.2']).toBeUndefined()
     expect(transformed.securityVersions).toHaveLength(8)
@@ -206,7 +209,11 @@ describe('transformPackument', () => {
     const transformed = transformPackument(packument, '1.0.1')
     const infos = toVersionInfos(transformed)
 
-    expect(infos.find(v => v.version === '1.0.0')?.hasProvenance).toBe(true)
+    expect(infos.find(v => v.version === '1.0.0')?.trustStatus).toEqual({
+      provenance: false,
+      trustedPublisher: true,
+      stagedPublish: false,
+    })
     expect(detectPublishSecurityDowngradeForVersion(infos, '1.0.1')?.trustedVersion).toBe('1.0.0')
   })
 
@@ -227,7 +234,11 @@ describe('transformPackument', () => {
 
     const transformed = transformPackument(packument, '1.0.1')
 
-    expect(transformed.versions['1.0.0']?.trustLevel).toBe('trustedPublisher')
+    expect(transformed.versions['1.0.0']?.trustStatus).toEqual({
+      provenance: true,
+      trustedPublisher: true,
+      stagedPublish: false,
+    })
   })
 
   // https://github.com/npmx-dev/npmx.dev/issues/1292
@@ -252,8 +263,16 @@ describe('transformPackument', () => {
     const infos = toVersionInfos(transformed)
 
     // Both versions should be trustedPublisher — no downgrade
-    expect(infos.find(v => v.version === '7.0.0')?.trustLevel).toBe('trustedPublisher')
-    expect(infos.find(v => v.version === '7.0.1')?.trustLevel).toBe('trustedPublisher')
+    expect(infos.find(v => v.version === '7.0.0')?.trustStatus).toEqual({
+      provenance: true,
+      trustedPublisher: true,
+      stagedPublish: false,
+    })
+    expect(infos.find(v => v.version === '7.0.1')?.trustStatus).toEqual({
+      provenance: true,
+      trustedPublisher: true,
+      stagedPublish: false,
+    })
     expect(detectPublishSecurityDowngradeForVersion(infos, '7.0.1')).toBeNull()
   })
 

--- a/test/nuxt/composables/use-package-transform.spec.ts
+++ b/test/nuxt/composables/use-package-transform.spec.ts
@@ -54,8 +54,10 @@ function createPackument(
   latest: string,
 ): Packument {
   return {
-    '_id': 'foo',
     '_rev': '1',
+    // TODO (43081j): _id specifically cannot be the first key for now as it is used for determining through hackery
+    // if the package was staged or not. We should remove this comment once that hackery is removed upstream.
+    '_id': 'foo',
     'name': 'foo',
     'dist-tags': { latest },
     time,

--- a/test/unit/app/utils/publish-security.spec.ts
+++ b/test/unit/app/utils/publish-security.spec.ts
@@ -6,17 +6,17 @@ describe('detectPublishSecurityDowngradeForVersion', () => {
     {
       version: '1.0.0',
       time: '2026-01-01T00:00:00.000Z',
-      hasProvenance: true,
+      trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false },
     },
     {
       version: '1.0.1',
       time: '2026-01-02T00:00:00.000Z',
-      hasProvenance: false,
+      trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
     },
     {
       version: '1.0.2',
       time: '2026-01-03T00:00:00.000Z',
-      hasProvenance: true,
+      trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false },
     },
   ]
 
@@ -43,14 +43,12 @@ describe('detectPublishSecurityDowngradeForVersion', () => {
         {
           version: '1.0.0',
           time: '2026-01-01T00:00:00.000Z',
-          hasProvenance: true,
-          trustLevel: 'trustedPublisher',
+          trustStatus: { provenance: true, trustedPublisher: true, stagedPublish: false },
         },
         {
           version: '1.0.1',
           time: '2026-01-02T00:00:00.000Z',
-          hasProvenance: true,
-          trustLevel: 'provenance',
+          trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false },
         },
       ],
       '1.0.1',
@@ -72,14 +70,12 @@ describe('detectPublishSecurityDowngradeForVersion', () => {
         {
           version: '1.0.0',
           time: '2026-01-01T00:00:00.000Z',
-          hasProvenance: true,
-          trustLevel: 'provenance',
+          trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false },
         },
         {
           version: '1.0.1',
           time: '2026-01-02T00:00:00.000Z',
-          hasProvenance: true,
-          trustLevel: 'trustedPublisher',
+          trustStatus: { provenance: true, trustedPublisher: true, stagedPublish: false },
         },
       ],
       '1.0.1',
@@ -93,32 +89,27 @@ describe('detectPublishSecurityDowngradeForVersion', () => {
       {
         version: '2.1.0',
         time: '2026-01-01T00:00:00.000Z',
-        hasProvenance: true,
-        trustLevel: 'provenance' as const,
+        trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false },
       },
       {
         version: '2.1.1',
         time: '2026-01-02T00:00:00.000Z',
-        hasProvenance: false,
-        trustLevel: 'none' as const,
+        trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
       },
       {
         version: '2.2.0',
         time: '2026-01-03T00:00:00.000Z',
-        hasProvenance: false,
-        trustLevel: 'none' as const,
+        trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
       },
       {
         version: '2.3.0',
         time: '2026-01-04T00:00:00.000Z',
-        hasProvenance: false,
-        trustLevel: 'none' as const,
+        trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
       },
       {
         version: '2.4.0',
         time: '2026-01-05T00:00:00.000Z',
-        hasProvenance: true,
-        trustLevel: 'provenance' as const,
+        trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false },
       },
     ]
 
@@ -140,21 +131,18 @@ describe('detectPublishSecurityDowngradeForVersion', () => {
         {
           version: '1.0.0',
           time: '2026-01-01T00:00:00.000Z',
-          hasProvenance: true,
-          trustLevel: 'provenance',
+          trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false },
         },
         {
           version: '1.0.1',
           time: '2026-01-02T00:00:00.000Z',
-          hasProvenance: true,
-          trustLevel: 'provenance',
+          trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false },
           deprecated: 'Use 1.0.2 instead',
         },
         {
           version: '1.0.2',
           time: '2026-01-03T00:00:00.000Z',
-          hasProvenance: false,
-          trustLevel: 'none',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
         },
       ],
       '1.0.2',
@@ -170,15 +158,13 @@ describe('detectPublishSecurityDowngradeForVersion', () => {
         {
           version: '1.0.0',
           time: '2026-01-01T00:00:00.000Z',
-          hasProvenance: true,
-          trustLevel: 'provenance',
+          trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false },
           deprecated: 'Deprecated',
         },
         {
           version: '1.0.1',
           time: '2026-01-02T00:00:00.000Z',
-          hasProvenance: false,
-          trustLevel: 'none',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
         },
       ],
       '1.0.1',
@@ -193,14 +179,12 @@ describe('detectPublishSecurityDowngradeForVersion', () => {
         {
           version: '1.0.0',
           time: '2026-01-01T00:00:00.000Z',
-          hasProvenance: true,
-          trustLevel: 'provenance',
+          trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false },
         },
         {
           version: '2.0.0',
           time: '2026-01-02T00:00:00.000Z',
-          hasProvenance: false,
-          trustLevel: 'none',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
         },
       ],
       '2.0.0',
@@ -219,20 +203,17 @@ describe('detectPublishSecurityDowngradeForVersion', () => {
         {
           version: '1.0.0',
           time: '2026-01-01T00:00:00.000Z',
-          hasProvenance: true,
-          trustLevel: 'provenance',
+          trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false },
         },
         {
           version: '2.0.0',
           time: '2026-01-02T00:00:00.000Z',
-          hasProvenance: true,
-          trustLevel: 'provenance',
+          trustStatus: { provenance: true, trustedPublisher: false, stagedPublish: false },
         },
         {
           version: '2.1.0',
           time: '2026-01-03T00:00:00.000Z',
-          hasProvenance: false,
-          trustLevel: 'none',
+          trustStatus: { provenance: false, trustedPublisher: false, stagedPublish: false },
         },
       ],
       '2.1.0',
@@ -240,63 +221,5 @@ describe('detectPublishSecurityDowngradeForVersion', () => {
 
     // Should recommend 2.0.0 (same major), not 1.0.0
     expect(result?.trustedVersion).toBe('2.0.0')
-  })
-
-  it('uses provenance rank (not trustedPublisher) for hasProvenance fallback without trustLevel', () => {
-    // When trustLevel is absent, hasProvenance: true should map to provenance rank,
-    // not trustedPublisher rank. This means a version with only hasProvenance: true
-    // should be considered a downgrade from trustedPublisher.
-    const result = detectPublishSecurityDowngradeForVersion(
-      [
-        {
-          version: '1.0.0',
-          time: '2026-01-01T00:00:00.000Z',
-          hasProvenance: true,
-          trustLevel: 'trustedPublisher',
-        },
-        {
-          version: '1.0.1',
-          time: '2026-01-02T00:00:00.000Z',
-          hasProvenance: true,
-          // no trustLevel — fallback path maps to provenance
-        },
-      ],
-      '1.0.1',
-    )
-
-    // hasProvenance fallback maps to provenance (rank 1), trustedPublisher is rank 2, so this is a downgrade
-    expect(result).toEqual({
-      downgradedVersion: '1.0.1',
-      downgradedPublishedAt: '2026-01-02T00:00:00.000Z',
-      downgradedTrustLevel: 'provenance',
-      trustedVersion: '1.0.0',
-      trustedPublishedAt: '2026-01-01T00:00:00.000Z',
-      trustedTrustLevel: 'trustedPublisher',
-    })
-  })
-
-  it('does not flag hasProvenance fallback against provenance trustLevel', () => {
-    // When trustLevel is absent, hasProvenance: true maps to provenance rank.
-    // An explicit provenance trustLevel is the same rank, so no downgrade.
-    const result = detectPublishSecurityDowngradeForVersion(
-      [
-        {
-          version: '1.0.0',
-          time: '2026-01-01T00:00:00.000Z',
-          hasProvenance: true,
-          // no trustLevel — fallback path maps to provenance
-        },
-        {
-          version: '1.0.1',
-          time: '2026-01-02T00:00:00.000Z',
-          hasProvenance: true,
-          trustLevel: 'provenance',
-        },
-      ],
-      '1.0.1',
-    )
-
-    // Both are provenance rank, so no downgrade
-    expect(result).toBeNull()
   })
 })


### PR DESCRIPTION

### 🔗 Linked issue

N/A

### 🧭 Context

Unifying trust level scales across ecosystem tools.

### 📚 Description

This switches our trust level logic to use the new `packumeta` package,
so we can share the same scale as other tools in the space (e.g. e18e
tools already use this).

Once staging signals are added to npm, this package will be updated to
expose them as the existing `stagedPublish` level.

NOTE: This does not fix the current problem of staged packages showing
up as a "downgrade".
