### PR TITLE
chore: print more lunaria generation logs

### DIFF
--- a/modules/lunaria.ts
+++ b/modules/lunaria.ts
@@ -31,13 +31,16 @@ export default defineNuxtModule({
         try {
           execSync('node --experimental-transform-types ./lunaria/lunaria.ts', {
             cwd: nuxt.options.rootDir,
+            stdio: 'inherit',
           })
         } catch (e) {
           // Always throw in local dev.
           // In CI, only throw if building for production.
           const { env } = await getEnv(!isCI)
-          if (env === 'dev' || env === 'release') {
+          if (env === 'dev' || env === 'release' || env === 'canary') {
             throw e
+          } else {
+            console.error(e)
           }
         }
       })


### PR DESCRIPTION
### 🔗 Linked issue

Related #2785

### 🧭 Context

The error only in mentioned issue occurs only in canary. We have logic that outputs logs that can help understand what exactly happened, but these logs are only printed in release, not canary. To understand what exactly happened, enabling logs in canary would help

I'm almost sure that the problem is because lunaria, for some reason, can't process git data in the main branch (it definitely didn't generate the file and it definitely crashed here, but without logs it's hard to understand why)

Overall, I can't find a reason why we should ignore logs, so I want us to display them