### PR TITLE
fix(ui): render Geist consistently across Firefox and Chrome

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -273,6 +273,9 @@ export default defineNuxtConfig({
     providers: {
       fontshare: false,
     },
+    experimental: {
+      disableLocalFallbacks: true,
+    },
     families: [
       {
         name: 'Geist',


### PR DESCRIPTION
### 🔗 Linked issue

resolves #2841

### 🧭 Context

Firefox on macOS renders the site's header text (logo, nav, "jump to..." button) noticeably thinner than Chrome. Reproducible on any machine with Geist or Geist Mono installed in `~/Library/Fonts/`, which is pretty common since Vercel ships them with their dev tools.

The cause is the `local()` fallbacks in the auto-generated `@font-face` rules:

    src: local("Geist Mono Regular"), local("Geist Mono"), url("/fonts/GeistMono-Regular.ttf") format(truetype);

Chrome 86+ ignores `local()` for user-installed fonts as an anti-fingerprinting measure, so it falls through to the bundled TTF. Firefox honours it and picks up the local OTF. Same Geist family, but the OTF (CFF outlines) and TTF (TrueType outlines) rasterize differently in Firefox on macOS, and the OTF ends up lighter. Identical CSS, two different fonts actually rendered.

### 📚 Description

Sets `fonts.experimental.disableLocalFallbacks: true` in `nuxt.config.ts`. With it on, `@nuxt/fonts` stops emitting `local(...)` in the generated `nuxt-fonts-global.css`, so both browsers always load the bundled TTFs from `public/fonts/`.

Verified by checking the generated CSS no longer contains `local(...)` entries and that Firefox now matches Chrome after a hard reload.

**Before ( macos w/ firefox ) - npmx.dev**
<img width="1539" height="833" alt="Screenshot 2026-06-02 at 23 40 00" src="https://github.com/user-attachments/assets/33bc76e6-bd14-4ff0-b5d0-fb02b94764a7" />

**After ( macos w/ firefox ) - localhost**
<img width="1534" height="822" alt="Screenshot 2026-06-02 at 23 39 56" src="https://github.com/user-attachments/assets/ed1d5378-cdd5-4813-9b29-70fceacfb4f4" />
