### PR TITLE
chore: bump vue-data-ui from 3.20.10 to 3.20.11

### DIFF
--- a/app/components/Package/TimelineChart.vue
+++ b/app/components/Package/TimelineChart.vue
@@ -711,7 +711,7 @@ const indexSelection = computed(() => {
               class="pointer-events-none"
             >
               <path
-                :d="`M ${plot.x - 5} ${plot.y - 20} l 4 6 l 10 -12`"
+                :d="`M ${plot.x - 4} ${plot.y - 20} l 4 6 l 10 -12`"
                 fill="none"
                 :stroke="colors.bg"
                 stroke-width="6"
@@ -720,7 +720,7 @@ const indexSelection = computed(() => {
                 class="svg-element-transition"
               />
               <path
-                :d="`M ${plot.x - 5} ${plot.y - 20} l 4 6 l 10 -12`"
+                :d="`M ${plot.x - 4} ${plot.y - 20} l 4 6 l 10 -12`"
                 fill="none"
                 :stroke="e18eGradientColors.at(-1)"
                 stroke-width="2"
@@ -737,7 +737,7 @@ const indexSelection = computed(() => {
               class="pointer-events-none"
             >
               <path
-                :d="`M ${plot.x - 1} ${plot.y - 20 - (plot.offsetY ?? 0)} l -6 10 l 12 0 l -6 -10 m 0 5 l 0 2`"
+                :d="`M ${plot.x} ${plot.y - 20 - (plot.offsetY ?? 0)} l -6 10 l 12 0 l -6 -10 m 0 5 l 0 2`"
                 fill="none"
                 :stroke="colors.bg"
                 stroke-width="6"
@@ -746,7 +746,7 @@ const indexSelection = computed(() => {
                 class="svg-element-transition"
               />
               <path
-                :d="`M ${plot.x - 1} ${plot.y - 20 - (plot.offsetY ?? 0)} l -6 10 l 12 0 l -6 -10 m 0 5 l 0 2`"
+                :d="`M ${plot.x} ${plot.y - 20 - (plot.offsetY ?? 0)} l -6 10 l 12 0 l -6 -10 m 0 5 l 0 2`"
                 fill="none"
                 :stroke="e18eGradientColors[0]"
                 stroke-width="2"

--- a/app/components/Package/TimelineChart.vue
+++ b/app/components/Package/TimelineChart.vue
@@ -277,6 +277,9 @@ const tooltipPosition = useChartTooltipPosition(chartRef)
 const config = computed<VueUiXyConfig>(() => {
   return {
     theme: isDarkMode.value ? 'dark' : '',
+    downsample: {
+      threshold: 5000,
+    },
     line: {
       useGradient: false,
       radius: 2,

--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -1380,6 +1380,9 @@ const keepZoomState = shallowRef(true)
 const chartConfig = computed<VueUiXyConfig>(() => {
   return {
     theme: isDarkMode.value ? 'dark' : ('' as VueDataUiTheme),
+    downsample: {
+      threshold: 5000,
+    },
     a11y: {
       translations: {
         keyboardNavigation: $t(

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "0.1.20",
     "vue": "3.5.34",
-    "vue-data-ui": "3.20.10",
+    "vue-data-ui": "3.20.11",
     "vue-router": "5.0.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,8 +253,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@6.0.2)
       vue-data-ui:
-        specifier: 3.20.10
-        version: 3.20.10(vue@3.5.34)
+        specifier: 3.20.11
+        version: 3.20.11(vue@3.5.34)
       vue-router:
         specifier: 5.0.4
         version: 5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.34)
@@ -11167,8 +11167,8 @@ packages:
   vue-component-type-helpers@3.3.2:
     resolution: {integrity: sha512-l4Z2Y34m7nFMlx8vrslJaVtXxUpzgDMSESC7TakG/c5kwjYT/do+E0NcT2/vWDzaoIhsShg/2OKwX7Q4nbzC0g==}
 
-  vue-data-ui@3.20.10:
-    resolution: {integrity: sha512-w9RDQzyfMDIFdT2oFB9JyHebOKQww098KsLQ5fZtBGFAMEFTuSD72BEg2dYKD/UVQcu8WPV9xKSQAp7Kcjls3g==}
+  vue-data-ui@3.20.11:
+    resolution: {integrity: sha512-BvK9amlFqGWF40J00guYmy4IYraDV1qrgMgKC48HGvn6HUCGw4HrAhRBr/7eRrRdMkR3ym6E77/GKLQhr1fQow==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -23689,7 +23689,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.2: {}
 
-  vue-data-ui@3.20.10(vue@3.5.34):
+  vue-data-ui@3.20.11(vue@3.5.34):
     dependencies:
       vue: 3.5.34(typescript@6.0.2)
 


### PR DESCRIPTION
This updates vue-data-ui to the latest version, which fixes an issue with the chart zoom minimap handles, that would jump when the dataset is very large (for example when pulling hundreds of versions on the timeline), due to a lack of precision caused by excessive internal rounding.

Other improvements:

### 1. Timeline  chart
I slightly offset the positive & negative icons in the timeline chart, which were not exactly centered on x.

| Before| After|
|-|-|
|<img width="100" alt="image" src="https://github.com/user-attachments/assets/e8e0a714-54aa-4759-97a6-cd9326cba50d" />|<img width="100" alt="image" src="https://github.com/user-attachments/assets/2260f282-8993-45be-9a7b-e861e5b59e0f" />|

### 2. TrendsChart & TimelineChart
I upped the threshold above which the charts trigger lttb downsampling (from the default 1095 to 5000), for the rare cases where users will explore daily downloads history with a very wide range of dates, and in case a user is patient enough to load more than a thousand versions in the timeline chart. Downsampling does not affect the shape of the chart, but would alter the values at a given index.