### PR TITLE
refactor: convert emoji shortcodes without regex-only parsing

### DIFF
--- a/shared/utils/emoji.ts
+++ b/shared/utils/emoji.ts
@@ -1942,4 +1942,3 @@ export function convertToEmoji(html: string): string {
   output += html.slice(position)
   return output
 }
-

--- a/shared/utils/emoji.ts
+++ b/shared/utils/emoji.ts
@@ -1904,17 +1904,42 @@ const emojis: Record<string, string> = {
   'scotland': '🏴󠁧󠁢󠁳󠁣󠁴󠁿',
   'wales': '🏴󠁧󠁢󠁷󠁬󠁳󠁿',
 }
+const SKIP_EMOJI_TAGS = new Set(['code', 'pre'])
 
 export function convertToEmoji(html: string): string {
-  return html.replace(
-    /(<code[\s>][\s\S]*?<\/code>|<pre[\s>][\s\S]*?<\/pre>)|(:[\w+-]+:)/gi,
-    (match, codeBlock: string | undefined, shortcode: string | undefined) => {
-      if (codeBlock) return codeBlock
-      if (shortcode) {
-        const key = shortcode.slice(1, -1)
-        return emojis[key] ?? shortcode
+  let output = ''
+  let position = 0
+  let skipDepth = 0
+
+  for (const match of html.matchAll(/<\/?([a-z][\w:-]*)(?:\s[^>]*)?>|:[\w+-]+:/gi)) {
+    const token = match[0]
+    const tagName = match[1]?.toLowerCase()
+    const index = match.index ?? 0
+
+    if (index > position) {
+      output += html.slice(position, index)
+    }
+
+    if (tagName) {
+      if (SKIP_EMOJI_TAGS.has(tagName)) {
+        if (token.startsWith('</')) {
+          skipDepth = Math.max(0, skipDepth - 1)
+        } else if (!token.endsWith('/>')) {
+          skipDepth += 1
+        }
       }
-      return match
-    },
-  )
+      output += token
+    } else if (skipDepth > 0) {
+      output += token
+    } else {
+      const key = token.slice(1, -1)
+      output += emojis[key] ?? token
+    }
+
+    position = index + token.length
+  }
+
+  output += html.slice(position)
+  return output
 }
+

--- a/test/unit/shared/utils/emoji.spec.ts
+++ b/test/unit/shared/utils/emoji.spec.ts
@@ -20,6 +20,8 @@ describe('convertToEmoji', () => {
   })
 
   it('does not require matching code blocks with regex', () => {
-    expect(convertToEmoji('<p>:1234:</p><code>:smile:</code><p>:smile:</p>')).toBe('<p>🔢</p><code>:smile:</code><p>😄</p>')
+    expect(convertToEmoji('<p>:1234:</p><code>:smile:</code><p>:smile:</p>')).toBe(
+      '<p>🔢</p><code>:smile:</code><p>😄</p>',
+    )
   })
 })

--- a/test/unit/shared/utils/emoji.spec.ts
+++ b/test/unit/shared/utils/emoji.spec.ts
@@ -14,4 +14,12 @@ describe('convertToEmoji', () => {
     expect(convertToEmoji('<p>:1234:</p><code>:1234:</code>')).toBe('<p>🔢</p><code>:1234:</code>')
     expect(convertToEmoji('<code>:1234:</code><p>:1234:</p>')).toBe('<code>:1234:</code><p>🔢</p>')
   })
+
+  it('leaves :1234: in pre blocks untouched', () => {
+    expect(convertToEmoji('<pre><code>:1234:</code></pre>')).toBe('<pre><code>:1234:</code></pre>')
+  })
+
+  it('does not require matching code blocks with regex', () => {
+    expect(convertToEmoji('<p>:1234:</p><code>:smile:</code><p>:smile:</p>')).toBe('<p>🔢</p><code>:smile:</code><p>😄</p>')
+  })
 })


### PR DESCRIPTION
## Summary

Addresses #2822 by changing `convertToEmoji` so it no longer relies on one regex that both finds skipped code/pre blocks and converts emoji shortcodes.

The new implementation scans HTML tokens and emoji shortcodes in order, tracks whether the current position is inside a skipped tag (`code`/`pre`), and only converts shortcodes outside those skipped ranges. This keeps code/pre contents untouched while avoiding a single regex that has to match whole code blocks.

## Tests

- Added coverage for `<pre><code>...</code></pre>`
- Added coverage for converting emoji before/after a code block while leaving the code block unchanged
- Locally sanity-checked the conversion logic with Node against the existing and new cases

Closes #2822