### PR TITLE
fix: update colors when prefers-color-scheme changes

### DIFF
--- a/app/composables/useColors.ts
+++ b/app/composables/useColors.ts
@@ -1,5 +1,18 @@
-import { computed, shallowRef, type ComputedRef, type Ref, type ShallowRef, unref } from 'vue'
-import { useMutationObserver, useResizeObserver, useSupported } from '@vueuse/core'
+import {
+  computed,
+  shallowRef,
+  type ComputedRef,
+  type Ref,
+  type ShallowRef,
+  unref,
+  watch,
+} from 'vue'
+import {
+  useMutationObserver,
+  useResizeObserver,
+  useSupported,
+  usePreferredDark,
+} from '@vueuse/core'
 
 type CssVariableSource = HTMLElement | null | undefined | Ref<HTMLElement | null | undefined>
 
@@ -36,6 +49,8 @@ export function useColors(
   options: { watchHtmlAttributes?: boolean; watchResize?: boolean } = {},
 ): { colors: ComputedRef<Record<string, string>> } {
   const recomputeToken = shallowRef(0)
+  const isPreferredDark = usePreferredDark()
+
   const invalidateColors = () => {
     recomputeToken.value += 1
   }
@@ -43,6 +58,8 @@ export function useColors(
   const isClientSupported = useSupported(
     () => typeof window !== 'undefined' && typeof document !== 'undefined',
   )
+
+  watch(isPreferredDark, invalidateColors)
 
   const colors = computed<Record<string, string>>(() => {
     void recomputeToken.value

--- a/test/unit/app/composables/use-colors.spec.ts
+++ b/test/unit/app/composables/use-colors.spec.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { computed, shallowRef } from 'vue'
+import { computed, nextTick, shallowRef, ref, type Ref } from 'vue'
 import { useColors } from '~/composables/useColors'
 
 const useSupportedMock = vi.hoisted(() => vi.fn())
 const useMutationObserverMock = vi.hoisted(() => vi.fn())
 const useResizeObserverMock = vi.hoisted(() => vi.fn())
 
+const vueUseMockState = vi.hoisted(() => ({
+  preferredDark: undefined as unknown as Ref<boolean>,
+}))
+
 vi.mock('@vueuse/core', () => {
+  vueUseMockState.preferredDark = ref(false)
+
   return {
     useSupported: (callback: () => boolean) => {
       useSupportedMock(callback)
@@ -14,12 +20,14 @@ vi.mock('@vueuse/core', () => {
     },
     useMutationObserver: useMutationObserverMock,
     useResizeObserver: useResizeObserverMock,
+    usePreferredDark: () => vueUseMockState.preferredDark,
   }
 })
 
 describe('useColors', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vueUseMockState.preferredDark.value = false
   })
 
   afterEach(() => {
@@ -56,5 +64,78 @@ describe('useColors', () => {
     const elementReference = shallowRef<HTMLElement | null>(null)
     const { colors } = useColors(elementReference)
     expect(colors.value).toEqual({})
+  })
+
+  it('recomputes colors when preferred dark mode changes', async () => {
+    const styleValues = {
+      accent: '#FF0000',
+    }
+
+    vi.stubGlobal('window', {})
+    vi.stubGlobal('document', {
+      documentElement: {},
+    })
+
+    vi.stubGlobal('getComputedStyle', () => ({
+      getPropertyValue: (variableName: string) => {
+        if (variableName === '--accent') {
+          return styleValues.accent
+        }
+
+        return ''
+      },
+    }))
+
+    const elementReference = shallowRef<HTMLElement | null>({} as HTMLElement)
+    const { colors } = useColors(elementReference)
+    expect(colors.value.accent).toBe('#FF0000')
+    styleValues.accent = '#00FF00'
+    vueUseMockState.preferredDark.value = true
+    await nextTick()
+
+    expect(colors.value.accent).toBe('#00FF00')
+  })
+
+  it('attaches an html mutation observer when enabled', () => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal('document', {
+      documentElement: {},
+    })
+    const elementReference = shallowRef<HTMLElement | null>(null)
+    useColors(elementReference, {
+      watchHtmlAttributes: true,
+    })
+    expect(useMutationObserverMock).toHaveBeenCalledTimes(1)
+    expect(useMutationObserverMock).toHaveBeenCalledWith(
+      document.documentElement,
+      expect.any(Function),
+      {
+        attributes: true,
+        attributeFilter: ['class', 'style', 'data-theme', 'data-bg-theme'],
+      },
+    )
+  })
+
+  it('falls back to document element when no element is provided', () => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal('document', {
+      documentElement: {},
+    })
+    vi.stubGlobal('getComputedStyle', (element: HTMLElement) => {
+      expect(element).toBe(document.documentElement)
+
+      return {
+        getPropertyValue: (variableName: string) => {
+          if (variableName === '--accent') {
+            return 'red'
+          }
+
+          return ''
+        },
+      }
+    })
+    const elementReference = shallowRef<HTMLElement | null>(null)
+    const { colors } = useColors(elementReference)
+    expect(colors.value.accent).toBe('red')
   })
 })


### PR DESCRIPTION
Resolves #2819

This fixes the `useColors` composable to make it reactive to changes made to `prefers-color-scheme` on the fly, when the theme is set to 'system'.

Also updated the test for the composable.

To test:
- open a page with a chart (chart modal, timeline, compare page...)
- change the prefers-color-theme from the dev tools
- the chart colors update dynamically