### PR TITLE
feat: versions page improvements

### DIFF
--- a/app/pages/package/[[org]]/[name]/versions.vue
+++ b/app/pages/package/[[org]]/[name]/versions.vue
@@ -269,7 +269,7 @@ const flatItems = computed<FlatItem[]>(() => {
   <main class="flex-1 flex flex-col">
     <!-- Header -->
     <header class="border-b border-border bg-bg sticky top-14 z-20">
-      <div class="container py-3 flex items-center justify-between gap-4">
+      <div class="container py-3 flex items-center justify-between gap-2 sm:gap-4">
         <div class="flex items-center gap-2 min-w-0">
           <NuxtLink
             :to="packageRoute(packageName)"
@@ -297,7 +297,7 @@ const flatItems = computed<FlatItem[]>(() => {
         <!-- Latest — featured card -->
         <div
           v-if="latestTagRow"
-          class="border-y sm:rounded-lg sm:border border-accent/40 bg-accent/5 px-4 py-4 relative flex max-sm:flex-col sm:items-center justify-between gap-4 hover:bg-accent/8 transition-colors"
+          class="border-y sm:rounded-lg sm:border border-accent/40 bg-accent/5 px-4 py-4 relative flex max-sm:flex-col sm:items-center justify-between gap-2 sm:gap-4 hover:bg-accent/8 transition-colors"
         >
           <!-- Left: tags + version + deprecated -->
           <div>
@@ -312,10 +312,14 @@ const flatItems = computed<FlatItem[]>(() => {
               >
               <span
                 v-if="fullVersionMap?.get(latestTagRow!.version)?.deprecated"
-                class="text-xs font-medium text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded"
+                class="text-xs font-medium text-red-700 dark:text-red-400 relative z-10"
                 :title="fullVersionMap!.get(latestTagRow!.version)!.deprecated"
-                >deprecated</span
               >
+                <span class="sm:hidden i-lucide:octagon-alert" aria-hidden="true"></span>
+                <span class="max-sm:sr-only bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded"
+                  >deprecated</span
+                >
+              </span>
             </div>
             <div class="flex items-center gap-2">
               <LinkBase
@@ -336,7 +340,7 @@ const flatItems = computed<FlatItem[]>(() => {
             </div>
           </div>
           <!-- Right: downloads + date -->
-          <div class="flex sm:items-center gap-4 shrink-0 relative z-10">
+          <div class="flex sm:items-center gap-2 sm:gap-4 shrink-0 relative z-10">
             <span
               v-if="getVersionDownloads(latestTagRow!.version)"
               class="max-w-32 md:w-32 grid grid-flow-col auto-cols-max items-center gap-1 text-xs text-fg-muted tabular-nums sm:justify-end"
@@ -376,10 +380,10 @@ const flatItems = computed<FlatItem[]>(() => {
           <div
             v-for="row in otherTagRows"
             :key="row.id"
-            class="flex items-center gap-4 px-4 py-2.5 border-b border-border last:border-0 hover:bg-bg-subtle transition-colors relative"
+            class="flex items-center gap-2 sm:gap-4 px-4 py-2.5 border-b border-border last:border-0 hover:bg-bg-subtle transition-colors relative"
           >
             <!-- Tag labels -->
-            <div class="max-w-32 md:w-32 shrink-0 flex flex-wrap gap-x-1.5 gap-y-0.5">
+            <div class="max-w-[max(32px,32vw)] md:w-32 shrink-0 flex flex-wrap gap-x-1.5 gap-y-0.5">
               <span
                 v-for="tag in row.tags"
                 :key="tag"
@@ -390,10 +394,10 @@ const flatItems = computed<FlatItem[]>(() => {
             </div>
 
             <!-- Version + Provenance + Deprecated -->
-            <div class="flex-1 min-w-0 flex items-center gap-2 truncate overflow-hidden">
+            <div class="flex-1 flex items-center gap-2">
               <LinkBase
                 :to="packageRoute(packageName, row.version)"
-                class="block! text-sm after:absolute after:inset-0 after:content-[''] truncate"
+                class="block! min-w-16 max-sm:max-w-40 text-sm after:absolute after:inset-0 after:content-[''] truncate"
                 :title="row.version"
                 dir="ltr"
               >
@@ -409,10 +413,14 @@ const flatItems = computed<FlatItem[]>(() => {
               />
               <span
                 v-if="fullVersionMap?.get(row.version)?.deprecated"
-                class="text-xs font-medium text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded relative z-10"
+                class="text-xs font-medium text-red-700 dark:text-red-400 relative z-10"
                 :title="fullVersionMap!.get(row.version)!.deprecated"
-                >deprecated</span
               >
+                <span class="sm:hidden i-lucide:octagon-alert" aria-hidden="true"></span>
+                <span class="max-sm:sr-only bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded"
+                  >deprecated</span
+                >
+              </span>
             </div>
 
             <!-- Downloads -->
@@ -445,7 +453,7 @@ const flatItems = computed<FlatItem[]>(() => {
 
       <!-- ── Version History ───────────────────────────────────────────────── -->
       <section v-if="versionGroups.length > 0">
-        <div class="flex items-center justify-between gap-2 mb-3">
+        <div class="flex max-sm:flex-col sm:items-center justify-between gap-2 mb-3">
           <h2 class="text-sm text-fg-subtle uppercase">
             {{ $t('package.versions.page_title') }}
             <span class="ms-1 normal-case font-normal"> ({{ versionStrings.length }}) </span>
@@ -461,7 +469,7 @@ const flatItems = computed<FlatItem[]>(() => {
               :aria-describedby="isInvalidRange ? 'version-filter-error' : undefined"
               autocomplete="off"
               size="sm"
-              class="w-36 sm:w-64"
+              class="w-36 sm:w-64 max-sm:w-full"
               :class="isInvalidRange ? 'pe-7 !border-red-500' : ''"
             />
             <Transition
@@ -534,9 +542,14 @@ const flatItems = computed<FlatItem[]>(() => {
                     <span class="text-sm font-medium">{{ item.label }}</span>
                     <span
                       v-if="deprecatedGroupKeys.has(item.groupKey)"
-                      class="text-xs font-medium text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded"
-                      >deprecated</span
+                      class="text-xs font-medium text-red-700 dark:text-red-400 relative z-10"
                     >
+                      <span class="sm:hidden i-lucide:octagon-alert" aria-hidden="true"></span>
+                      <span
+                        class="max-sm:sr-only bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded"
+                        >deprecated</span
+                      >
+                    </span>
                     <span class="text-xs text-fg-subtle">({{ item.versions.length }})</span>
                     <span class="text-xs text-fg-muted truncate" :title="item.versions[0]" dir="ltr"
                       >v{{ item.versions[0] }}</span
@@ -628,10 +641,14 @@ const flatItems = computed<FlatItem[]>(() => {
                         </div>
                         <span
                           v-if="fullVersionMap?.get(item.version)?.deprecated"
-                          class="text-xs font-medium text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded relative z-10"
+                          class="text-xs font-medium text-red-700 dark:text-red-400 relative z-10"
                           :title="fullVersionMap.get(item.version)!.deprecated"
                         >
-                          deprecated
+                          <span class="sm:hidden i-lucide:octagon-alert" aria-hidden="true"></span>
+                          <span
+                            class="max-sm:sr-only bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded"
+                            >deprecated</span
+                          >
                         </span>
                       </div>
 

--- a/app/pages/package/[[org]]/[name]/versions.vue
+++ b/app/pages/package/[[org]]/[name]/versions.vue
@@ -324,7 +324,7 @@ const flatItems = computed<FlatItem[]>(() => {
     <div class="container w-full py-8 space-y-8">
       <!-- ── Current Tags ───────────────────────────────────────────────────── -->
       <section class="space-y-3">
-        <h2 class="text-fg-subtle uppercase">
+        <h2 class="text-sm text-fg-subtle uppercase">
           {{ $t('package.versions.current_tags') }}
         </h2>
 
@@ -373,7 +373,7 @@ const flatItems = computed<FlatItem[]>(() => {
           <div class="flex sm:items-center gap-4 shrink-0 relative z-10">
             <span
               v-if="getVersionDownloads(latestTagRow!.version)"
-              class="w-32 grid grid-flow-col auto-cols-max items-center gap-1 text-xs text-fg-muted tabular-nums sm:justify-end"
+              class="max-w-32 md:w-32 grid grid-flow-col auto-cols-max items-center gap-1 text-xs text-fg-muted tabular-nums sm:justify-end"
               :aria-label="
                 getDownloadsAriaLabel(
                   getVersionDownloads(latestTagRow!.version)!,
@@ -413,7 +413,7 @@ const flatItems = computed<FlatItem[]>(() => {
             class="flex items-center gap-4 px-4 py-2.5 border-b border-border last:border-0 hover:bg-bg-subtle transition-colors relative"
           >
             <!-- Tag labels -->
-            <div class="w-32 shrink-0 flex flex-wrap gap-x-1.5 gap-y-0.5">
+            <div class="max-w-32 md:w-32 shrink-0 flex flex-wrap gap-x-1.5 gap-y-0.5">
               <span
                 v-for="tag in row.tags"
                 :key="tag"
@@ -424,10 +424,10 @@ const flatItems = computed<FlatItem[]>(() => {
             </div>
 
             <!-- Version + Provenance + Deprecated -->
-            <div class="flex-1 min-w-0 flex items-center gap-2">
+            <div class="flex-1 min-w-0 flex items-center gap-2 truncate overflow-hidden">
               <LinkBase
                 :to="packageRoute(packageName, row.version)"
-                class="text-sm after:absolute after:inset-0 after:content-['']"
+                class="block! text-sm after:absolute after:inset-0 after:content-[''] truncate"
                 :title="row.version"
                 dir="ltr"
               >
@@ -452,7 +452,7 @@ const flatItems = computed<FlatItem[]>(() => {
             <!-- Downloads -->
             <span
               v-if="getVersionDownloads(row.version)"
-              class="w-32 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0 relative z-10"
+              class="max-w-32 md:w-32 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0 relative z-10"
               :aria-label="getDownloadsAriaLabel(getVersionDownloads(row.version)!, row.version)"
               dir="ltr"
               :title="getDownloadsAriaLabel(getVersionDownloads(row.version)!, row.version)"
@@ -460,7 +460,7 @@ const flatItems = computed<FlatItem[]>(() => {
               <span>{{ numberFormatter.format(getVersionDownloads(row.version)!) }}</span>
               <span class="i-lucide:chart-line" aria-hidden="true"></span>
             </span>
-            <span v-else class="w-32 shrink-0" />
+            <span v-else class="max-w-32 md:w-32 shrink-0" />
 
             <!-- Date -->
             <div class="flex items-center gap-2 shrink-0 relative z-10">
@@ -479,7 +479,7 @@ const flatItems = computed<FlatItem[]>(() => {
 
       <!-- ── Version History ───────────────────────────────────────────────── -->
       <section v-if="versionGroups.length > 0">
-        <h2 class="text-fg-subtle uppercase mb-3">
+        <h2 class="text-sm text-fg-subtle uppercase mb-3">
           {{ $t('package.versions.page_title') }}
           <span class="ms-1 normal-case font-normal"> ({{ versionStrings.length }}) </span>
         </h2>
@@ -535,12 +535,12 @@ const flatItems = computed<FlatItem[]>(() => {
                       >deprecated</span
                     >
                     <span class="text-xs text-fg-subtle">({{ item.versions.length }})</span>
-                    <span class="text-xs text-fg-muted" :title="item.versions[0]" dir="ltr"
+                    <span class="text-xs text-fg-muted truncate" :title="item.versions[0]" dir="ltr"
                       >v{{ item.versions[0] }}</span
                     >
                     <span
                       v-if="groupDownloadsMap.has(item.groupKey)"
-                      class="ms-auto w-32 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0"
+                      class="ms-auto max-w-32 md:w-32 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0"
                       :aria-label="
                         getDownloadsAriaLabel(groupDownloadsMap.get(item.groupKey)!, item.label)
                       "
@@ -554,7 +554,7 @@ const flatItems = computed<FlatItem[]>(() => {
                       }}</span>
                       <span class="i-lucide:chart-line" aria-hidden="true"></span>
                     </span>
-                    <span v-else class="ms-auto w-32 shrink-0" />
+                    <span v-else class="ms-auto max-w-32 md:w-32 shrink-0" />
                     <span class="flex items-center gap-3 shrink-0">
                       <DateTime
                         v-if="getVersionTime(item.versions[0]!)"
@@ -635,7 +635,7 @@ const flatItems = computed<FlatItem[]>(() => {
                       <!-- Downloads -->
                       <span
                         v-if="getVersionDownloads(item.version)"
-                        class="w-32 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0 relative z-10"
+                        class="max-w-32 md:w-32 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0 relative z-10"
                         :aria-label="
                           getDownloadsAriaLabel(getVersionDownloads(item.version)!, item.version)
                         "
@@ -649,7 +649,7 @@ const flatItems = computed<FlatItem[]>(() => {
                         }}</span>
                         <span class="i-lucide:chart-line" aria-hidden="true"></span>
                       </span>
-                      <span v-else class="w-32 shrink-0" />
+                      <span v-else class="max-w-32 md:w-32 shrink-0" />
 
                       <!-- Date -->
                       <div class="flex items-center gap-2 shrink-0 relative z-10">
@@ -688,7 +688,7 @@ const flatItems = computed<FlatItem[]>(() => {
                   >
                   <span
                     v-if="groupDownloadsMap.has(item.groupKey)"
-                    class="ms-auto w-32 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0"
+                    class="ms-auto max-w-32 md:w-32 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0"
                     :aria-label="
                       getDownloadsAriaLabel(groupDownloadsMap.get(item.groupKey)!, item.label)
                     "
@@ -700,7 +700,7 @@ const flatItems = computed<FlatItem[]>(() => {
                     <span>{{ numberFormatter.format(groupDownloadsMap.get(item.groupKey)!) }}</span>
                     <span class="i-lucide:chart-line" aria-hidden="true"></span>
                   </span>
-                  <span v-else class="ms-auto w-32 shrink-0" />
+                  <span v-else class="ms-auto max-w-32 md:w-32 shrink-0" />
                   <span class="flex items-center gap-3 shrink-0">
                     <DateTime
                       v-if="getVersionTime(item.versions[0] ?? '')"

--- a/app/pages/package/[[org]]/[name]/versions.vue
+++ b/app/pages/package/[[org]]/[name]/versions.vue
@@ -324,7 +324,7 @@ const flatItems = computed<FlatItem[]>(() => {
     <div class="container w-full py-8 space-y-8">
       <!-- ── Current Tags ───────────────────────────────────────────────────── -->
       <section class="space-y-3">
-        <h2 class="text-xs text-fg-subtle uppercase tracking-wider px-4 sm:px-6 ps-1">
+        <h2 class="text-fg-subtle uppercase">
           {{ $t('package.versions.current_tags') }}
         </h2>
 
@@ -336,17 +336,17 @@ const flatItems = computed<FlatItem[]>(() => {
           <!-- Left: tags + version + deprecated -->
           <div>
             <div class="flex items-center gap-2 mb-1.5 flex-wrap">
-              <span class="text-3xs font-bold uppercase tracking-widest text-accent">latest</span>
+              <span class="text-xs font-bold uppercase tracking-wider text-accent">latest</span>
               <span
                 v-for="tag in latestTagRow!.tags.filter(t => t !== 'latest')"
                 :key="tag"
-                class="text-3xs font-semibold uppercase tracking-wide text-fg-subtle"
+                class="text-xs font-semibold uppercase tracking-wider text-fg-subtle"
                 :title="tag"
                 >{{ tag }}</span
               >
               <span
                 v-if="fullVersionMap?.get(latestTagRow!.version)?.deprecated"
-                class="text-3xs font-medium text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded"
+                class="text-xs font-medium text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded"
                 :title="fullVersionMap!.get(latestTagRow!.version)!.deprecated"
                 >deprecated</span
               >
@@ -373,7 +373,7 @@ const flatItems = computed<FlatItem[]>(() => {
           <div class="flex items-center gap-4 shrink-0 relative z-10">
             <span
               v-if="getVersionDownloads(latestTagRow!.version)"
-              class="w-28 grid grid-flow-col auto-cols-max items-center gap-1 text-xs text-fg-muted tabular-nums justify-end"
+              class="w-32 grid grid-flow-col auto-cols-max items-center gap-1 text-xs text-fg-muted tabular-nums justify-end"
               :aria-label="
                 getDownloadsAriaLabel(
                   getVersionDownloads(latestTagRow!.version)!,
@@ -413,11 +413,11 @@ const flatItems = computed<FlatItem[]>(() => {
             class="flex items-center gap-4 px-4 py-2.5 border-b border-border last:border-0 hover:bg-bg-subtle transition-colors relative"
           >
             <!-- Tag labels -->
-            <div class="w-28 shrink-0 flex flex-wrap gap-x-1.5 gap-y-0.5">
+            <div class="w-32 shrink-0 flex flex-wrap gap-x-1.5 gap-y-0.5">
               <span
                 v-for="tag in row.tags"
                 :key="tag"
-                class="text-3xs font-semibold uppercase tracking-wide text-fg-subtle"
+                class="text-xs font-semibold uppercase tracking-wider text-fg-subtle"
                 :title="tag"
                 >{{ tag }}</span
               >
@@ -443,7 +443,7 @@ const flatItems = computed<FlatItem[]>(() => {
               />
               <span
                 v-if="fullVersionMap?.get(row.version)?.deprecated"
-                class="text-3xs font-medium text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded relative z-10"
+                class="text-xs font-medium text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded relative z-10"
                 :title="fullVersionMap!.get(row.version)!.deprecated"
                 >deprecated</span
               >
@@ -452,7 +452,7 @@ const flatItems = computed<FlatItem[]>(() => {
             <!-- Downloads -->
             <span
               v-if="getVersionDownloads(row.version)"
-              class="w-28 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0 relative z-10"
+              class="w-32 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0 relative z-10"
               :aria-label="getDownloadsAriaLabel(getVersionDownloads(row.version)!, row.version)"
               dir="ltr"
               :title="getDownloadsAriaLabel(getVersionDownloads(row.version)!, row.version)"
@@ -460,7 +460,7 @@ const flatItems = computed<FlatItem[]>(() => {
               <span>{{ numberFormatter.format(getVersionDownloads(row.version)!) }}</span>
               <span class="i-lucide:chart-line" aria-hidden="true"></span>
             </span>
-            <span v-else class="w-28 shrink-0" />
+            <span v-else class="w-32 shrink-0" />
 
             <!-- Date -->
             <div class="flex items-center gap-2 shrink-0 relative z-10">
@@ -479,11 +479,9 @@ const flatItems = computed<FlatItem[]>(() => {
 
       <!-- ── Version History ───────────────────────────────────────────────── -->
       <section v-if="versionGroups.length > 0">
-        <h2 class="text-xs text-fg-subtle uppercase tracking-wider mb-3 px-4 sm:px-6 ps-1">
+        <h2 class="text-fg-subtle uppercase mb-3">
           {{ $t('package.versions.page_title') }}
-          <span class="ms-1 normal-case font-normal tracking-normal">
-            ({{ versionStrings.length }})
-          </span>
+          <span class="ms-1 normal-case font-normal"> ({{ versionStrings.length }}) </span>
         </h2>
 
         <!-- No filter matches -->
@@ -533,7 +531,7 @@ const flatItems = computed<FlatItem[]>(() => {
                     <span class="text-sm font-medium">{{ item.label }}</span>
                     <span
                       v-if="deprecatedGroupKeys.has(item.groupKey)"
-                      class="text-3xs font-medium text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded"
+                      class="text-xs font-medium text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded"
                       >deprecated</span
                     >
                     <span class="text-xs text-fg-subtle">({{ item.versions.length }})</span>
@@ -542,7 +540,7 @@ const flatItems = computed<FlatItem[]>(() => {
                     >
                     <span
                       v-if="groupDownloadsMap.has(item.groupKey)"
-                      class="ms-auto w-28 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0"
+                      class="ms-auto w-32 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0"
                       :aria-label="
                         getDownloadsAriaLabel(groupDownloadsMap.get(item.groupKey)!, item.label)
                       "
@@ -556,7 +554,7 @@ const flatItems = computed<FlatItem[]>(() => {
                       }}</span>
                       <span class="i-lucide:chart-line" aria-hidden="true"></span>
                     </span>
-                    <span v-else class="ms-auto w-28 shrink-0" />
+                    <span v-else class="ms-auto w-32 shrink-0" />
                     <span class="flex items-center gap-3 shrink-0">
                       <DateTime
                         v-if="getVersionTime(item.versions[0]!)"
@@ -618,7 +616,7 @@ const flatItems = computed<FlatItem[]>(() => {
                           <span
                             v-for="tag in versionToTagsMap.get(item.version)"
                             :key="tag"
-                            class="text-4xs font-semibold uppercase tracking-wide"
+                            class="text-2xs font-semibold uppercase tracking-wide"
                             :class="tag === 'latest' ? 'text-accent' : 'text-fg-subtle'"
                             :title="tag"
                           >
@@ -627,7 +625,7 @@ const flatItems = computed<FlatItem[]>(() => {
                         </div>
                         <span
                           v-if="fullVersionMap?.get(item.version)?.deprecated"
-                          class="text-3xs font-medium text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded relative z-10"
+                          class="text-xs font-medium text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 rounded relative z-10"
                           :title="fullVersionMap.get(item.version)!.deprecated"
                         >
                           deprecated
@@ -637,7 +635,7 @@ const flatItems = computed<FlatItem[]>(() => {
                       <!-- Downloads -->
                       <span
                         v-if="getVersionDownloads(item.version)"
-                        class="w-28 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0 relative z-10"
+                        class="w-32 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0 relative z-10"
                         :aria-label="
                           getDownloadsAriaLabel(getVersionDownloads(item.version)!, item.version)
                         "
@@ -651,7 +649,7 @@ const flatItems = computed<FlatItem[]>(() => {
                         }}</span>
                         <span class="i-lucide:chart-line" aria-hidden="true"></span>
                       </span>
-                      <span v-else class="w-28 shrink-0" />
+                      <span v-else class="w-32 shrink-0" />
 
                       <!-- Date -->
                       <div class="flex items-center gap-2 shrink-0 relative z-10">
@@ -690,7 +688,7 @@ const flatItems = computed<FlatItem[]>(() => {
                   >
                   <span
                     v-if="groupDownloadsMap.has(item.groupKey)"
-                    class="ms-auto w-28 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0"
+                    class="ms-auto w-32 grid grid-flow-col auto-cols-max items-center justify-end gap-1 text-xs text-fg-muted tabular-nums shrink-0"
                     :aria-label="
                       getDownloadsAriaLabel(groupDownloadsMap.get(item.groupKey)!, item.label)
                     "
@@ -702,7 +700,7 @@ const flatItems = computed<FlatItem[]>(() => {
                     <span>{{ numberFormatter.format(groupDownloadsMap.get(item.groupKey)!) }}</span>
                     <span class="i-lucide:chart-line" aria-hidden="true"></span>
                   </span>
-                  <span v-else class="ms-auto w-28 shrink-0" />
+                  <span v-else class="ms-auto w-32 shrink-0" />
                   <span class="flex items-center gap-3 shrink-0">
                     <DateTime
                       v-if="getVersionTime(item.versions[0] ?? '')"

--- a/app/pages/package/[[org]]/[name]/versions.vue
+++ b/app/pages/package/[[org]]/[name]/versions.vue
@@ -446,7 +446,7 @@ const flatItems = computed<FlatItem[]>(() => {
       <!-- ── Version History ───────────────────────────────────────────────── -->
       <section v-if="versionGroups.length > 0">
         <div class="flex items-center justify-between gap-2 mb-3">
-          <h2 class="text-sm text-fg-subtle uppercase mb-3">
+          <h2 class="text-sm text-fg-subtle uppercase">
             {{ $t('package.versions.page_title') }}
             <span class="ms-1 normal-case font-normal"> ({{ versionStrings.length }}) </span>
           </h2>

--- a/app/pages/package/[[org]]/[name]/versions.vue
+++ b/app/pages/package/[[org]]/[name]/versions.vue
@@ -283,40 +283,6 @@ const flatItems = computed<FlatItem[]>(() => {
           <span class="text-fg-subtle shrink-0">/</span>
           <h1 class="text-sm text-fg-muted shrink-0">{{ $t('package.versions.page_title') }}</h1>
         </div>
-        <div class="relative">
-          <InputBase
-            v-model="versionFilterInput"
-            type="text"
-            :placeholder="$t('package.versions.filter_placeholder')"
-            :aria-label="$t('package.versions.filter_placeholder')"
-            :aria-invalid="isInvalidRange ? 'true' : undefined"
-            :aria-describedby="isInvalidRange ? 'version-filter-error' : undefined"
-            autocomplete="off"
-            size="sm"
-            class="w-36 sm:w-64"
-            :class="isInvalidRange ? 'pe-7 !border-red-500' : ''"
-          />
-          <Transition
-            enter-active-class="transition-all duration-150"
-            enter-from-class="opacity-0 scale-60"
-            leave-active-class="transition-all duration-150"
-            leave-to-class="opacity-0 scale-60"
-          >
-            <TooltipApp
-              v-if="isInvalidRange"
-              :text="$t('package.versions.filter_invalid')"
-              position="bottom"
-              class="absolute end-0 inset-y-0 flex items-center pe-2"
-            >
-              <span
-                id="version-filter-error"
-                class="i-lucide:circle-alert w-3.5 h-3.5 text-red-500 block"
-                role="img"
-                :aria-label="$t('package.versions.filter_invalid')"
-              />
-            </TooltipApp>
-          </Transition>
-        </div>
       </div>
     </header>
 
@@ -479,10 +445,47 @@ const flatItems = computed<FlatItem[]>(() => {
 
       <!-- ── Version History ───────────────────────────────────────────────── -->
       <section v-if="versionGroups.length > 0">
-        <h2 class="text-sm text-fg-subtle uppercase mb-3">
-          {{ $t('package.versions.page_title') }}
-          <span class="ms-1 normal-case font-normal"> ({{ versionStrings.length }}) </span>
-        </h2>
+        <div class="flex items-center justify-between gap-2 mb-3">
+          <h2 class="text-sm text-fg-subtle uppercase mb-3">
+            {{ $t('package.versions.page_title') }}
+            <span class="ms-1 normal-case font-normal"> ({{ versionStrings.length }}) </span>
+          </h2>
+
+          <div class="relative">
+            <InputBase
+              v-model="versionFilterInput"
+              type="text"
+              :placeholder="$t('package.versions.filter_placeholder')"
+              :aria-label="$t('package.versions.filter_placeholder')"
+              :aria-invalid="isInvalidRange ? 'true' : undefined"
+              :aria-describedby="isInvalidRange ? 'version-filter-error' : undefined"
+              autocomplete="off"
+              size="sm"
+              class="w-36 sm:w-64"
+              :class="isInvalidRange ? 'pe-7 !border-red-500' : ''"
+            />
+            <Transition
+              enter-active-class="transition-all duration-150"
+              enter-from-class="opacity-0 scale-60"
+              leave-active-class="transition-all duration-150"
+              leave-to-class="opacity-0 scale-60"
+            >
+              <TooltipApp
+                v-if="isInvalidRange"
+                :text="$t('package.versions.filter_invalid')"
+                position="bottom"
+                class="absolute end-0 inset-y-0 flex items-center pe-2"
+              >
+                <span
+                  id="version-filter-error"
+                  class="i-lucide:circle-alert w-3.5 h-3.5 text-red-500 block"
+                  role="img"
+                  :aria-label="$t('package.versions.filter_invalid')"
+                />
+              </TooltipApp>
+            </Transition>
+          </div>
+        </div>
 
         <!-- No filter matches -->
         <div

--- a/app/pages/package/[[org]]/[name]/versions.vue
+++ b/app/pages/package/[[org]]/[name]/versions.vue
@@ -331,7 +331,7 @@ const flatItems = computed<FlatItem[]>(() => {
         <!-- Latest — featured card -->
         <div
           v-if="latestTagRow"
-          class="border-y sm:rounded-lg sm:border border-accent/40 bg-accent/5 px-4 py-4 relative flex items-center justify-between gap-4 hover:bg-accent/8 transition-colors"
+          class="border-y sm:rounded-lg sm:border border-accent/40 bg-accent/5 px-4 py-4 relative flex max-sm:flex-col sm:items-center justify-between gap-4 hover:bg-accent/8 transition-colors"
         >
           <!-- Left: tags + version + deprecated -->
           <div>
@@ -370,10 +370,10 @@ const flatItems = computed<FlatItem[]>(() => {
             </div>
           </div>
           <!-- Right: downloads + date -->
-          <div class="flex items-center gap-4 shrink-0 relative z-10">
+          <div class="flex sm:items-center gap-4 shrink-0 relative z-10">
             <span
               v-if="getVersionDownloads(latestTagRow!.version)"
-              class="w-32 grid grid-flow-col auto-cols-max items-center gap-1 text-xs text-fg-muted tabular-nums justify-end"
+              class="w-32 grid grid-flow-col auto-cols-max items-center gap-1 text-xs text-fg-muted tabular-nums sm:justify-end"
               :aria-label="
                 getDownloadsAriaLabel(
                   getVersionDownloads(latestTagRow!.version)!,
@@ -394,7 +394,7 @@ const flatItems = computed<FlatItem[]>(() => {
             <DateTime
               v-if="getVersionTime(latestTagRow!.version)"
               :datetime="getVersionTime(latestTagRow!.version)!"
-              class="text-xs text-fg-subtle whitespace-nowrap w-24 text-end"
+              class="text-xs text-fg-subtle whitespace-nowrap w-24 sm:text-end"
               year="numeric"
               month="short"
               day="numeric"


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2796

### 🧭 Context

Improvements for versions page:

1. Fix horizontal scroll on mobile
1. Increase text-size (text-xs instead of text-4xs/text-3xs for small elements)
1. Minor mobile improvements to keep all the data in a row
1. move versions filter field to versions history section so it's clear what it's for (_see linked issue_)

<details>
<summary>Screenshots</summary>
versions field before/after - https://npmx.dev/package/@types/node/versions
<img width="1615" height="1621" alt="image" src="https://github.com/user-attachments/assets/bacc672b-1267-4988-b066-06e1201386fd" />
<img width="1610" height="1625" alt="image" src="https://github.com/user-attachments/assets/54e4501c-2635-4904-bc2b-1b9bd0cef7e2" />

Mobile before/after - https://npmx.dev/package/@types/node/versions
<img width="938" height="1628" alt="image" src="https://github.com/user-attachments/assets/5966a85b-e518-4c75-8480-3ce44f7e14c5" />
<img width="935" height="1621" alt="image" src="https://github.com/user-attachments/assets/9b30b129-a03a-4544-87f7-3787de8a75a2" />

</details>