### PR TITLE
feat: support description elements in readmes

### DIFF
--- a/app/components/Readme.vue
+++ b/app/components/Readme.vue
@@ -283,6 +283,14 @@ function handleClick(event: MouseEvent) {
   font-style: italic;
 }
 
+.readme :deep(dt) {
+  margin-block-start: 0.5rem;
+}
+
+.readme :deep(dd) {
+  padding-inline-start: 1.5rem;
+}
+
 /* GitHub-style callouts/alerts */
 .readme :deep(blockquote[data-callout]) {
   border-inline-start-width: 3px;

--- a/server/utils/readme.ts
+++ b/server/utils/readme.ts
@@ -180,6 +180,9 @@ export const ALLOWED_TAGS = [
   'kbd',
   'mark',
   'button',
+  'dl',
+  'dt',
+  'dd',
 ]
 
 export const ALLOWED_ATTR: Record<string, string[]> = {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2776

### 🧭 Context

Added support for Description elements - dl, dt, dd. These are just regular HTML elements and they were probably simply forgotten when we configured parsing

<details>
<summary>Screenshots (https://npmx.dev/package/@mishieck/graph-js)</summary>
<img width="3802" height="1823" alt="image" src="https://github.com/user-attachments/assets/321e853e-cfc9-4b06-a0ae-d63ae8fae643" />
<img width="3808" height="1809" alt="image" src="https://github.com/user-attachments/assets/bf4629f4-48ae-411f-a3de-649234859b9e" />

</details>