### PR TITLE
fix: enable CORS on chart embed endpoint and add missing tooltip

### DIFF
--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -1999,8 +1999,21 @@ const copyEmbedUrl = () => copyEmbed(embedUrl.value)
           <div class="flex flex-row flex-wrap gap-2 mt-2">
             <SettingsToggle v-model="isEmbedDarkMode" :label="$t('command_palette.theme.dark')" />
           </div>
-          <div class="text-sm text-fg-subtle">
+          <div class="text-sm text-fg-subtle flex gap-1">
             {{ $t('package.trends.embedding.copy_url') }}
+            <TooltipApp
+              :text="$t('package.trends.embedding.tip')"
+              interactive
+              to="#chart-modal"
+              position="top"
+            >
+              <span
+                tabindex="0"
+                class="inline-flex items-center justify-center min-w-6 min-h-6 -m-1 p-1 text-fg-subtle hover:text-fg transition-colors cursor-help focus-visible:outline-2 focus-visible:outline-accent/70 rounded"
+              >
+                <span class="i-lucide:info w-3 h-3" aria-hidden="true" />
+              </span>
+            </TooltipApp>
           </div>
           <div class="flex flex-row gap-4 flex-wrap">
             <div

--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -2004,7 +2004,7 @@ const copyEmbedUrl = () => copyEmbed(embedUrl.value)
             <TooltipApp
               :text="$t('package.trends.embedding.tip')"
               interactive
-              to="#chart-modal"
+              :to="inModal ? '#chart-modal' : undefined"
               position="top"
             >
               <span

--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -1973,7 +1973,6 @@ const copyEmbedUrl = () => copyEmbed(embedUrl.value)
         <button
           type="button"
           :aria-expanded="showEmbedFields"
-          +
           aria-controls="trends-embed-chart"
           class="self-start flex items-center gap-1 text-2xs font-mono text-fg-subtle hover:text-fg transition-colors"
           @click="showEmbedFields = !showEmbedFields"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -742,7 +742,8 @@
       "embedding": {
         "chart": "Embed this chart",
         "copy_url": "Copy this URL to embed the chart into your website",
-        "preview": "Preview"
+        "preview": "Preview",
+        "tip": "If startDate and endDate are not provided, the chart defaults to the last 12 months."
       }
     },
     "downloads": {

--- a/i18n/locales/fr-FR.json
+++ b/i18n/locales/fr-FR.json
@@ -701,7 +701,8 @@
       "embedding": {
         "chart": "Intégrer ce graphique",
         "copy_url": "Copiez cette URL pour intégrer le graphique à votre site web",
-        "preview": "Aperçu"
+        "preview": "Aperçu",
+        "tip": "Par défaut, si startDate et endDate ne sont pas renseignés, la période couvre les 12 derniers mois."
       }
     },
     "downloads": {

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -2232,6 +2232,9 @@
                 },
                 "preview": {
                   "type": "string"
+                },
+                "tip": {
+                  "type": "string"
                 }
               },
               "additionalProperties": false

--- a/server/api/embed/downloads.svg.get.ts
+++ b/server/api/embed/downloads.svg.get.ts
@@ -12,7 +12,6 @@ export default defineCachedEventHandler(
     setHeader(event, 'Content-Type', 'image/svg+xml; charset=utf-8')
     setHeader(event, 'Cache-Control', 'public, max-age=3600, s-maxage=86400')
     setHeader(event, 'Access-Control-Allow-Origin', '*')
-    setHeader(event, 'Vary', 'Origin')
 
     return svg
   },

--- a/server/api/embed/downloads.svg.get.ts
+++ b/server/api/embed/downloads.svg.get.ts
@@ -2,8 +2,8 @@
  * Embedding of the downloads trends chart (single package via ChartModal, or multiple via compare)
  * A static svg is generated from the endpoint.
  */
-
 import { createDownloadsSvgResponse } from '~~/server/utils/embed-downloads-svg'
