### PR TITLE
fix: arrows are allowed as the label value parameter

### DIFF
--- a/server/api/registry/badge/[type]/[...pkg].get.ts
+++ b/server/api/registry/badge/[type]/[...pkg].get.ts
@@ -13,7 +13,8 @@ const NPM_DOWNLOADS_API = 'https://api.npmjs.org/downloads/point'
 const OSV_QUERY_API = 'https://api.osv.dev/v1/query'
 const BUNDLEPHOBIA_API = 'https://bundlephobia.com/api/size'
 
-const SafeStringSchema = v.pipe(v.string(), v.regex(/^[^<>"&]*$/, 'Invalid characters'))
+// Allow semver range operators like >= and <= while still rejecting quotes and ampersands.
+const SafeStringSchema = v.pipe(v.string(), v.regex(/^[^"&]*$/, 'Invalid characters'))
 const SafeColorSchema = v.pipe(
   v.string(),
   v.transform(value => (value.startsWith('#') ? value : `#${value}`)),

--- a/test/e2e/badge.spec.ts
+++ b/test/e2e/badge.spec.ts
@@ -188,6 +188,17 @@ test.describe('badge API', () => {
     expect(body).toContain(customValue)
   })
 
+  test('custom value parameter supports semver range operators', async ({ page, baseURL }) => {
+    const customValue = '>=22.13.0'
+    const url = toLocalUrl(
+      baseURL,
+      `/api/registry/badge/engines/nuxt?value=${encodeURIComponent(customValue)}`,
+    )
+    const { body } = await fetchBadge(page, url)
+
+    expect(body).toContain(customValue)
+  })
+
   test('style=default keeps current badge renderer', async ({ page, baseURL }) => {
     const url = toLocalUrl(baseURL, '/api/registry/badge/version/nuxt?style=default')
     const { body } = await fetchBadge(page, url)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context
The `value` parameter can be passed as an arrow string, just like in the test cases.
<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
