### PR TITLE
fix(ui): keep compare header links inside their grid column

### DIFF
--- a/app/components/Compare/ComparisonGrid.vue
+++ b/app/components/Compare/ComparisonGrid.vue
@@ -49,7 +49,7 @@ function getReplacementTooltip(col: ComparisonGridColumn): string {
           <div class="flex items-start justify-center gap-1.5 min-w-0">
             <LinkBase
               :to="packageRoute(col.name, col.version)"
-              class="flex min-w-0 flex-col items-center text-center text-sm"
+              class="flex min-w-0 flex-1 flex-col items-center text-center text-sm"
               :title="col.version ? `${col.name}@${col.version}` : col.name"
             >
               <span class="min-w-0 break-words line-clamp-1">

--- a/app/components/Compare/ComparisonGrid.vue
+++ b/app/components/Compare/ComparisonGrid.vue
@@ -52,10 +52,10 @@ function getReplacementTooltip(col: ComparisonGridColumn): string {
               class="flex min-w-0 flex-1 flex-col items-center text-center text-sm"
               :title="col.version ? `${col.name}@${col.version}` : col.name"
             >
-              <span class="min-w-0 break-words line-clamp-1">
+              <span class="w-full truncate">
                 {{ col.name }}
               </span>
-              <span v-if="col.version" class="text-fg-muted line-clamp-1">
+              <span v-if="col.version" class="w-full truncate text-fg-muted">
                 @{{ col.version }}
               </span>
             </LinkBase>

--- a/test/nuxt/components/compare/ComparisonGrid.spec.ts
+++ b/test/nuxt/components/compare/ComparisonGrid.spec.ts
@@ -60,10 +60,10 @@ describe('ComparisonGrid', () => {
     })
 
     it('constrains the header link to its grid track so long scoped names cannot overflow', async () => {
-      const longName = '@agentmemory/agentmemory@0.9.22'
+      const longName = '@scope/very-long-package-name@1.2.3'
       const component = await mountSuspended(ComparisonGrid, {
         props: {
-          columns: cols(longName, 'claude-mem@13.3.0', 'supermemory@4.21.1', 'mem0ai@3.0.3'),
+          columns: cols(longName, 'pkg-b@1.0.0', 'pkg-c@1.0.0', 'pkg-d@1.0.0'),
         },
       })
 

--- a/test/nuxt/components/compare/ComparisonGrid.spec.ts
+++ b/test/nuxt/components/compare/ComparisonGrid.spec.ts
@@ -58,24 +58,6 @@ describe('ComparisonGrid', () => {
       expect(link.attributes('title')).toBe(longName)
       expect(link.findAll('.truncate')).toHaveLength(2)
     })
-
-    it('constrains the header link to its grid track so long scoped names cannot overflow', async () => {
-      const scopedName = '@scope/very-long-package-name'
-      const scopedVersion = '1.2.3'
-      const component = await mountSuspended(ComparisonGrid, {
-        props: {
-          columns: [
-            { name: scopedName, version: scopedVersion },
-            ...cols('pkg-b@1.0.0', 'pkg-c@1.0.0', 'pkg-d@1.0.0'),
-          ],
-        },
-      })
-
-      const link = component.find(`a[title="${scopedName}@${scopedVersion}"]`)
-      expect(link.exists()).toBe(true)
-      expect(link.classes()).toContain('flex-1')
-      expect(link.classes()).toContain('min-w-0')
-    })
   })
 
   describe('column layout', () => {

--- a/test/nuxt/components/compare/ComparisonGrid.spec.ts
+++ b/test/nuxt/components/compare/ComparisonGrid.spec.ts
@@ -45,7 +45,7 @@ describe('ComparisonGrid', () => {
       expect(component.find('.comparison-cell-nodep').exists()).toBe(true)
     })
 
-    it('renders package name and version on separate clamped lines with a full title attribute', async () => {
+    it('renders package name and version on separate truncated lines with a full title attribute', async () => {
       const longName = 'very-long-package-name@1.0.0-beta.1'
       const component = await mountSuspended(ComparisonGrid, {
         props: {
@@ -56,7 +56,7 @@ describe('ComparisonGrid', () => {
       const link = component.find(`a[title="${longName}"]`)
       expect(link.exists()).toBe(true)
       expect(link.attributes('title')).toBe(longName)
-      expect(link.findAll('.line-clamp-1')).toHaveLength(2)
+      expect(link.findAll('.truncate')).toHaveLength(2)
     })
 
     it('constrains the header link to its grid track so long scoped names cannot overflow', async () => {

--- a/test/nuxt/components/compare/ComparisonGrid.spec.ts
+++ b/test/nuxt/components/compare/ComparisonGrid.spec.ts
@@ -58,6 +58,20 @@ describe('ComparisonGrid', () => {
       expect(link.attributes('title')).toBe(longName)
       expect(link.findAll('.line-clamp-1')).toHaveLength(2)
     })
+
+    it('constrains the header link to its grid track so long scoped names cannot overflow', async () => {
+      const longName = '@agentmemory/agentmemory@0.9.22'
+      const component = await mountSuspended(ComparisonGrid, {
+        props: {
+          columns: cols(longName, 'claude-mem@13.3.0', 'supermemory@4.21.1', 'mem0ai@3.0.3'),
+        },
+      })
+
+      const link = component.find(`a[title="${longName}"]`)
+      expect(link.exists()).toBe(true)
+      expect(link.classes()).toContain('flex-1')
+      expect(link.classes()).toContain('min-w-0')
+    })
   })
 
   describe('column layout', () => {

--- a/test/nuxt/components/compare/ComparisonGrid.spec.ts
+++ b/test/nuxt/components/compare/ComparisonGrid.spec.ts
@@ -60,14 +60,18 @@ describe('ComparisonGrid', () => {
     })
 
     it('constrains the header link to its grid track so long scoped names cannot overflow', async () => {
-      const longName = '@scope/very-long-package-name@1.2.3'
+      const scopedName = '@scope/very-long-package-name'
+      const scopedVersion = '1.2.3'
       const component = await mountSuspended(ComparisonGrid, {
         props: {
-          columns: cols(longName, 'pkg-b@1.0.0', 'pkg-c@1.0.0', 'pkg-d@1.0.0'),
+          columns: [
+            { name: scopedName, version: scopedVersion },
+            ...cols('pkg-b@1.0.0', 'pkg-c@1.0.0', 'pkg-d@1.0.0'),
+          ],
         },
       })
 
-      const link = component.find(`a[title="${longName}"]`)
+      const link = component.find(`a[title="${scopedName}@${scopedVersion}"]`)
       expect(link.exists()).toBe(true)
       expect(link.classes()).toContain('flex-1')
       expect(link.classes()).toContain('min-w-0')


### PR DESCRIPTION
Fixes #2802

On the compare page, package headers like `@agentmemory/agentmemory` ran wider than their grid column and visibly overlapped both the sticky label cell on the left and the next package header on the right.

The header link in `ComparisonGrid.vue` was `flex min-w-0 flex-col` with no `flex-1` / `w-full`, so it sized to its intrinsic content width and escaped the grid track. Adding `flex-1` makes the link fill the available track width, which gives the inner `line-clamp-1` spans a real width to clamp against. The existing `min-w-0` already lets it shrink when the column is narrower than the name.

Repro URL: https://npmx.dev/compare?packages=@agentmemory/agentmemory,claude-mem,supermemory,mem0ai&layout=split

I also added a small regression test that mounts the grid with the four packages from the screenshot above and asserts the long-name header link carries `flex-1` and `min-w-0`.