### PR TITLE
chore: minor ui improvements

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -258,7 +258,7 @@ useShortcuts({
       <ButtonBase
         type="button"
         variant="secondary"
-        class="hidden lg:inline-flex shrink-0 gap-2 px-2.5 me-3"
+        class="hidden lg:inline-flex shrink-0 gap-2 ps-2.5 pe-1.25 py-1.25! me-3"
         :aria-label="$t('shortcuts.command_palette')"
         :title="$t('shortcuts.command_palette_description', { ctrlKey: $t('shortcuts.ctrl_key') })"
         @click="openCommandPalette"

--- a/app/components/Noodle/Pride1/Logo.vue
+++ b/app/components/Noodle/Pride1/Logo.vue
@@ -5,7 +5,7 @@
     </template>
     <img
       width="400"
-      class="mb-6 w-80 sm:w-140 max-w-full"
+      class="mb-6 w-80 sm:w-140 max-w-full mx-auto"
       src="/extra/pride-1.svg"
       :alt="$t('alt_logo')"
     />

--- a/app/pages/package-timeline/[[org]]/[packageName].vue
+++ b/app/pages/package-timeline/[[org]]/[packageName].vue
@@ -347,7 +347,7 @@ useSeoMeta({
       page="timeline"
     />
 
-    <div class="sticky top-24 z-1 bg-bg mt-8">
+    <div class="[@media(min-height:1024px)]:sticky top-24 z-1 bg-bg mt-8">
       <div class="container w-full">
         <div class="mx-auto">
           <PackageTimelineChart


### PR DESCRIPTION
### 🧭 Context

A few minor fixes:

1. Fixing the noodle on mobile devices to center it (main one)
1. Fixing the size of the "jump to" button to align with the search field
1. Improving the timeline chart sticky note to stay at the top on narrow screens (otherwise it takes up half the screen)