### PR TITLE
fix: hide mobile search field on blur

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -327,7 +327,7 @@ useShortcuts({
       <!-- Mobile: Search button (expands search) -->
       <ButtonBase
         type="button"
-        class="sm:hidden ms-auto"
+        class="sm:hidden ms-auto py-2.5!"
         :aria-label="$t('nav.tap_to_search')"
         :aria-expanded="showMobileMenu"
         @click="expandMobileSearch"
@@ -338,7 +338,7 @@ useShortcuts({
       <!-- Mobile: Menu button (always visible, click to open menu) -->
       <ButtonBase
         type="button"
-        class="sm:hidden"
+        class="sm:hidden py-2.5!"
         :aria-label="$t('nav.open_menu')"
         :aria-expanded="showMobileMenu"
         @click="showMobileMenu = !showMobileMenu"

--- a/app/components/Header/SearchBox.vue
+++ b/app/components/Header/SearchBox.vue
@@ -32,15 +32,19 @@ function clearSearch() {
 const inputRef = useTemplateRef('inputRef')
 function handleFocus() {
   isSearchFocused.value = true
-  inputRef.value?.focus()
   emit('focus')
 }
 function handleBlur() {
   isSearchFocused.value = false
-  inputRef.value?.blur()
   emit('blur')
 }
-defineExpose({ focus: handleFocus, blur: handleBlur })
+function focus() {
+  inputRef.value?.focus()
+}
+function blur() {
+  inputRef.value?.blur()
+}
+defineExpose({ focus, blur })
 </script>
 <template>
   <search v-if="showSearchBar" :class="'flex-1 sm:max-w-md ' + inputClass">

--- a/app/components/Header/SearchBox.vue
+++ b/app/components/Header/SearchBox.vue
@@ -30,10 +30,17 @@ function clearSearch() {
 
 // Expose focus method for parent components
 const inputRef = useTemplateRef('inputRef')
-function focus() {
+function handleFocus() {
+  isSearchFocused.value = true
   inputRef.value?.focus()
+  emit('focus')
 }
-defineExpose({ focus })
+function handleBlur() {
+  isSearchFocused.value = false
+  inputRef.value?.blur()
+  emit('blur')
+}
+defineExpose({ focus: handleFocus, blur: handleBlur })
 </script>
 <template>
   <search v-if="showSearchBar" :class="'flex-1 sm:max-w-md ' + inputClass">
@@ -60,8 +67,8 @@ defineExpose({ focus })
             :placeholder="$t('search.placeholder')"
             no-correct
             class="w-full min-w-25 ps-7 pe-8"
-            @focus="isSearchFocused = true"
-            @blur="isSearchFocused = false"
+            @focus="handleFocus"
+            @blur="handleBlur"
             size="sm"
             ariaKeyshortcuts="/"
           />


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1881, Closes #2021

### 🧭 Context

Hiding the search field in the header on mobile devices when blurred (unfocused). We had logic for this, but the field component itself didn't support it, so I simply added correct events emit

Also adjusted the button sizes a bit so that they are in a better proportion to each other