### PR TITLE
fix: noodle date check

### DIFF
--- a/app/components/Landing/IntroHeader.vue
+++ b/app/components/Landing/IntroHeader.vue
@@ -55,16 +55,17 @@ onPrehydrate(el => {
   }
 
   const currentActiveNoodles = activeNoodles.filter(noodle => {
-    const todayDate = new Date()
-    const todayDateRaw = `${todayDate.getFullYear()}-${todayDate.getMonth() + 1}-${todayDate.getDate()}`
+    if (!noodle.date) return false
 
-    const noodleDateFrom = new Date(noodle.date!)
-    if (!noodle.dateTo) {
-      const noodleDateFromRaw = `${noodleDateFrom.getFullYear()}-${noodleDateFrom.getMonth() + 1}-${noodleDateFrom.getDate()}`
-      return todayDateRaw === noodleDateFromRaw
-    }
-    const noodleDateTo = new Date(noodle.dateTo!)
-    return todayDate >= noodleDateFrom && todayDate <= noodleDateTo
+    const today = new Intl.DateTimeFormat('en-CA', {
+      timeZone: noodle.timezone !== 'auto' ? noodle.timezone : undefined,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(new Date())
+
+    if (!noodle.dateTo) return today === noodle.date
+    return today >= noodle.date && today <= noodle.dateTo
   })
 
   if (!currentActiveNoodles.length) return

--- a/app/components/Landing/IntroHeader.vue
+++ b/app/components/Landing/IntroHeader.vue
@@ -56,21 +56,11 @@ onPrehydrate(el => {
 
   const currentActiveNoodles = activeNoodles.filter(noodle => {
     const todayDate = new Date()
-    const todayDateRaw = new Intl.DateTimeFormat('en-US', {
-      timeZone: noodle.timezone === 'auto' ? undefined : noodle.timezone,
-      month: '2-digit',
-      day: '2-digit',
-      year: 'numeric',
-    }).format(todayDate)
+    const todayDateRaw = `${todayDate.getFullYear()}-${todayDate.getMonth() + 1}-${todayDate.getDate()}`
 
     const noodleDateFrom = new Date(noodle.date!)
     if (!noodle.dateTo) {
-      const noodleDateFromRaw = new Intl.DateTimeFormat('en-US', {
-        timeZone: noodle.timezone === 'auto' ? undefined : noodle.timezone,
-        month: '2-digit',
-        day: '2-digit',
-        year: 'numeric',
-      }).format(noodleDateFrom)
+      const noodleDateFromRaw = `${noodleDateFrom.getFullYear()}-${noodleDateFrom.getMonth() + 1}-${noodleDateFrom.getDate()}`
       return todayDateRaw === noodleDateFromRaw
     }
     const noodleDateTo = new Date(noodle.dateTo!)

--- a/app/components/Noodle/index.ts
+++ b/app/components/Noodle/index.ts
@@ -6,10 +6,10 @@ export type Noodle = {
   key: string
   // Timezone for the noodle (default is auto, i.e. user's timezone)
   timezone?: string
-  // Date for the noodle
-  date?: string
-  // `Date to` for the noodle
-  dateTo?: string
+  // Date for the noodle (YYYY-MM-DD)
+  date?: `${number}-${number}-${number}`
+  // `Date to` for the noodle (YYYY-MM-DD)
+  dateTo?: `${number}-${number}-${number}`
   // Logo for the noodle - could be any component. Relative parent - intro section
   logo: Component
   // Show npmx tagline or not (default is true)

--- a/test/e2e/noodle.spec.ts
+++ b/test/e2e/noodle.spec.ts
@@ -2,9 +2,11 @@ import type { Page } from '@playwright/test'
 import type { Noodle } from '../../app/components/Noodle'
 import { expect, test } from './test-utils'
 
+type MockNoodle = Partial<Omit<Noodle, 'logo'>>
+
 type MockNoodlesOptions = {
-  active?: Noodle[]
-  permanent?: Noodle[]
+  active?: MockNoodle[]
+  permanent?: MockNoodle[]
 }
 
 function htmlAttrEncode(value: string) {
@@ -19,15 +21,21 @@ async function mockNoodles(page: Page, options: MockNoodlesOptions = {}) {
     url => new URL(url).pathname === '/',
     async route => {
       const response = await route.fetch()
-      const body = (await response.text())
-        .replace(
-          /data-active-noodles="[^"]*"/,
-          `data-active-noodles="${htmlAttrEncode(activeJson)}"`,
-        )
-        .replace(
-          /data-permanent-noodles="[^"]*"/,
-          `data-permanent-noodles="${htmlAttrEncode(permanentJson)}"`,
-        )
+      const original = await response.text()
+
+      const activeRegex = /data-active-noodles="[^"]*"/
+      const permanentRegex = /data-permanent-noodles="[^"]*"/
+
+      if (!activeRegex.test(original)) {
+        throw new Error('mockNoodles: `data-active-noodles` marker not found in response HTML')
+      }
+      if (!permanentRegex.test(original)) {
+        throw new Error('mockNoodles: `data-permanent-noodles` marker not found in response HTML')
+      }
+
+      const body = original
+        .replace(activeRegex, `data-active-noodles="${htmlAttrEncode(activeJson)}"`)
+        .replace(permanentRegex, `data-permanent-noodles="${htmlAttrEncode(permanentJson)}"`)
 
       await route.fulfill({ response, body })
     },
@@ -50,8 +58,8 @@ test.describe('LandingIntroHeader onPrehydrate noodle', () => {
       goto,
     }) => {
       await mockNoodles(page, {
-        active: [{ key: 'noodle', date: '2099-06-12', logo: '' }],
-        permanent: [{ key: 'kawaii', tagline: false, logo: '' }],
+        active: [{ key: 'noodle', date: '2099-06-12' }],
+        permanent: [{ key: 'kawaii', tagline: false }],
       })
 
       await goto('/', { waitUntil: 'hydration' })
@@ -69,7 +77,7 @@ test.describe('LandingIntroHeader onPrehydrate noodle', () => {
       goto,
     }) => {
       await mockNoodles(page, {
-        permanent: [{ key: 'kawaii', tagline: false, logo: '' }],
+        permanent: [{ key: 'kawaii', tagline: false }],
         active: [],
       })
 
@@ -84,7 +92,7 @@ test.describe('LandingIntroHeader onPrehydrate noodle', () => {
   test.describe('active noodles', () => {
     test('exact date match → noodle visible, tagline visible', async ({ page, goto }) => {
       await mockNoodles(page, {
-        active: [{ key: 'nodejs', date: TEST_DATE, timezone: 'UTC', logo: '' }],
+        active: [{ key: 'nodejs', date: TEST_DATE, timezone: 'UTC' }],
       })
 
       await goto('/', { waitUntil: 'hydration' })
@@ -96,9 +104,7 @@ test.describe('LandingIntroHeader onPrehydrate noodle', () => {
 
     test('current date inside [date, dateTo] range → noodle visible', async ({ page, goto }) => {
       await mockNoodles(page, {
-        active: [
-          { key: 'nodejs', date: '2099-06-14', dateTo: '2099-06-16', timezone: 'UTC', logo: '' },
-        ],
+        active: [{ key: 'nodejs', date: '2099-06-14', dateTo: '2099-06-16', timezone: 'UTC' }],
       })
 
       await goto('/', { waitUntil: 'hydration' })
@@ -116,7 +122,7 @@ test.describe('LandingIntroHeader onPrehydrate noodle', () => {
       // 2099-06-15T22:00Z is 2099-06-16 07:00 in Asia/Tokyo (UTC+9)
       await page.clock.setFixedTime(new Date('2099-06-15T22:00:00Z'))
       await mockNoodles(page, {
-        active: [{ key: 'nodejs', date: '2099-06-16', timezone: 'Asia/Tokyo', logo: '' }],
+        active: [{ key: 'nodejs', date: '2099-06-16', timezone: 'Asia/Tokyo' }],
       })
 
       await goto('/', { waitUntil: 'hydration' })
@@ -137,7 +143,7 @@ test.describe('LandingIntroHeader onPrehydrate noodle — non-UTC browser timezo
     // 2099-06-15T05:00Z is 2099-06-14 22:00 in America/Los_Angeles (UTC-7 DST)
     await page.clock.setFixedTime(new Date('2099-06-15T05:00:00Z'))
     await mockNoodles(page, {
-      active: [{ key: 'nodejs', date: '2099-06-14', timezone: 'auto', logo: '' }],
+      active: [{ key: 'nodejs', date: '2099-06-14', timezone: 'auto' }],
     })
 
     await goto('/', { waitUntil: 'hydration' })

--- a/test/e2e/noodle.spec.ts
+++ b/test/e2e/noodle.spec.ts
@@ -1,0 +1,148 @@
+import type { Page } from '@playwright/test'
+import type { Noodle } from '../../app/components/Noodle'
+import { expect, test } from './test-utils'
+
+type MockNoodlesOptions = {
+  active?: Noodle[]
+  permanent?: Noodle[]
+}
+
+function htmlAttrEncode(value: string) {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;')
+}
+
+async function mockNoodles(page: Page, options: MockNoodlesOptions = {}) {
+  const activeJson = JSON.stringify(options.active ?? [])
+  const permanentJson = JSON.stringify(options.permanent ?? [])
+
+  await page.route(
+    url => new URL(url).pathname === '/',
+    async route => {
+      const response = await route.fetch()
+      const body = (await response.text())
+        .replace(
+          /data-active-noodles="[^"]*"/,
+          `data-active-noodles="${htmlAttrEncode(activeJson)}"`,
+        )
+        .replace(
+          /data-permanent-noodles="[^"]*"/,
+          `data-permanent-noodles="${htmlAttrEncode(permanentJson)}"`,
+        )
+
+      await route.fulfill({ response, body })
+    },
+  )
+}
+
+const TEST_TIME = new Date('2099-06-15T12:00:00Z')
+const TEST_DATE = '2099-06-15'
+
+test.describe('LandingIntroHeader onPrehydrate noodle', () => {
+  test.use({ timezoneId: 'UTC' })
+
+  test.beforeEach(async ({ page }) => {
+    await page.clock.setFixedTime(TEST_TIME)
+  })
+
+  test.describe('default behavior', () => {
+    test('no permanent or active match → default logo and tagline visible', async ({
+      page,
+      goto,
+    }) => {
+      await mockNoodles(page, {
+        active: [{ key: 'noodle', date: '2099-06-12', logo: '' }],
+        permanent: [{ key: 'kawaii', tagline: false, logo: '' }],
+      })
+
+      await goto('/', { waitUntil: 'hydration' })
+
+      await expect(page.locator('#intro-header-noodle-default')).toBeVisible()
+      await expect(page.locator('#intro-header-noodle-kawaii')).toBeHidden()
+      await expect(page.locator('#intro-header-noodle-nodejs')).toBeHidden()
+      await expect(page.locator('#intro-header-tagline')).toBeVisible()
+    })
+  })
+
+  test.describe('permanent noodles', () => {
+    test('matching query swaps in the noodle and hides the tagline (opt-out)', async ({
+      page,
+      goto,
+    }) => {
+      await mockNoodles(page, {
+        permanent: [{ key: 'kawaii', tagline: false, logo: '' }],
+        active: [],
+      })
+
+      await goto('/?kawaii', { waitUntil: 'hydration' })
+
+      await expect(page.locator('#intro-header-noodle-kawaii')).toBeVisible()
+      await expect(page.locator('#intro-header-noodle-default')).toBeHidden()
+      await expect(page.locator('#intro-header-tagline')).toBeHidden()
+    })
+  })
+
+  test.describe('active noodles', () => {
+    test('exact date match → noodle visible, tagline visible', async ({ page, goto }) => {
+      await mockNoodles(page, {
+        active: [{ key: 'nodejs', date: TEST_DATE, timezone: 'UTC', logo: '' }],
+      })
+
+      await goto('/', { waitUntil: 'hydration' })
+
+      await expect(page.locator('#intro-header-noodle-nodejs')).toBeVisible()
+      await expect(page.locator('#intro-header-noodle-default')).toBeHidden()
+      await expect(page.locator('#intro-header-tagline')).toBeVisible()
+    })
+
+    test('current date inside [date, dateTo] range → noodle visible', async ({ page, goto }) => {
+      await mockNoodles(page, {
+        active: [
+          { key: 'nodejs', date: '2099-06-14', dateTo: '2099-06-16', timezone: 'UTC', logo: '' },
+        ],
+      })
+
+      await goto('/', { waitUntil: 'hydration' })
+
+      await expect(page.locator('#intro-header-noodle-nodejs')).toBeVisible()
+      await expect(page.locator('#intro-header-noodle-default')).toBeHidden()
+    })
+  })
+
+  test.describe('noodles in different timezone', () => {
+    test('explicit timezone shifts current date forward (UTC late night → next day in JST)', async ({
+      page,
+      goto,
+    }) => {
+      // 2099-06-15T22:00Z is 2099-06-16 07:00 in Asia/Tokyo (UTC+9)
+      await page.clock.setFixedTime(new Date('2099-06-15T22:00:00Z'))
+      await mockNoodles(page, {
+        active: [{ key: 'nodejs', date: '2099-06-16', timezone: 'Asia/Tokyo', logo: '' }],
+      })
+
+      await goto('/', { waitUntil: 'hydration' })
+
+      await expect(page.locator('#intro-header-noodle-nodejs')).toBeVisible()
+      await expect(page.locator('#intro-header-noodle-default')).toBeHidden()
+    })
+  })
+})
+
+test.describe('LandingIntroHeader onPrehydrate noodle — non-UTC browser timezone', () => {
+  test.use({ timezoneId: 'America/Los_Angeles' })
+
+  test('timezone "auto" follows the browser timezone (UTC early morning → previous day in LA)', async ({
+    page,
+    goto,
+  }) => {
+    // 2099-06-15T05:00Z is 2099-06-14 22:00 in America/Los_Angeles (UTC-7 DST)
+    await page.clock.setFixedTime(new Date('2099-06-15T05:00:00Z'))
+    await mockNoodles(page, {
+      active: [{ key: 'nodejs', date: '2099-06-14', timezone: 'auto', logo: '' }],
+    })
+
+    await goto('/', { waitUntil: 'hydration' })
+
+    await expect(page.locator('#intro-header-noodle-nodejs')).toBeVisible()
+    await expect(page.locator('#intro-header-noodle-default')).toBeHidden()
+  })
+})

--- a/test/e2e/noodle.spec.ts
+++ b/test/e2e/noodle.spec.ts
@@ -1,8 +1,13 @@
 import type { Page } from '@playwright/test'
-import type { Noodle } from '../../app/components/Noodle'
 import { expect, test } from './test-utils'
 
-type MockNoodle = Partial<Omit<Noodle, 'logo'>>
+type MockNoodle = {
+  key: string
+  date?: string
+  dateTo?: string
+  timezone?: string
+  tagline?: boolean
+}
 
 type MockNoodlesOptions = {
   active?: MockNoodle[]


### PR DESCRIPTION
### 🧭 Context

Due to the logic behind noodle detection, noodles in American time zones appeared on the previous day. We didn't notice this for a previous ones, but fortunately, with the current noodle dedicated to a specific date, it became clear.

### 📚 Description

I removed the logic for processing the date through intl for dates specified in the config and left it only for the user's date. In theory, this should eliminate all risks