### PR TITLE
fix(i18n): localize size increase/decrease percentage

### DIFF
--- a/app/components/Package/SizeDecrease.vue
+++ b/app/components/Package/SizeDecrease.vue
@@ -10,10 +10,8 @@ const { locale } = useI18n()
 const bytesFormatter = useBytesFormatter()
 const numberFormatter = useNumberFormatter()
 
-const sizePercent = computed(() => {
-  const percentFormatter = new Intl.NumberFormat(locale.value, { style: 'percent' })
-  return percentFormatter.format(props.diff.sizeRatio)
-})
+const percentFormatter = computed(() => new Intl.NumberFormat(locale.value, { style: 'percent' }))
+const sizePercent = computed(() => percentFormatter.value.format(props.diff.sizeRatio))
 const sizeDecreaseAbs = computed(() => Math.abs(props.diff.sizeIncrease))
 const depDecreaseAbs = computed(() => Math.abs(props.diff.depDiff))
 </script>

--- a/app/components/Package/SizeDecrease.vue
+++ b/app/components/Package/SizeDecrease.vue
@@ -5,12 +5,10 @@ const props = defineProps<{
   diff: InstallSizeDiff
 }>()
 
-const { locale } = useI18n()
-
 const bytesFormatter = useBytesFormatter()
 const numberFormatter = useNumberFormatter()
+const percentFormatter = useNumberFormatter({ style: 'percent' })
 
-const percentFormatter = computed(() => new Intl.NumberFormat(locale.value, { style: 'percent' }))
 const sizePercent = computed(() => percentFormatter.value.format(props.diff.sizeRatio))
 const sizeDecreaseAbs = computed(() => Math.abs(props.diff.sizeIncrease))
 const depDecreaseAbs = computed(() => Math.abs(props.diff.depDiff))

--- a/app/components/Package/SizeDecrease.vue
+++ b/app/components/Package/SizeDecrease.vue
@@ -5,10 +5,15 @@ const props = defineProps<{
   diff: InstallSizeDiff
 }>()
 
+const { locale } = useI18n()
+
 const bytesFormatter = useBytesFormatter()
 const numberFormatter = useNumberFormatter()
 
-const sizePercent = computed(() => Math.round(Math.abs(props.diff.sizeRatio) * 100))
+const sizePercent = computed(() => {
+  const percentFormatter = new Intl.NumberFormat(locale.value, { style: 'percent' })
+  return percentFormatter.format(props.diff.sizeRatio)
+})
 const sizeDecreaseAbs = computed(() => Math.abs(props.diff.sizeIncrease))
 const depDecreaseAbs = computed(() => Math.abs(props.diff.depDiff))
 </script>
@@ -33,7 +38,7 @@ const depDecreaseAbs = computed(() => Math.abs(props.diff.depDiff))
     <p class="text-sm m-0 mt-1">
       <i18n-t v-if="diff.sizeThresholdExceeded" keypath="package.size_decrease.size" scope="global">
         <template #percent
-          ><strong>{{ sizePercent }}%</strong></template
+          ><strong>{{ sizePercent }}</strong></template
         >
         <template #size
           ><strong>{{ bytesFormatter.format(sizeDecreaseAbs) }}</strong></template

--- a/app/components/Package/SizeDecrease.vue
+++ b/app/components/Package/SizeDecrease.vue
@@ -9,7 +9,7 @@ const bytesFormatter = useBytesFormatter()
 const numberFormatter = useNumberFormatter()
 const percentFormatter = useNumberFormatter({ style: 'percent' })
 
-const sizePercent = computed(() => percentFormatter.value.format(props.diff.sizeRatio))
+const sizePercent = computed(() => percentFormatter.value.format(Math.abs(props.diff.sizeRatio)))
 const sizeDecreaseAbs = computed(() => Math.abs(props.diff.sizeIncrease))
 const depDecreaseAbs = computed(() => Math.abs(props.diff.depDiff))
 </script>

--- a/app/components/Package/SizeIncrease.vue
+++ b/app/components/Package/SizeIncrease.vue
@@ -5,10 +5,15 @@ const props = defineProps<{
   diff: InstallSizeDiff
 }>()
 
