### PR TITLE
fix: use monospace font in embed chart

### DIFF
--- a/server/utils/embed-downloads-svg.ts
+++ b/server/utils/embed-downloads-svg.ts
@@ -334,6 +334,7 @@ export async function createDownloadsSvgResponse(query: QueryParameters): Promis
       })
 
       return `
+          <style>text {font-family:monospace;}</style>
           ${lastPlotValues}
           ${logo}
         `


### PR DESCRIPTION
Follow up to #2833

Embedded charts currently have the default browser font, which does not convey the npmx design language.
This adds a style tag inside the svg to set the font-family of text elements to monospace.