### PR TITLE
chore: enable fetch-depth for canary build

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 2
 
       - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
         with:

--- a/modules/lunaria.ts
+++ b/modules/lunaria.ts
@@ -37,7 +37,7 @@ export default defineNuxtModule({
           // Always throw in local dev.
           // In CI, only throw if building for production.
           const { env } = await getEnv(!isCI)
-          if (env === 'dev' || env === 'release' || env === 'canary') {
+          if (env === 'dev' || env === 'release') {
             throw e
           } else {
             console.error(e)


### PR DESCRIPTION
### 🔗 Linked issue

Related #2848, #2785

### 🧭 Context

From the logs, the problem of missed translations in canary is definitely in the lunaria/lunaria file, but nothing much has come up. So, as suggested in discord earlier, I'm trying to configure fetch depth. It seems even more likely that it's related to git