### PR TITLE
fix(i18n): add singular forms to en strings

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -386,14 +386,14 @@
       "title_deps": "Significant dependency count increase since v{version}",
       "title_both": "Significant size and dependency increase since v{version}",
       "size": "Install size increased by {percent} ({size} larger)",
-      "deps": "{count} more dependencies"
+      "deps": "{count} more dependency | {count} more dependencies"
     },
     "size_decrease": {
       "title_size": "Package size decreased since v{version}!",
       "title_deps": "Dependency count decreased since v{version}!",
       "title_both": "Package size and dependency count decreased since v{version}!",
       "size": "Install size reduced by {percent} ({size} smaller)",
-      "deps": "{count} fewer dependencies"
+      "deps": "{count} fewer dependency | {count} fewer dependencies"
     },
     "replacement": {
       "title": "You might not need this dependency.",
@@ -588,8 +588,8 @@
       "load_error": "Failed to load timeline. Please try again later.",
       "size_increase": "Install size increased by {percent}% ({size})",
       "size_decrease": "Install size decreased by {percent}% ({size})",
-      "dep_increase": "{count} dependencies added",
-      "dep_decrease": "{count} dependencies removed",
+      "dep_increase": "{count} dependency added | {count} dependencies added",
+      "dep_decrease": "{count} dependency removed | {count} dependencies removed",
       "license_change": "License changed from {from} to {to}",
       "esm_added": "Module type changed to ESM",
       "esm_removed": "Module type changed from ESM to CJS",


### PR DESCRIPTION
### 🧭 Context

English Translation strings.

### 📚 Description

While translating, I noticed some translation strings in `en` only have plural forms, but the `{count}` could be 1 as well, so we should include the singular form as well. 

I'm not sure if the translation keys have to change, so the translation workflow works correctly...