+import { CACHE_MAX_AGE_ONE_HOUR } from '#shared/utils/constants'
 
 export default defineCachedEventHandler(
   async event => {
@@ -11,12 +11,15 @@ export default defineCachedEventHandler(
 
     setHeader(event, 'Content-Type', 'image/svg+xml; charset=utf-8')
     setHeader(event, 'Cache-Control', 'public, max-age=3600, s-maxage=86400')
+    setHeader(event, 'Access-Control-Allow-Origin', '*')
+    setHeader(event, 'Vary', 'Origin')
 
     return svg
   },
   {
-    maxAge: 60 * 60,
+    maxAge: CACHE_MAX_AGE_ONE_HOUR,
     swr: true,
+    name: 'embed-package-downloads',
     getKey: event => event.node.req.url || event.path,
   },
 )

--- a/server/utils/embed-downloads-svg.ts
+++ b/server/utils/embed-downloads-svg.ts
@@ -140,25 +140,12 @@ export async function createDownloadsSvgResponse(query: QueryParameters): Promis
   const accent = parseAccent(query.accent)
   const yLabel = parseSafeText(query.yLabel, '', 100)
 
-  const requestedEndDate = parseDateQuery(query.endDate ?? query.end)
-
-  const defaultEndDate = new Date()
-  defaultEndDate.setDate(defaultEndDate.getDate() - 1)
-
-  const effectiveEndDate: string = requestedEndDate ?? defaultEndDate.toISOString().split('T')[0]!
-
-  const defaultStartDate = new Date(effectiveEndDate)
-  defaultStartDate.setFullYear(defaultStartDate.getFullYear() - 1)
-
-  const effectiveStartDate: string =
-    parseDateQuery(query.startDate ?? query.start) ?? defaultStartDate.toISOString().split('T')[0]!
-
   const evolutionOptions = {
     granularity: fetchGranularity,
     weeks: clampNumber(query.weeks, 1, 260, 52),
     months: clampNumber(query.months, 1, 120, 12),
-    startDate: effectiveStartDate,
-    endDate: effectiveEndDate,
+    startDate: parseDateQuery(query.startDate ?? query.start),
+    endDate: parseDateQuery(query.endDate ?? query.end),
   }
 
   if (metric !== 'downloads') {

--- a/server/utils/embed-downloads-svg.ts
+++ b/server/utils/embed-downloads-svg.ts
@@ -140,12 +140,25 @@ export async function createDownloadsSvgResponse(query: QueryParameters): Promis
   const accent = parseAccent(query.accent)
   const yLabel = parseSafeText(query.yLabel, '', 100)
 
+  const requestedEndDate = parseDateQuery(query.endDate ?? query.end)
+
+  const defaultEndDate = new Date()
+  defaultEndDate.setDate(defaultEndDate.getDate() - 1)
+
+  const effectiveEndDate: string = requestedEndDate ?? defaultEndDate.toISOString().split('T')[0]!
+
+  const defaultStartDate = new Date(effectiveEndDate)
+  defaultStartDate.setFullYear(defaultStartDate.getFullYear() - 1)
+
+  const effectiveStartDate: string =
+    parseDateQuery(query.startDate ?? query.start) ?? defaultStartDate.toISOString().split('T')[0]!
+
   const evolutionOptions = {
     granularity: fetchGranularity,
     weeks: clampNumber(query.weeks, 1, 260, 52),
     months: clampNumber(query.months, 1, 120, 12),
-    startDate: parseDateQuery(query.startDate ?? query.start),
-    endDate: parseDateQuery(query.endDate ?? query.end),
+    startDate: effectiveStartDate,
+    endDate: effectiveEndDate,
   }
 
   if (metric !== 'downloads') {


### PR DESCRIPTION
Follow up to #2833
This enables CORS on the embed downloads chart endpoint, to enable fetch and retrieve the svg string. Without it, only the image tag can be consumed with the url in its src.

I also added a tooltip, informing that `startDate` and `endDate` can be omitted from the query to dynamically get the last year of data.

<img width="343" height="102" alt="image" src="https://github.com/user-attachments/assets/becafe68-1520-45b4-8fa7-ca0a6af0acb2" />
