### PR TITLE
feat(ui): independent terminal cards with fixed copy button

### DIFF
--- a/app/components/Terminal/Install.vue
+++ b/app/components/Terminal/Install.vue
@@ -324,7 +324,9 @@ useCommandPaletteContextCommands(
             :title="$t('package.get_started.view_types', { package: typesPackageName })"
           >
             <span class="i-lucide:arrow-right rtl-flip w-3 h-3 align-middle" aria-hidden="true" />
-            <span class="sr-only">View {{ typesPackageName }}</span>
+            <span class="sr-only">{{
+              $t('package.get_started.view_types', { package: typesPackageName })
+            }}</span>
           </NuxtLink>
         </div>
       </div>

--- a/app/components/Terminal/Install.vue
+++ b/app/components/Terminal/Install.vue
@@ -210,56 +210,64 @@ useCommandPaletteContextCommands(
 </script>
 
 <template>
-  <div class="relative group">
-    <!-- Terminal-style install command -->
-    <div class="bg-bg-subtle border border-border rounded-lg overflow-hidden">
+  <div class="space-y-2">
+    <!-- Install command - each PM variant is its own terminal card -->
+    <div
+      v-for="pm in packageManagers"
+      :key="`install-${pm.id}`"
+      :data-pm-cmd="pm.id"
+      class="bg-bg-subtle border border-border rounded-lg overflow-hidden"
+    >
       <div class="flex gap-1.5 px-3 pt-2 sm:px-4 sm:pt-3">
         <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
         <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
         <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
       </div>
-      <div class="px-3 pt-2 pb-3 sm:px-4 sm:pt-3 sm:pb-4 space-y-1 overflow-x-auto" dir="ltr">
-        <!-- Install command - render all PM variants, CSS controls visibility -->
-        <div
-          v-for="pm in packageManagers"
-          :key="`install-${pm.id}`"
-          :data-pm-cmd="pm.id"
-          class="flex items-center gap-2 group/installcmd min-w-0"
+      <div
+        class="flex items-center gap-2 px-3 pt-2 pb-3 sm:px-4 sm:pt-3 sm:pb-4 overflow-x-auto"
+        dir="ltr"
+      >
+        <span class="self-start text-fg-subtle font-mono text-sm select-none shrink-0">$</span>
+        <code class="font-mono text-sm min-w-0 flex-1"
+          ><span
+            v-for="(part, i) in getInstallPartsForPM(pm.id)"
+            :key="i"
+            :class="i === 0 ? 'text-fg' : 'text-fg-muted'"
+            >{{ i > 0 ? ' ' : '' }}{{ part }}</span
+          ></code
         >
-          <span class="self-start text-fg-subtle font-mono text-sm select-none shrink-0">$</span>
-          <code class="font-mono text-sm min-w-0"
-            ><span
-              v-for="(part, i) in getInstallPartsForPM(pm.id)"
-              :key="i"
-              :class="i === 0 ? 'text-fg' : 'text-fg-muted'"
-              >{{ i > 0 ? ' ' : '' }}{{ part }}</span
-            ></code
-          >
-          <button
-            type="button"
-            class="px-2 py-0.5 font-mono text-xs text-fg-muted bg-bg-subtle/80 border border-border rounded transition-colors duration-200 opacity-0 group-hover/installcmd:opacity-100 hover:(text-fg border-border-hover) active:scale-95 focus-visible:opacity-100 focus-visible:outline-accent/70 select-none"
-            :aria-label="$t('package.get_started.copy_command')"
-            @click.stop="copyInstallCommand"
-          >
-            <span aria-live="polite">{{ copied ? $t('common.copied') : $t('common.copy') }}</span>
-          </button>
-        </div>
+        <button
+          type="button"
+          class="flex items-center gap-1.5 px-2 py-1 font-mono text-xs text-fg-muted bg-bg-muted border border-border rounded transition-colors hover:(text-fg border-border-hover) active:scale-95 focus-visible:outline-accent/70 select-none shrink-0"
+          :aria-label="$t('package.get_started.copy_command')"
+          @click.stop="copyInstallCommand"
+        >
+          <span class="i-lucide:copy w-3.5 h-3.5" aria-hidden="true" />
+          <span aria-live="polite">{{ copied ? $t('common.copied') : $t('common.copy') }}</span>
+        </button>
+      </div>
+    </div>
 
-        <!-- Suggested dev dependency install command -->
-        <template v-if="devDependencySuggestion.recommended">
-          <div class="flex items-center gap-2 pt-1 select-none">
-            <span class="text-fg-subtle font-mono text-sm"
-              ># {{ $t('package.get_started.dev_dependency_hint') }}</span
-            >
+    <!-- Suggested dev dependency install command -->
+    <template v-if="devDependencySuggestion.recommended">
+      <div
+        v-for="pm in packageManagers"
+        :key="`install-dev-${pm.id}`"
+        :data-pm-cmd="pm.id"
+        class="bg-bg-subtle border border-border rounded-lg overflow-hidden"
+      >
+        <div class="flex gap-1.5 px-3 pt-2 sm:px-4 sm:pt-3">
+          <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
+          <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
+          <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
+        </div>
+        <div class="px-3 pt-2 pb-3 sm:px-4 sm:pt-3 sm:pb-4 overflow-x-auto" dir="ltr">
+          <div class="text-fg-subtle font-mono text-sm select-none pb-1">
+            # {{ $t('package.get_started.dev_dependency_hint') }}
           </div>
-          <div
-            v-for="pm in packageManagers"
-            :key="`install-dev-${pm.id}`"
-            :data-pm-cmd="pm.id"
-            class="flex items-center gap-2 group/devinstallcmd min-w-0"
-          >
+          <div class="flex items-center gap-2 min-w-0">
             <span class="text-fg-subtle font-mono text-sm select-none shrink-0">$</span>
-            <code class="font-mono text-sm min-w-0"
+            <code class="font-mono text-sm min-w-0 flex-1"
               ><span
                 v-for="(part, i) in getDevInstallPartsForPM(pm.id)"
                 :key="i"
@@ -267,65 +275,80 @@ useCommandPaletteContextCommands(
                 >{{ i > 0 ? ' ' : '' }}{{ part }}</span
               ></code
             >
-            <ButtonBase
+            <button
               type="button"
-              size="sm"
-              class="text-fg-muted bg-bg-subtle/80 border-border opacity-0 group-hover/devinstallcmd:opacity-100 active:scale-95 focus-visible:opacity-100 select-none"
+              class="flex items-center gap-1.5 px-2 py-1 font-mono text-xs text-fg-muted bg-bg-muted border border-border rounded transition-colors hover:(text-fg border-border-hover) active:scale-95 focus-visible:outline-accent/70 select-none shrink-0"
               :aria-label="$t('package.get_started.copy_dev_command')"
               @click.stop="copyDevInstallCommand"
             >
+              <span class="i-lucide:copy w-3.5 h-3.5" aria-hidden="true" />
               <span aria-live="polite">{{
                 devInstallCopied ? $t('common.copied') : $t('common.copy')
               }}</span>
-            </ButtonBase>
+            </button>
           </div>
-        </template>
+        </div>
+      </div>
+    </template>
 
-        <!-- @types package install - render all PM variants when types package exists -->
-        <template v-if="typesPackageName && showTypesInInstall">
-          <div
-            v-for="pm in packageManagers"
-            :key="`types-${pm.id}`"
-            :data-pm-cmd="pm.id"
-            class="flex items-center gap-2 min-w-0"
+    <!-- @types package install -->
+    <template v-if="typesPackageName && showTypesInInstall">
+      <div
+        v-for="pm in packageManagers"
+        :key="`types-${pm.id}`"
+        :data-pm-cmd="pm.id"
+        class="bg-bg-subtle border border-border rounded-lg overflow-hidden"
+      >
+        <div class="flex gap-1.5 px-3 pt-2 sm:px-4 sm:pt-3">
+          <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
+          <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
+          <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
+        </div>
+        <div
+          class="flex items-center gap-2 px-3 pt-2 pb-3 sm:px-4 sm:pt-3 sm:pb-4 overflow-x-auto"
+          dir="ltr"
+        >
+          <span class="self-start text-fg-subtle font-mono text-sm select-none shrink-0">$</span>
+          <code class="font-mono text-sm min-w-0 flex-1"
+            ><span
+              v-for="(part, i) in getTypesInstallPartsForPM(pm.id)"
+              :key="i"
+              :class="i === 0 ? 'text-fg' : 'text-fg-muted'"
+              >{{ i > 0 ? ' ' : '' }}{{ part }}</span
+            ></code
           >
+          <NuxtLink
+            :to="packageRoute(typesPackageName!)"
+            class="text-fg-subtle hover:text-fg-muted text-xs transition-colors focus-visible:outline-accent/70 rounded select-none -m-1 p-1 shrink-0"
+            :title="$t('package.get_started.view_types', { package: typesPackageName })"
+          >
+            <span class="i-lucide:arrow-right rtl-flip w-3 h-3 align-middle" aria-hidden="true" />
+            <span class="sr-only">View {{ typesPackageName }}</span>
+          </NuxtLink>
+        </div>
+      </div>
+    </template>
+
+    <!-- Run command (only if package has executables) -->
+    <template v-if="executableInfo?.hasExecutable">
+      <div
+        v-for="pm in packageManagers"
+        :key="`run-${pm.id}`"
+        :data-pm-cmd="pm.id"
+        class="bg-bg-subtle border border-border rounded-lg overflow-hidden"
+      >
+        <div class="flex gap-1.5 px-3 pt-2 sm:px-4 sm:pt-3">
+          <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
+          <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
+          <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
+        </div>
+        <div class="px-3 pt-2 pb-3 sm:px-4 sm:pt-3 sm:pb-4 overflow-x-auto" dir="ltr">
+          <div class="text-fg-subtle font-mono text-sm select-none pb-1" dir="auto">
+            # {{ $t('package.run.locally') }}
+          </div>
+          <div class="flex items-center gap-2">
             <span class="self-start text-fg-subtle font-mono text-sm select-none shrink-0">$</span>
-            <code class="font-mono text-sm min-w-0"
-              ><span
-                v-for="(part, i) in getTypesInstallPartsForPM(pm.id)"
-                :key="i"
-                :class="i === 0 ? 'text-fg' : 'text-fg-muted'"
-                >{{ i > 0 ? ' ' : '' }}{{ part }}</span
-              ></code
-            >
-            <NuxtLink
-              :to="packageRoute(typesPackageName!)"
-              class="text-fg-subtle hover:text-fg-muted text-xs transition-colors focus-visible:outline-accent/70 rounded select-none -m-1 p-1"
-              :title="$t('package.get_started.view_types', { package: typesPackageName })"
-            >
-              <span class="i-lucide:arrow-right rtl-flip w-3 h-3 align-middle" aria-hidden="true" />
-              <span class="sr-only">View {{ typesPackageName }}</span>
-            </NuxtLink>
-          </div>
-        </template>
-
-        <!-- Run command (only if package has executables) - render all PM variants -->
-        <template v-if="executableInfo?.hasExecutable">
-          <!-- Comment line -->
-          <div class="flex items-center gap-2 pt-1" dir="auto">
-            <span class="text-fg-subtle font-mono text-sm select-none"
-              ># {{ $t('package.run.locally') }}</span
-            >
-          </div>
-
-          <div
-            v-for="pm in packageManagers"
-            :key="`run-${pm.id}`"
-            :data-pm-cmd="pm.id"
-            class="flex items-center gap-2 group/runcmd"
-          >
-            <span class="self-start text-fg-subtle font-mono text-sm select-none">$</span>
-            <code class="font-mono text-sm"
+            <code class="font-mono text-sm flex-1"
               ><span
                 v-for="(part, i) in getRunPartsForPM(pm.id, executableInfo?.primaryCommand)"
                 :key="i"
@@ -335,18 +358,32 @@ useCommandPaletteContextCommands(
             >
             <button
               type="button"
-              class="px-2 py-0.5 font-mono text-xs text-fg-muted bg-bg-subtle/80 border border-border rounded transition-colors duration-200 opacity-0 group-hover/runcmd:opacity-100 hover:(text-fg border-border-hover) active:scale-95 focus-visible:opacity-100 focus-visible:outline-accent/70 select-none"
+              class="flex items-center gap-1.5 px-2 py-1 font-mono text-xs text-fg-muted bg-bg-muted border border-border rounded transition-colors hover:(text-fg border-border-hover) active:scale-95 focus-visible:outline-accent/70 select-none shrink-0"
               @click.stop="copyRunCommand(executableInfo?.primaryCommand)"
             >
+              <span class="i-lucide:copy w-3.5 h-3.5" aria-hidden="true" />
               {{ runCopied ? $t('common.copied') : $t('common.copy') }}
             </button>
           </div>
-        </template>
+        </div>
+      </div>
+    </template>
 
-        <!-- Create command (for packages with associated create-* package) - render all PM variants -->
-        <template v-if="createPackageInfo">
-          <!-- Comment line -->
-          <div class="flex items-center gap-2 pt-1 select-none" dir="auto">
+    <!-- Create command (for packages with associated create-* package) -->
+    <template v-if="createPackageInfo">
+      <div
+        v-for="pm in packageManagers"
+        :key="`create-${pm.id}`"
+        :data-pm-cmd="pm.id"
+        class="bg-bg-subtle border border-border rounded-lg overflow-hidden"
+      >
+        <div class="flex gap-1.5 px-3 pt-2 sm:px-4 sm:pt-3">
+          <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
+          <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
+          <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
+        </div>
+        <div class="px-3 pt-2 pb-3 sm:px-4 sm:pt-3 sm:pb-4 overflow-x-auto" dir="ltr">
+          <div class="flex items-center gap-2 pb-1 select-none" dir="auto">
             <span class="text-fg-subtle font-mono text-sm"># {{ $t('package.create.title') }}</span>
             <TooltipApp
               :text="$t('package.create.view', { packageName: createPackageInfo.packageName })"
@@ -362,15 +399,9 @@ useCommandPaletteContextCommands(
               </NuxtLink>
             </TooltipApp>
           </div>
-
-          <div
-            v-for="pm in packageManagers"
-            :key="`create-${pm.id}`"
-            :data-pm-cmd="pm.id"
-            class="flex items-center gap-2 group/createcmd"
-          >
-            <span class="self-start text-fg-subtle font-mono text-sm select-none">$</span>
-            <code class="font-mono text-sm"
+          <div class="flex items-center gap-2">
+            <span class="self-start text-fg-subtle font-mono text-sm select-none shrink-0">$</span>
+            <code class="font-mono text-sm flex-1"
               ><span
                 v-for="(part, i) in getCreatePartsForPM(pm.id)"
                 :key="i"
@@ -380,18 +411,19 @@ useCommandPaletteContextCommands(
             >
             <button
               type="button"
-              class="px-2 py-0.5 font-mono text-xs text-fg-muted bg-bg-subtle/80 border border-border rounded transition-colors duration-200 opacity-0 group-hover/createcmd:opacity-100 hover:(text-fg border-border-hover) active:scale-95 focus-visible:opacity-100 focus-visible:outline-accent/70 select-none"
+              class="flex items-center gap-1.5 px-2 py-1 font-mono text-xs text-fg-muted bg-bg-muted border border-border rounded transition-colors hover:(text-fg border-border-hover) active:scale-95 focus-visible:outline-accent/70 select-none shrink-0"
               :aria-label="$t('package.create.copy_command')"
               @click.stop="copyCreateCommand"
             >
+              <span class="i-lucide:copy w-3.5 h-3.5" aria-hidden="true" />
               <span aria-live="polite">{{
                 createCopied ? $t('common.copied') : $t('common.copy')
               }}</span>
             </button>
           </div>
-        </template>
+        </div>
       </div>
-    </div>
+    </template>
   </div>
 </template>
 
@@ -414,7 +446,7 @@ useCommandPaletteContextCommands(
 :root[data-pm='deno'] [data-pm-cmd='deno'],
 :root[data-pm='vlt'] [data-pm-cmd='vlt'],
 :root[data-pm='vp'] [data-pm-cmd='vp'] {
-  display: flex;
+  display: block;
 }
 
 /* Fallback: when no data-pm is set (SSR initial), show npm as default */

--- a/app/components/Terminal/Install.vue
+++ b/app/components/Terminal/Install.vue
@@ -224,6 +224,7 @@ useCommandPaletteContextCommands(
         <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
       </div>
       <div
+        data-testid="install-cmd"
         class="flex items-center gap-2 px-3 pt-2 pb-3 sm:px-4 sm:pt-3 sm:pb-4 overflow-x-auto"
         dir="ltr"
       >
@@ -238,7 +239,7 @@ useCommandPaletteContextCommands(
         >
         <button
           type="button"
-          class="flex items-center gap-1.5 px-2 py-1 font-mono text-xs text-fg-muted bg-bg-muted border border-border rounded transition-colors hover:(text-fg border-border-hover) active:scale-95 focus-visible:outline-accent/70 select-none shrink-0"
+          class="flex items-center gap-1.5 px-2 py-1 font-mono text-xs text-fg-muted bg-bg-muted border border-border rounded transition-colors hover:(text-fg border-border-hover) active:scale-95 select-none shrink-0"
           :aria-label="$t('package.get_started.copy_command')"
           @click.stop="copyInstallCommand"
         >
@@ -277,7 +278,7 @@ useCommandPaletteContextCommands(
             >
             <button
               type="button"
-              class="flex items-center gap-1.5 px-2 py-1 font-mono text-xs text-fg-muted bg-bg-muted border border-border rounded transition-colors hover:(text-fg border-border-hover) active:scale-95 focus-visible:outline-accent/70 select-none shrink-0"
+              class="flex items-center gap-1.5 px-2 py-1 font-mono text-xs text-fg-muted bg-bg-muted border border-border rounded transition-colors hover:(text-fg border-border-hover) active:scale-95 select-none shrink-0"
               :aria-label="$t('package.get_started.copy_dev_command')"
               @click.stop="copyDevInstallCommand"
             >
@@ -358,7 +359,7 @@ useCommandPaletteContextCommands(
             >
             <button
               type="button"
-              class="flex items-center gap-1.5 px-2 py-1 font-mono text-xs text-fg-muted bg-bg-muted border border-border rounded transition-colors hover:(text-fg border-border-hover) active:scale-95 focus-visible:outline-accent/70 select-none shrink-0"
+              class="flex items-center gap-1.5 px-2 py-1 font-mono text-xs text-fg-muted bg-bg-muted border border-border rounded transition-colors hover:(text-fg border-border-hover) active:scale-95 select-none shrink-0"
               @click.stop="copyRunCommand(executableInfo?.primaryCommand)"
             >
               <span class="i-lucide:copy w-3.5 h-3.5" aria-hidden="true" />
@@ -399,7 +400,7 @@ useCommandPaletteContextCommands(
               </NuxtLink>
             </TooltipApp>
           </div>
-          <div class="flex items-center gap-2">
+          <div data-testid="create-cmd" class="flex items-center gap-2">
             <span class="self-start text-fg-subtle font-mono text-sm select-none shrink-0">$</span>
             <code class="font-mono text-sm flex-1"
               ><span
@@ -411,7 +412,7 @@ useCommandPaletteContextCommands(
             >
             <button
               type="button"
-              class="flex items-center gap-1.5 px-2 py-1 font-mono text-xs text-fg-muted bg-bg-muted border border-border rounded transition-colors hover:(text-fg border-border-hover) active:scale-95 focus-visible:outline-accent/70 select-none shrink-0"
+              class="flex items-center gap-1.5 px-2 py-1 font-mono text-xs text-fg-muted bg-bg-muted border border-border rounded transition-colors hover:(text-fg border-border-hover) active:scale-95 select-none shrink-0"
               :aria-label="$t('package.create.copy_command')"
               @click.stop="copyCreateCommand"
             >

--- a/test/e2e/create-command.spec.ts
+++ b/test/e2e/create-command.spec.ts
@@ -7,7 +7,7 @@ test.describe('Create Command', () => {
 
       // Create command section should be visible (SSR)
       // Use specific container to avoid matching README code blocks
-      const createCommandSection = page.locator('.group\\/createcmd').first()
+      const createCommandSection = page.locator('[data-testid="create-cmd"]').first()
       await expect(createCommandSection).toBeVisible()
       await expect(createCommandSection.locator('code')).toContainText(/create vite/i)
 
@@ -23,7 +23,7 @@ test.describe('Create Command', () => {
 
       // Create command section should be visible (SSR)
       // Use specific container to avoid matching README code blocks
-      const createCommandSection = page.locator('.group\\/createcmd').first()
+      const createCommandSection = page.locator('[data-testid="create-cmd"]').first()
       await expect(createCommandSection).toBeVisible()
       await expect(createCommandSection.locator('code')).toContainText(/create next-app/i)
 
@@ -40,7 +40,7 @@ test.describe('Create Command', () => {
       // Create command section should be visible (SSR)
       // nuxt has create-nuxt package, so command is "npm create nuxt"
       // Use specific container to avoid matching README code blocks
-      const createCommandSection = page.locator('.group\\/createcmd').first()
+      const createCommandSection = page.locator('[data-testid="create-cmd"]').first()
       await expect(createCommandSection).toBeVisible()
       await expect(createCommandSection.locator('code')).toContainText(/create nuxt/i)
     })
@@ -56,27 +56,22 @@ test.describe('Create Command', () => {
 
       // Create command section should NOT be visible (no create-is-odd exists)
       // Use .first() for consistency, though none should exist
-      const createCommandSection = page.locator('.group\\/createcmd').first()
+      const createCommandSection = page.locator('[data-testid="create-cmd"]').first()
       await expect(createCommandSection).not.toBeVisible()
     })
   })
 
   test.describe('Install Command Copy', () => {
-    test('hovering install command shows copy button', async ({ page, goto }) => {
+    test('copy button is always visible on install command', async ({ page, goto }) => {
       await goto('/package/is-odd', { waitUntil: 'hydration' })
 
       // Find the install command container
-      const installCommandContainer = page.locator('.group\\/installcmd').first()
+      const installCommandContainer = page.locator('[data-testid="install-cmd"]').first()
       await expect(installCommandContainer).toBeVisible()
 
-      // Copy button should initially be hidden
+      // Copy button should always be visible (no hover required)
       const copyButton = installCommandContainer.locator('button')
-      await expect(copyButton).toHaveCSS('opacity', '0')
-
-      // Hover over the container
-      await installCommandContainer.hover()
-
-      // Copy button should become visible
+      await expect(copyButton).toBeVisible()
       await expect(copyButton).toHaveCSS('opacity', '1')
     })
 
@@ -90,11 +85,8 @@ test.describe('Create Command', () => {
 
       await goto('/package/is-odd', { waitUntil: 'hydration' })
 
-      // Find and hover over the install command container
-      const installCommandContainer = page.locator('.group\\/installcmd').first()
-      await installCommandContainer.hover()
-
-      // Click the copy button
+      // Find the install command container and click copy directly (no hover needed)
+      const installCommandContainer = page.locator('[data-testid="install-cmd"]').first()
       const copyButton = installCommandContainer.locator('button')
       await copyButton.click()
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

The GET STARTED section showed all commands grouped inside a single shared terminal block. This made it harder to copy individual commands and the copy button was only visible on hover.

### 📚 Description

- Each command (install, dev install, @types, run, create) is now wrapped in its own independent terminal card with the three-dot header and the same dark border/rounded style as the original container
- The copy button is now always visible (removed `opacity-0` / `group-hover` pattern) and includes the `i-lucide:copy` icon alongside the "Copy" label
- Updated the CSS selector from `display: flex` to `display: block` for `[data-pm-cmd]` elements since each card is now a block container, with the inner row using flex

### 📚 Screenshots
<img width="821" height="330" alt="Screenshot 2026-05-31 at 8 33 39 PM" src="https://github.com/user-attachments/assets/7efe187e-713d-4852-ad66-d64a257a128d" />
