### PR TITLE
docs: add link to npmxers site

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ We welcome contributions &ndash; please do feel free to explore the project and 
 - [npmx-weekly](https://npmx-weekly.trueberryless.org/) &ndash; A weekly newsletter for the npmx ecosystem. Add your own content via suggestions in the weekly PR on [GitHub](https://github.com/trueberryless-org/npmx-weekly/pulls?q=is%3Aopen+is%3Apr+label%3A%22%F0%9F%95%94+weekly+post%22).
 - [npmx-digest](https://npmx-digest.trueberryless.org/) &ndash; An automated news aggregation website that summarizes npmx activity from GitHub and Bluesky every 8 hours.
 - [npmx-badge](https://npmx-badge.vercel.app/) &ndash; A playground to help you create custom badges quickly.
+- [npmxers](https://npmxers.trueberryless.org/) &ndash; Discover the number of contributions you made to npmx and share your npmxer profile.
 
 If you're building something cool, let us know! 🙏
 


### PR DESCRIPTION
### 🧭 Context

I made a little website which collects contribution stats for all `npmx-dev` repos (from the whole org). It's available under https://npmxers.trueberryless.org/

I would like to link to it from the `README.md` if allowed.