+const { locale } = useI18n()
+
 const bytesFormatter = useBytesFormatter()
 const numberFormatter = useNumberFormatter()
 
-const sizePercent = computed(() => Math.round(props.diff.sizeRatio * 100))
+const sizePercent = computed(() => {
+  const percentFormatter = new Intl.NumberFormat(locale.value, { style: 'percent' })
+  return percentFormatter.format(props.diff.sizeRatio)
+})
 </script>
 
 <template>
@@ -28,7 +33,7 @@ const sizePercent = computed(() => Math.round(props.diff.sizeRatio * 100))
     <p class="text-sm m-0 mt-1">
       <i18n-t v-if="diff.sizeThresholdExceeded" keypath="package.size_increase.size" scope="global">
         <template #percent
-          ><strong>{{ sizePercent }}%</strong></template
+          ><strong>{{ sizePercent }}</strong></template
         >
         <template #size
           ><strong>{{ bytesFormatter.format(diff.sizeIncrease) }}</strong></template

--- a/app/components/Package/SizeIncrease.vue
+++ b/app/components/Package/SizeIncrease.vue
@@ -5,12 +5,10 @@ const props = defineProps<{
   diff: InstallSizeDiff
 }>()
 
-const { locale } = useI18n()
-
 const bytesFormatter = useBytesFormatter()
 const numberFormatter = useNumberFormatter()
+const percentFormatter = useNumberFormatter({ style: 'percent' })
 
-const percentFormatter = computed(() => new Intl.NumberFormat(locale.value, { style: 'percent' }))
 const sizePercent = computed(() => percentFormatter.value.format(props.diff.sizeRatio))
 </script>
 

--- a/app/components/Package/SizeIncrease.vue
+++ b/app/components/Package/SizeIncrease.vue
@@ -10,10 +10,8 @@ const { locale } = useI18n()
 const bytesFormatter = useBytesFormatter()
 const numberFormatter = useNumberFormatter()
 
-const sizePercent = computed(() => {
-  const percentFormatter = new Intl.NumberFormat(locale.value, { style: 'percent' })
-  return percentFormatter.format(props.diff.sizeRatio)
-})
+const percentFormatter = computed(() => new Intl.NumberFormat(locale.value, { style: 'percent' }))
+const sizePercent = computed(() => percentFormatter.value.format(props.diff.sizeRatio))
 </script>
 
 <template>

--- a/app/components/Package/SizeIncrease.vue
+++ b/app/components/Package/SizeIncrease.vue
@@ -9,7 +9,7 @@ const bytesFormatter = useBytesFormatter()
 const numberFormatter = useNumberFormatter()
 const percentFormatter = useNumberFormatter({ style: 'percent' })
 
-const sizePercent = computed(() => percentFormatter.value.format(props.diff.sizeRatio))
+const sizePercent = computed(() => percentFormatter.value.format(Math.abs(props.diff.sizeRatio)))
 </script>
 
 <template>


### PR DESCRIPTION
### 🧭 Context

Display correctly localized percentage value for size increase / decrease notice.

### 📚 Description

While translating some UI strings, I noticed that the size increase / decrease components show the percentage value hard coded with the `%` sign right after the calculated number.

In some languages however, this is wrong, so I updated the components to use the [`Intl.NumberFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#percent) (suggestion from Wilco) to get the correct string for all languages.

### 📸 Screenshots

Here you can see screenshots of before and after in English and German (not translated yet, but you see the space in the after image):

|   | Before  | After  |
|---|---|---|
| English  | <img width="734" height="83" alt="image" src="https://github.com/user-attachments/assets/879ae4bd-0dd8-4760-a56a-e739fc3b6cde" />  | <img width="865" height="86" alt="image" src="https://github.com/user-attachments/assets/6a5d60d2-835b-417c-aba0-b6d9c8027e91" />  |
| German  | <img width="729" height="82" alt="image" src="https://github.com/user-attachments/assets/f4f7b1be-9dc0-450f-a874-2fea37d87af0" />  | <img width="729" height="85" alt="image" src="https://github.com/user-attachments/assets/169bf70e-c2f6-4219-93b4-9651bad35aec" />  |