### PR TITLE
feat(i18n): add Korean translation

### DIFF
--- a/config/i18n.ts
+++ b/config/i18n.ts
@@ -306,12 +306,12 @@ const locales: (LocaleObjectData | (Omit<LocaleObjectData, 'code'> & { code: str
       code: 'gl-ES',
       file: 'gl-ES.json',
       name: 'Galego',
-    },
-    {
-      code: 'ko-KR',
-      file: 'ko-KR.json',
-      name: '한국어',
     },*/
+  {
+    code: 'ko-KR',
+    file: 'ko-KR.json',
+    name: '한국어',
+  },
   {
     code: 'id-ID',
     file: 'id-ID.json',

--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -1,4 +1,4 @@
-import { koreanModifiers } from '../shared/utils/korean'
+import { koreanModifiers } from '#shared/utils/korean'
 import { currentLocales, datetimeFormats, numberFormats, pluralRules } from '../config/i18n'
 
 export default defineI18nConfig(() => {

--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -1,7 +1,7 @@
 import { currentLocales, datetimeFormats, numberFormats, pluralRules } from '../config/i18n'
 
-function getKoreanJosa(
-  text: unknown,
+function getKoreanJosa<T>(
+  text: T,
   isRo: boolean,
   withFinalConsonant: string,
   withoutFinalConsonant: string,

--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -1,65 +1,5 @@
+import { koreanModifiers } from '../shared/utils/korean'
 import { currentLocales, datetimeFormats, numberFormats, pluralRules } from '../config/i18n'
-
-/**
- * Get the correct Korean particle following the given word.
- *
- * Korean usually has a pair of two particles, which is chosen depending on
- * whether a word ends with a consonant or a vowel.
- * This function deals with such Korean particles, with a plausible heuristic
- * for non-Korean characters.
- *
- * @param text
- * @param isRo whether the particle pair is 으로/로 or not
- *        If isRo is true, `withFinalConsonant` excludes ㄹ (L sound) from
- *        its consonant set.
- * @param withFinalConsonant a version in case ending with a consonant
- * @param withoutFinalConsonant a version in case ending with a vowel
- * @returns the correct particle
- */
-function getKoreanJosa<T>(
-  text: T,
-  isRo: boolean,
-  withFinalConsonant: string,
-  withoutFinalConsonant: string,
-) {
-  if (typeof text !== 'string') return text
-
-  // Strip out all non-Korean (vowels, consonants, and complete characters)
-  // non-alphanumeric characters.
-  const normalizedText = text.replace(/[^\u3131-\u3163\uac00-\ud7a3a-z0-9]/gi, '')
-
-  if (typeof normalizedText !== 'string' || normalizedText.length === 0)
-    return withoutFinalConsonant
-
-  // If `text` ends with two or more consecutive latin alphabets,
-  // apply the following syllable final sound huristic:
-  if (/[a-z]{2,}$/.test(normalizedText)) {
-    return /(?:\w[lm]|[aeiouwy][ckpqt])e?$/i.test(normalizedText)
-      ? withFinalConsonant
-      : withoutFinalConsonant
-  }
-
-  // If `text` ends with complete Korean characters,
-  // check if it has a syllable final sound and return the appropriate one.
-  if (/[\uac00-\ud7a3]$/.test(normalizedText)) {
-    const code = normalizedText.charCodeAt(normalizedText.length - 1) - 0xac00
-    const hasFinalConsonant = !(code % 28 === 0 || (isRo && code % 28 === 8))
-    return hasFinalConsonant ? withFinalConsonant : withoutFinalConsonant
-  }
-
-  // The case `text` ends with incomplete Korean characters (consonants or vowels)
-  if (isRo && normalizedText.endsWith('ㄹ')) return withoutFinalConsonant
-  // Consonant cases
-  if (/[\u3131-\u314e]$/.test(normalizedText)) return withFinalConsonant
-  // Vowel cases
-  if (/[\u314f-\u3163]$/.test(normalizedText)) return withoutFinalConsonant
-
-  // The case `text` ends with a single latin alphabet or a digit
-  const singleAlphabetOrNumericRegex = isRo ? /[mn036]$/i : /[lmnr013678]$/i
-  return singleAlphabetOrNumericRegex.test(normalizedText)
-    ? withFinalConsonant
-    : withoutFinalConsonant
-}
 
 export default defineI18nConfig(() => {
   return {
@@ -71,11 +11,7 @@ export default defineI18nConfig(() => {
     numberFormats,
     pluralRules,
     modifiers: {
-      koreanI: text => getKoreanJosa(text, false, '이', '가'),
-      koreanEun: text => getKoreanJosa(text, false, '은', '는'),
-      koreanEul: text => getKoreanJosa(text, false, '을', '를'),
-      koreanWa: text => getKoreanJosa(text, false, '과', '와'),
-      koreanRo: text => getKoreanJosa(text, true, '으로', '로'),
+      ...koreanModifiers,
     },
   }
 })

--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -1,5 +1,47 @@
 import { currentLocales, datetimeFormats, numberFormats, pluralRules } from '../config/i18n'
 
+function getKoreanJosa(
+  text: unknown,
+  isRo: boolean,
+  withFinalConsonant: string,
+  withoutFinalConsonant: string,
+) {
+  if (typeof text !== 'string') return text
+
+  // Strip out all non-Korean non-alphanumeric characters.
+  const normalizedText = text.replace(/[^ㄱ-ㅎㅏ-ㅣ가-힣a-z0-9]/gi, '')
+
+  if (typeof normalizedText !== 'string' || normalizedText.length === 0)
+    return withoutFinalConsonant
+
+  // If `text` ends with two or more consecutive latin alphabets,
+  // apply the following syllable final sound huristic:
+  if (/[a-z]{2,}$/.test(normalizedText)) {
+    return /(?:\w[lm]|[aeiouwy][ckpqt])e?$/i.test(normalizedText)
+      ? withFinalConsonant
+      : withoutFinalConsonant
+  }
+
+  // If `text` ends with complete Korean characters,
+  // check if it has a syllable final sound and return the appropriate one.
+  if (/[가-힣]$/.test(normalizedText)) {
+    const code = normalizedText.charCodeAt(normalizedText.length - 1) - 0xac00
+    const hasFinalConsonant = !(code % 28 === 0 || (isRo && code % 28 === 8))
+    return hasFinalConsonant ? withFinalConsonant : withoutFinalConsonant
+  }
+
+  // The case `text` ends with incomplete Korean characters (consonants or vowels)
+  if (isRo && normalizedText.endsWith('ㄹ')) return withoutFinalConsonant
+  if (/[ㄱ-ㅎ]$/.test(normalizedText)) return withFinalConsonant
+  if (/[ㅏ-ㅣ]$/.test(normalizedText)) return withoutFinalConsonant
+
+  // The case `text` ends with a single latin alphabet or a digit
+  const singleAlphabetOrNumericRegex = isRo ? /[mn036]$/i : /[lmnr013678]$/i
+  return singleAlphabetOrNumericRegex.test(normalizedText)
+    ? withFinalConsonant
+    : withoutFinalConsonant
+}
+
 export default defineI18nConfig(() => {
   return {
     availableLocales: currentLocales.map(l => l.code),
@@ -9,5 +51,12 @@ export default defineI18nConfig(() => {
     datetimeFormats,
     numberFormats,
     pluralRules,
+    modifiers: {
+      koreanI: text => getKoreanJosa(text, false, '이', '가'),
+      koreanEun: text => getKoreanJosa(text, false, '은', '는'),
+      koreanEul: text => getKoreanJosa(text, false, '을', '를'),
+      koreanWa: text => getKoreanJosa(text, false, '과', '와'),
+      koreanRo: text => getKoreanJosa(text, true, '으로', '로'),
+    },
   }
 })

--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -1,5 +1,21 @@
 import { currentLocales, datetimeFormats, numberFormats, pluralRules } from '../config/i18n'
 
+/**
+ * Get the correct Korean particle following the given word.
+ *
+ * Korean usually has a pair of two particles, which is chosen depending on
+ * whether a word ends with a consonant or a vowel.
+ * This function deals with such Korean particles, with a plausible heuristic
+ * for non-Korean characters.
+ *
+ * @param text
+ * @param isRo whether the particle pair is 으로/로 or not
+ *        If isRo is true, `withFinalConsonant` excludes ㄹ (L sound) from
+ *        its consonant set.
+ * @param withFinalConsonant a version in case ending with a consonant
+ * @param withoutFinalConsonant a version in case ending with a vowel
+ * @returns the correct particle
+ */
 function getKoreanJosa<T>(
   text: T,
   isRo: boolean,
@@ -8,8 +24,9 @@ function getKoreanJosa<T>(
 ) {
   if (typeof text !== 'string') return text
 
-  // Strip out all non-Korean non-alphanumeric characters.
-  const normalizedText = text.replace(/[^ㄱ-ㅎㅏ-ㅣ가-힣a-z0-9]/gi, '')
+  // Strip out all non-Korean (vowels, consonants, and complete characters)
+  // non-alphanumeric characters.
+  const normalizedText = text.replace(/[^\u3131-\u3163\uac00-\ud7a3a-z0-9]/gi, '')
 
   if (typeof normalizedText !== 'string' || normalizedText.length === 0)
     return withoutFinalConsonant
@@ -24,7 +41,7 @@ function getKoreanJosa<T>(
 
   // If `text` ends with complete Korean characters,
   // check if it has a syllable final sound and return the appropriate one.
-  if (/[가-힣]$/.test(normalizedText)) {
+  if (/[\uac00-\ud7a3]$/.test(normalizedText)) {
     const code = normalizedText.charCodeAt(normalizedText.length - 1) - 0xac00
     const hasFinalConsonant = !(code % 28 === 0 || (isRo && code % 28 === 8))
     return hasFinalConsonant ? withFinalConsonant : withoutFinalConsonant
@@ -32,8 +49,10 @@ function getKoreanJosa<T>(
 
   // The case `text` ends with incomplete Korean characters (consonants or vowels)
   if (isRo && normalizedText.endsWith('ㄹ')) return withoutFinalConsonant
-  if (/[ㄱ-ㅎ]$/.test(normalizedText)) return withFinalConsonant
-  if (/[ㅏ-ㅣ]$/.test(normalizedText)) return withoutFinalConsonant
+  // Consonant cases
+  if (/[\u3131-\u314e]$/.test(normalizedText)) return withFinalConsonant
+  // Vowel cases
+  if (/[\u314f-\u3163]$/.test(normalizedText)) return withoutFinalConsonant
 
   // The case `text` ends with a single latin alphabet or a digit
   const singleAlphabetOrNumericRegex = isRo ? /[mn036]$/i : /[lmnr013678]$/i

--- a/i18n/locales/ko-KR.json
+++ b/i18n/locales/ko-KR.json
@@ -230,7 +230,29 @@
     }
   },
   "noodles": {
-    "missing": {}
+    "title": "noodles",
+    "meta_description": "npmx 홈페이지를 장식한 noodle 목록 — 계절별 로고, 이스터 에그 및 그 뒤에 숨겨진 이야기들.",
+    "latest": "최신 noodle",
+    "what_is": "noodle이란?",
+    "what_is_body": "Noodle은 npmx의 릴리스나 공휴일, 이벤트, 혹은 다른 축하해야 할 기념비적인 순간을 위해 npmx의 로고를 재미있게 변형한 것입니다. npm 패키지를 위한 구글 두들이라고 생각하시면 됩니다.",
+    "empty": "아직 noodle이 없습니다.",
+    "load_more": "{count}개 더 불러오기",
+    "dates": "적용된 날짜",
+    "shipped_in": "구현 PR",
+    "credits": "만든 이",
+    "learn_more": "더 보기",
+    "carousel_prev": "이전 이미지",
+    "carousel_next": "다음 이미지",
+    "carousel_dots": "다양한 이미지 둘러보기",
+    "carousel_jump": "{index}번째 이미지 보기",
+    "lens_label": "{title} — 이미지 캐로셀",
+    "lens_slide": "{index}번째 이미지",
+    "lens_slide_position": "이미지 {total}개 중 {index}번째",
+    "back_to_archive": "모든 noodle 보기",
+    "missing": {
+      "title": "이 noodle은 그릇 밖으로 나오지도 못했습니다.",
+      "body": "저희가 제공하는 noodle 메뉴에는 “{slug}”@.koreanI:{slug} 없습니다. 지금 막 그릇에 담고 있거나, 아직 만들어지지 않은 것 같네요. 어느 쪽이든, 모든 noodle을 볼 수 있는 메뉴로 돌아갑시다."
+    }
   },
   "settings": {
     "title": "설정",
@@ -717,7 +739,11 @@
         "facet_bar_general_description": "{packages}의 가로 막대그래프: {facet} 비교 ({description}) {facet_analysis} {watermark}",
         "facet_bar_analysis": "{package_name}의 값은 {value}입니다."
       },
-      "embedding": {}
+      "embedding": {
+        "chart": "이 그래프의 임베드 코드 복사하기",
+        "copy_url": "이 그래프의 임베드 코드를 복사하여 웹사이트에 삽입하실 수 있습니다.",
+        "preview": "미리보기"
+      }
     },
     "downloads": {
       "title": "주간 다운로드 수",
@@ -1470,6 +1496,9 @@
     "change_ratio": "변경률",
     "char_edits": "수정된 최대 문자 수",
     "diff_distance": "편집 거리",
+    "diff_truncated": "성능 향상을 위해 변경된 첫 번째 줄만 표시됩니다.",
+    "large_diff_mode": "성능 향상을 위해 큰 파일의 변경 사항 표시 중에는 수정된 행 합치기 기능이 비활성화됩니다.",
+    "large_diff_options_disabled": "성능 향상을 위해 큰 파일 모드에서는 수정된 행 합치기 기능이 비활성화됩니다.",
     "loading_diff": "변경 사항을 불러오는 중입니다.",
     "loading_diff_error": "변경 사항을 불러오는 데 실패했습니다.",
     "merge_modified_lines": "수정된 행 합치기",

--- a/i18n/locales/ko-KR.json
+++ b/i18n/locales/ko-KR.json
@@ -229,6 +229,9 @@
       "more_replies": "댓글 {count}개 더 보기"
     }
   },
+  "noodles": {
+    "missing": {}
+  },
   "settings": {
     "title": "설정",
     "tagline": "npmx 경험 사용자화하기",
@@ -713,7 +716,8 @@
         "general_description": "Y축은 다운로드 수, X축은 {start_date}부터 {end_date}까지의 기간(단위: {granularity})을 나타냅니다. {estimation_notice} {packages_analysis} {watermark}",
         "facet_bar_general_description": "{packages}의 가로 막대그래프: {facet} 비교 ({description}) {facet_analysis} {watermark}",
         "facet_bar_analysis": "{package_name}의 값은 {value}입니다."
-      }
+      },
+      "embedding": {}
     },
     "downloads": {
       "title": "주간 다운로드 수",
@@ -1426,8 +1430,6 @@
     "file_changes": "변경된 파일",
     "files_count": "파일 {count}개",
     "lines_hidden": "{count}개 행 숨기기",
-    "file_too_large": "파일이 너무 커서 비교할 수 없습니다.",
-    "file_size_warning": "{size}는 비교 가능 한도 250 kB를 넘었습니다.",
     "compare_versions": "비교",
     "compare_versions_title": "최신 버전과 비교",
     "comparing_versions_label": "버전을 비교하는 중입니다.",

--- a/i18n/locales/ko-KR.json
+++ b/i18n/locales/ko-KR.json
@@ -188,7 +188,7 @@
       "facets_all_selected": "모든 비교 항목을 선택했습니다.",
       "facets_all_deselected": "모든 비교 항목을 선택 해제했습니다.",
       "view_switched": "{view} 뷰로 변경되었습니다.",
-      "setting_toggled": "{setting}@.koreanEul:{settings} {state}@.koreanRo:{state} 변경했습니다."
+      "setting_toggled": "{setting}@.koreanEul:{setting} {state}@.koreanRo:{state} 변경했습니다."
     }
   },
   "nav": {
@@ -334,11 +334,11 @@
     "error": "에러",
     "view_on": {
       "npm": "npm에서 보기",
-      "github": "GitHubで表示",
+      "github": "GitHub에서 보기",
       "gitlab": "GitLab에서 보기",
       "bitbucket": "Bitbucket에서 보기",
       "codeberg": "Codeberg에서 보기",
-      "git_repo": "Gitリポジトリ에서 보기",
+      "git_repo": "Git 리포지터리에서 보기",
       "forgejo": "Forgejo에서 보기",
       "gitea": "Gitea에서 보기",
       "gitee": "Gitee에서 보기",
@@ -667,7 +667,7 @@
       "granularity_yearly": "연도별",
       "start_date": "시작 날짜",
       "end_date": "마지막 날짜",
-      "loading": "読み込み中...",
+      "loading": "불러오는 중...",
       "date_range": "{start}부터 {end}까지",
       "date_range_multiline": "{start}부터\n{end}까지",
       "download_file": "{fileType} 다운로드",
@@ -897,7 +897,7 @@
       "team_name_label": "팀 이름",
       "team_name_placeholder": "팀 이름...",
       "create_button": "생성",
-      "no_match": "“{query}”@.koreanWa:{query}　일치하는 팀을 찾을 수 없습니다.",
+      "no_match": "“{query}”@.koreanWa:{query} 일치하는 팀을 찾을 수 없습니다.",
       "cancel_create": "팀 생성을 취소합니다.",
       "create_team": "+ 팀 생성"
     },
@@ -940,7 +940,7 @@
       "no_packages": "공개된 패키지가 없습니다. 조직: ",
       "no_packages_hint": "존재하지 않는 조직이거나, 공개된 패키지가 없습니다.",
       "failed_to_load": "조직의 패키지를 불러오는 데 실패했습니다.",
-      "no_match": "“{query}”@.koreanWa:{query}　일치하는 패키지를 찾을 수 없습니다.",
+      "no_match": "“{query}”@.koreanWa:{query} 일치하는 패키지를 찾을 수 없습니다.",
       "not_found": "조직을 찾을 수 없습니다.",
       "not_found_message": "조직 “{'@'}{name}”은 npm에 존재하지 않습니다."
     }
@@ -957,7 +957,7 @@
       "no_packages": "공개된 패키지가 없습니다. 사용자: ",
       "no_packages_hint": "존재하지 않는 사용자거나, 공개된 패키지가 없습니다.",
       "failed_to_load": "사용자의 패키지를 불러오는 데 실패했습니다.",
-      "no_match": "“{query}”@.koreanWa:{query}　일치하는 패키지를 찾을 수 없습니다.",
+      "no_match": "“{query}”@.koreanWa:{query} 일치하는 패키지를 찾을 수 없습니다.",
       "filter_placeholder": "패키지 {count}개를 필터링해 보세요."
     },
     "orgs_page": {
@@ -1248,7 +1248,7 @@
       "connect": "연결",
       "create_account": "계정 신규 생성",
       "connect_bluesky": "Bluesky로 연결",
-      "what_is_atmosphere": "Atmosphere 계정이란？",
+      "what_is_atmosphere": "Atmosphere 계정이란?",
       "atmosphere_explanation": "{npmx}는 소셜 기능을 구현하는 데 {atproto}를 사용하고 있습니다. AT Protocol에 의해 사용자는 자신의 데이터를 소유하고, 1개의 계정으로 AT Protocol을 지원하는 모든 서비스를 사용할 수 있게 됩니다. 계정을 생성하면 {bluesky}나 {tangled} 등의 다른 서비스에서도 같은 계정을 사용할 수 있습니다.",
       "default_input_error": "올바른 핸들, DID, 혹은 완전한 PDS URL을 입력해 주세요.",
       "profile": "프로필"
@@ -1301,7 +1301,7 @@
       "search_first": "패키지를 검색해 보세요.",
       "search_add": "패키지를 추가해 보세요.",
       "searching": "검색 중입니다.",
-      "remove_package": "{package}　삭제",
+      "remove_package": "{package} 삭제",
       "packages_selected": "패키지 {max} 중 {count}개 선택됨",
       "add_hint": "비교하기 위해서는 적어도 2개 이상의 패키지를 선택해 주세요."
     },
@@ -1622,8 +1622,8 @@
     "p1": "npmx는 기본 언어로 {lang}를 사용하고 있고, 번역할 메시지는 총 {count}가 있습니다. 번역에 도움을 주고 싶으시다면, {bylang}에서 해당하는 언어를 찾아서 펼쳐 주시면 상세 정보를 보실 수 있습니다.",
     "p1_lang": "미국 영어(en-US)",
     "p1_count": "{count}개",
-    "p2": "開始する前に、翻訳プロセスと参加方法について説明した {guide} を読んでください。",
-    "guide": "ローカライズ (i18n) ガイド",
+    "p2": "시작하기 전에, 번역 과정과 참여 방법을 설명한 {guide}를 읽어 주세요.",
+    "guide": "번역(i18n) 가이드",
     "by_locale": "언어별 진행 상황",
     "by_file": "파일별 번역 진행 상황",
     "complete_text": "이 언어는 번역이 완료되었습니다. 수고하셨습니다!",

--- a/i18n/locales/ko-KR.json
+++ b/i18n/locales/ko-KR.json
@@ -1,0 +1,1743 @@
+{
+  "$schema": "../schema.json",
+  "seo": {
+    "home": {
+      "title": "npmx - npm 레지스트리를 위한 패키지 탐색기",
+      "description": "최신 기술로 만들어진 빠른 npm 레지스트리 탐색기. 모던 UI로 패키지를 검색, 열람, 또는 탐색할 수 있습니다."
+    }
+  },
+  "built_at": "{0} 빌드",
+  "alt_logo": "npmx 로고",
+  "tagline": "최신 기술로 만들어진 빠른 npm 레지스트리 탐색기",
+  "non_affiliation_disclaimer": "npm, Inc.와는 관련이 없습니다.",
+  "trademark_disclaimer": "npm은 npm, Inc.의 등록 상표입니다. 이 사이트는 npm, Inc.와는 관련이 없는 사이트입니다.",
+  "footer": {
+    "about": "npmx에 대하여",
+    "blog": "블로그",
+    "docs": "공식 문서",
+    "source": "소스 코드",
+    "social": "SNS",
+    "chat": "채팅",
+    "builders_chat": "기여자 채팅",
+    "keyboard_shortcuts": "단축키",
+    "brand": "브랜드",
+    "resources": "정보",
+    "features": "기능",
+    "other": "기타"
+  },
+  "shortcuts": {
+    "section": {
+      "global": "전체",
+      "search": "검색",
+      "package": "패키지"
+    },
+    "ctrl_key": "Ctrl",
+    "command_palette": "명령 팔레트 열기",
+    "command_palette_description": "명령 팔레트을 통해 키보드 조작만으로 페이지를 이동하거나 패키지를 열람하고, 설정 메뉴를 열거나 외부 링크로 이동할 수 있습니다. macOS에서는 ⌘K를, Windows나 Linux에서는 {ctrlKey}+K키를 눌러 주세요.",
+    "focus_search": "검색 창으로 포커스 이동",
+    "show_kbd_hints": "단축키 표시를 강조",
+    "settings": "설정",
+    "compare": "패키지 비교하기",
+    "compare_from_package": "패키지 비교 (현재 패키지 자동 입력)",
+    "navigate_results": "위/아래 검색 항목 선택",
+    "go_to_result": "검색 결과로 이동",
+    "open_code_view": "코드 뷰 열기",
+    "open_docs": "문서 보기",
+    "disable_shortcuts": "{settings}에서 단축키를 비활성화할 수 있습니다.",
+    "open_main": "주요 정보 보기",
+    "open_diff": "버전 비교하기",
+    "open_timeline": "타임라인 보기"
+  },
+  "search": {
+    "label": "npm 패키지 검색",
+    "placeholder": "패키지를 검색해 보세요.",
+    "button": "검색",
+    "searching": "검색 중...",
+    "found_packages": "{count}개의 패키지를 찾았습니다.",
+    "found_packages_sorted": "상위 {count}건의 결과를 정렬하는 중입니다.",
+    "updating": "(갱신 중...)",
+    "no_results": "“{query}”에 해당하는 패키지를 찾을 수 없습니다.",
+    "rate_limited": "npm의 API 호출 속도 제한에 다다랐습니다. 잠시 후에 다시 시도해 주세요.",
+    "title": "검색",
+    "title_search": "검색: {search}",
+    "title_packages": "패키지 검색",
+    "meta_description": "“{search}”에 대한 검색 결과",
+    "meta_description_packages": "npm 패키지 검색",
+    "not_taken": "{name}@.koreanEun:{name} 등록 가능합니다.",
+    "claim_prompt": "npm에 패키지 등록",
+    "claim_button": "“{name}”@.koreanEul:{name} 등록",
+    "want_to_claim": "이 이름으로 패키지를 등록하시겠습니까?",
+    "start_typing": "위 검색 창에 입력하여 패키지를 검색해 보세요.",
+    "algolia_disclaimer": "Algolia에 의해 제공됨",
+    "exact_match": "정확히 일치",
+    "suggestion": {
+      "user": "사용자",
+      "org": "조직",
+      "view_user_packages": "이 사용자의 패키지 보기",
+      "view_org_packages": "이 조직의 패키지 보기"
+    },
+    "instant_search": "즉시 검색 기능",
+    "instant_search_on": "활성화됨",
+    "instant_search_off": "비활성화됨",
+    "instant_search_turn_on": "활성화하기",
+    "instant_search_turn_off": "비활성화하기",
+    "instant_search_advisory": "{label} {state} — {action}"
+  },
+  "command_palette": {
+    "title": "명령어 팔레트",
+    "quick_actions": "빠르게 이동",
+    "subtitle": "npmx 내에서 빠르게 페이지를 이동하거나 설정을 변경할 수 있습니다.",
+    "subtitle_languages": "언어를 선택하거나 번역 개선에 도움을 줄 수 있습니다.",
+    "instructions": "입력하여 명령어를 필터링할 수 있습니다. 화살표 키로 이동하고, 엔터 키로 실행 가능합니다.",
+    "input_label": "명령어 팔레트 검색",
+    "results_label": "명령어 검색 결과",
+    "placeholder": "명령어를 입력해 보세요.",
+    "back": "뒤로 가기",
+    "empty": "일치하는 명령어가 없습니다.",
+    "empty_search_hint": "“{query}”를 검색하시려면 엔터 키를 눌러 주세요.",
+    "current": "선택됨",
+    "here": "현재 페이지",
+    "connected": "연결됨",
+    "state": {
+      "on": "활성화됨",
+      "off": "비활성화됨"
+    },
+    "groups": {
+      "actions": "액션",
+      "help": "도움말",
+      "language": "언어",
+      "connections": "연결",
+      "navigation": "이동",
+      "links": "링크",
+      "npmx": "npmx",
+      "package": "패키지",
+      "package_with_name": "패키지 ({name})",
+      "versions": "버전",
+      "versions_with_name": "{name}의 버전"
+    },
+    "actions": {
+      "search": "검색",
+      "search_for": "“{query}” 검색",
+      "keyboard_shortcuts": "단축키",
+      "help_translate": "번역에 도움 주기"
+    },
+    "connections": {
+      "npm_connect": "npm CLI에 연결",
+      "npm_connected": "npm CLI (~{username})",
+      "npm_disconnect": "npm CLI와의 연결 해제",
+      "atmosphere_connect": "Atmosphere에 연결",
+      "atmosphere_connected": "atmosphere ({'@'}{handle})",
+      "atmosphere_disconnect": "Atmosphere와의 연결 해제"
+    },
+    "navigation": {
+      "home": "홈",
+      "packages": "패키지 (~{username})",
+      "orgs": "조직 (~{username})",
+      "profile": "프로필 ({'@'}{handle})"
+    },
+    "links": {
+      "external": "외부 링크"
+    },
+    "package_links": {
+      "stars": "리포지터리의 스타 수",
+      "forks": "리포지터리의 포크 수"
+    },
+    "theme": {
+      "system": "시스템 테마 사용",
+      "light": "라이트 모드 사용",
+      "dark": "다크 모드 사용"
+    },
+    "package": {
+      "main": "패키지 정보",
+      "docs": "문서 탐색",
+      "code": "코드 탐색",
+      "diff": "버전 비교",
+      "compare": "다른 패키지와 비교하기",
+      "download": "tarball 다운로드",
+      "changelog": "변경 기록"
+    },
+    "package_actions": {
+      "copy_run": "실행 명령어 복사하기"
+    },
+    "code": {
+      "copy_file": "파일 내용 복사하기"
+    },
+    "diff": {
+      "merge_modified_lines": "수정된 행 합치기",
+      "word_wrap": "자동 줄 바꿈"
+    },
+    "version": {
+      "label": "{version}"
+    },
+    "status": {
+      "available_in_context": "{context}. 사용할 수 있는 명령어가 없습니다.|{context}. 1개의 명령어를 사용할 수 있습니다.|{context}. {count}개의 명령어를 사용할 수 있습니다.",
+      "matching_in_context": "{context}. 일치하는 명령어가 없습니다.|{context}. 1개의 명령어가 일치합니다.|{context}. {count}개의 명령어가 일치합니다.",
+      "no_matches_search_in_context": "{context}. 일치하는 명령어가 없습니다. 엔터 키를 눌러 “{query}”@.koreanEul:{query} 검색합니다."
+    },
+    "announcements": {
+      "language_changed": "언어를 {language}로 변경했습니다.",
+      "relative_dates_on": "상대적 날짜 표기를 활성화했습니다.",
+      "relative_dates_off": "상대적 날짜 표기를 비활성화했습니다.",
+      "theme_changed": "테마를 {theme}로 설정했습니다.",
+      "accent_color_changed": "테마 색상을 {color}로 변경했습니다.",
+      "background_theme_changed": "배경 색상을 {theme}로 변경했습니다.",
+      "download_started": "{package}의 tarball을 다운로드하는 중입니다.",
+      "copied_to_clipboard": "클립보드에 복사했습니다.",
+      "npm_disconnected": "npm CLI와의 연결을 해제했습니다.",
+      "atmosphere_disconnected": "Atmosphere와의 연결을 해제했습니다.",
+      "facets_all_selected": "모든 비교 항목을 선택했습니다.",
+      "facets_all_deselected": "모든 비교 항목을 선택 해제했습니다.",
+      "view_switched": "{view} 뷰로 변경되었습니다.",
+      "setting_toggled": "{setting}@.koreanEul:{settings} {state}@.koreanRo:{state} 변경했습니다."
+    }
+  },
+  "nav": {
+    "main_navigation": "메인 내비게이션",
+    "popular_packages": "인기 패키지",
+    "settings": "설정",
+    "compare": "비교",
+    "back": "뒤로 가기",
+    "menu": "메뉴",
+    "mobile_menu": "내비게이션 메뉴",
+    "open_menu": "메뉴 열기",
+    "links": "링크",
+    "tap_to_search": "탭하여 검색하기"
+  },
+  "blog": {
+    "title": "블로그",
+    "heading": "블로그",
+    "meta_description": "npmx 커뮤니티가 공유하는 최신 소식과 인사이트",
+    "author": {
+      "view_profile": "Bluesky에서 {name}의 프로필 표시"
+    },
+    "draft_badge": "초안",
+    "draft_banner": "이 글은 공개되지 않은 초안입니다. 내용이 불완전하거나, 부정확한 내용을 담고 있을 수 있습니다.",
+    "no_posts": "글이 없습니다.",
+    "atproto": {
+      "view_on_bluesky": "Bluesky에서 보기",
+      "reply_on_bluesky": "Bluesky에서 댓글 쓰기",
+      "likes_on_bluesky": "Bluesky에서 좋아요 누르기",
+      "like_or_reply_on_bluesky": "Bluesky에서 이 글에 좋아요를 누르거나 댓글 쓰기",
+      "no_comments_yet": "댓글이 아직 없습니다.",
+      "could_not_load_comments": "댓글을 불러오지 못했습니다.",
+      "comments": "댓글",
+      "loading_comments": "댓글을 불러오는 중입니다.",
+      "updating": "갱신 중...",
+      "reply_count": "댓글 {count}개",
+      "like_count": "좋아요 {count}개",
+      "repost_count": "리포스트 {count}개",
+      "more_replies": "댓글 {count}개 더 보기"
+    }
+  },
+  "settings": {
+    "title": "설정",
+    "tagline": "npmx 경험 사용자화하기",
+    "meta_description": "테마, 언어 혹은 기타 표시 설정을 변경하여 나에게 맞는 npmx 경험을 만듭니다.",
+    "sections": {
+      "appearance": "디자인",
+      "display": "표시",
+      "search": "검색",
+      "language": "언어",
+      "keyboard_shortcuts": "단축키"
+    },
+    "data_source": {
+      "label": "검색 데이터 소스",
+      "description": "npmx가 검색 데이터를 받아올 곳을 선택합니다. 개별 패키지 데이터는 이 설정과 관계 없이 항상 npm 레지스트리에서 가져옵니다.",
+      "npm": "npm 레지스트리",
+      "npm_description": "공식 npm 레지스트리에서 검색하여 조직과 사용자 정보를 가져옵니다. 정확하지만 속도가 느린 경우가 있습니다.",
+      "algolia": "Algolia",
+      "algolia_description": "Algolia를 사용하여 조직과 사용자 정보를 가져옵니다."
+    },
+    "instant_search": "즉시 검색",
+    "instant_search_description": "입력 도중에 검색 페이지로 이동하여 검색 결과를 갱신합니다.",
+    "relative_dates": "상대적 날짜 표기",
+    "include_types": "패키지 설치 시에 {'@'}types를 포함",
+    "include_types_description": "타입 정의가 없는 패키지의 경우 설치 명령어에 {'@'}types로 시작하는 타입 정의 패키지를 추가합니다.",
+    "hide_platform_packages": "검색 결과에서 플랫폼별 패키지 제외",
+    "hide_platform_packages_description": "검색 결과에서 {'@'}esbuild/linux-x64와 같이 OS나 CPU 아키텍처에 종속적인 네이티브 바이너리 패키지를 표시하지 않습니다.",
+    "enable_graph_pulse_loop": "미니 그래프의 펄스 애니메이션 효과 반복 재생",
+    "enable_graph_pulse_loop_description": "주간 다운로드 그래프에 펄스 애니메이션 효과를 활성화합니다. 일부 사용자의 경우 이 효과가 눈에 거슬릴 수 있습니다.",
+    "theme": "테마",
+    "theme_light": "라이트 모드",
+    "theme_dark": "다크 모드",
+    "theme_system": "시스템 테마",
+    "language": "언어",
+    "help_translate": "npmx 번역에 도움 주기",
+    "translation_status": "전체 번역 현황 확인",
+    "accent_colors": {
+      "label": "테마 색상",
+      "neutral": "뉴트럴",
+      "sky": "파란색",
+      "coral": "빨간색",
+      "amber": "주황색",
+      "emerald": "녹색",
+      "violet": "보라색",
+      "magenta": "자주색"
+    },
+    "clear_accent": "테마 색상 제거",
+    "translation_progress": "번역 진행 상황",
+    "background_themes": {
+      "label": "배경 색상",
+      "neutral": "뉴트럴",
+      "stone": "스톤",
+      "zinc": "징크",
+      "slate": "슬레이트",
+      "black": "블랙"
+    },
+    "keyboard_shortcuts_enabled": "단축키 활성화",
+    "keyboard_shortcuts_enabled_description": "브라우저나 시스템 단축키와 충돌하는 경우, 단축키를 비활성화할 수 있습니다.",
+    "enable_code_ligatures": "코드 폰트의 리가처(합자) 기능 활성화",
+    "enable_changelog_autoscroll": "변경 기록에서 선택한 버전으로 자동 스크롤 활성화",
+    "enable_changelog_autoscroll_description": "패키지의 변경 기록에서 선택한 버전 혹은 그 근처로 자동 스크롤합니다."
+  },
+  "i18n": {
+    "missing_keys": "미번역된 항목 {count}개",
+    "copy_keys": "미번역 항목 복사하기",
+    "show_more_keys": "기타 {count}개 보이기",
+    "contribute_hint": "아직 번역되지 않은 항목을 번역하여 번역 작업에 도움을 주세요.",
+    "edit_on_github": "GitHub에서 편집하기",
+    "view_guide": "번역 가이드"
+  },
+  "error": {
+    "401": "인증 오류",
+    "404": "페이지를 찾을 수 없습니다.",
+    "500": "내부 서버 오류",
+    "503": "서비스를 이용할 수 없습니다.",
+    "default": "문제가 발생했습니다."
+  },
+  "common": {
+    "loading": "불러오는 중...",
+    "loading_more": "더 불러오는 중...",
+    "loading_packages": "패키지를 불러오는 중...",
+    "end_of_results": "마지막 결과입니다.",
+    "try_again": "다시 한번 시도해 주세요.",
+    "close": "닫기",
+    "or": "또는",
+    "retry": "재시도",
+    "copy": "복사",
+    "copied": "복사했습니다!",
+    "skip_link": "메인 컨텐츠로 이동",
+    "warnings": "경고:",
+    "go_back_home": "홈으로 돌아가기",
+    "per_week": "/ 주",
+    "per_week_short": "/주",
+    "vanity_downloads_hint": "자만심 수치: 표시된 패키지가 없습니다.|자만심 수치: 표시된 패키지의 주당 다운로드 수|자만심 수치: 표시된 {count}개 패키지의 주당 다운로드 수의 합계",
+    "sort": {
+      "name": "이름",
+      "role": "역할",
+      "members": "멤버"
+    },
+    "scroll_to_top": "상단으로 이동",
+    "cancel": "취소",
+    "save": "저장",
+    "edit": "편집",
+    "error": "에러",
+    "view_on": {
+      "npm": "npm에서 보기",
+      "github": "GitHubで表示",
+      "gitlab": "GitLab에서 보기",
+      "bitbucket": "Bitbucket에서 보기",
+      "codeberg": "Codeberg에서 보기",
+      "git_repo": "Gitリポジトリ에서 보기",
+      "forgejo": "Forgejo에서 보기",
+      "gitea": "Gitea에서 보기",
+      "gitee": "Gitee에서 보기",
+      "radicle": "Radicle에서 보기",
+      "socket_dev": "socket.dev에서 보기",
+      "sourcehut": "SourceHut에서 보기",
+      "tangled": "Tangled에서 보기"
+    },
+    "collapse": "접기",
+    "collapse_with_name": "{name} 접기",
+    "expand": "펼치기",
+    "expand_with_name": "{name} 펼치기"
+  },
+  "profile": {
+    "display_name": "이름",
+    "description": "설명",
+    "no_description": "설명 없음",
+    "website": "홈페이지",
+    "website_placeholder": "https://example.com",
+    "likes": "좋아요",
+    "seo_title": "{handle} - npmx",
+    "seo_description": "{handle}의 npmx 프로필",
+    "not_found": "프로필을 찾을 수 없습니다.",
+    "not_found_message": "{handle}의 프로필을 찾을 수 없습니다.",
+    "invite": {
+      "message": "아직 npmx를 이용하고 있지 않습니다. npmx를 추천해 보시겠어요?",
+      "share_button": "Bluesky로 공유",
+      "compose_text": "{'@'}{handle} 님, npmx.dev에 대해 들어 보셨나요? 최신 기술을 사용해 빠른 npm 레지스트리 탐색기입니다!\nhttps://npmx.dev"
+    }
+  },
+  "package": {
+    "not_found": "패키지를 찾을 수 없습니다.",
+    "not_found_message": "패키지를 찾을 수 없습니다.",
+    "no_description": "설명이 없습니다.",
+    "verified_provenance": "패키지 출처 검증됨",
+    "navigation": "패키지 메뉴",
+    "copy_name": "패키지 이름 복사",
+    "deprecation": {
+      "package": "이 패키지는 지원이 중단되었습니다.",
+      "version": "이 버전은 지원이 중단되었습니다.",
+      "no_reason": "이유는 밝혀지지 않았습니다."
+    },
+    "size_increase": {
+      "title_size": "v{version}@.koreanRo:{version}부터 패키지 크기 대폭 증가",
+      "title_deps": "v{version}@.koreanRo:{version}부터 의존성 개수 대폭 증가",
+      "title_both": "v{version}@.koreanRo:{version}부터 패키지 크기와 의존성 개수 대폭 증가",
+      "size": "설치 시 크기 {percent} ({size}) 증가",
+      "deps": "의존성 {count}개 증가"
+    },
+    "size_decrease": {
+      "title_size": "v{version}@.koreanRo:{version}부터 패키지 크기가 감소했습니다!",
+      "title_deps": "v{version}@.koreanRo:{version}부터 의존성 개수가 감소했습니다!",
+      "title_both": "v{version}@.koreanRo:{version}부터 패키지 크기와 의존성 개수가 감소했습니다!",
+      "size": "설치 시 크기 {percent} ({size}) 감소",
+      "deps": "의존성 {count}개 감소"
+    },
+    "replacement": {
+      "title": "이 의존성은 불필요할 수 있습니다.",
+      "example": "예시:",
+      "native": "이 패키지는 Node {nodeVersion}부터 사용 가능한 {replacement}으로 대체할 수 있습니다.",
+      "native_no_version": "이 패키지는 {replacement}으로 대체할 수 있습니다.",
+      "simple": "{community}@.koreanEun:{community}는 이 패키지가 필요하지 않다고 여깁니다. {replacement}",
+      "documented": "{community}@.koreanEun:{community}는 이 패키지보다 성능 면에서 우수한 패키지로 대체를 권합니다.",
+      "none": "이 패키지는 더 이상 필요하지 않다고 여겨지며, 이 패키지의 기능은 모든 엔진에서 의존성 없이 사용 가능해 보입니다.",
+      "learn_more": "자세히 보기",
+      "learn_more_above": "자세한 사항은 위를 참고해 주세요.",
+      "community": "커뮤니티",
+      "consider_no_dep": "+ 의존성을 제거하려고 하고 계신가요?"
+    },
+    "stats": {
+      "license": "라이선스",
+      "deps": "의존성",
+      "install_size": "설치 시 크기",
+      "vulns": "취약점",
+      "published": "공개일",
+      "published_tooltip": "{package}{'@'}{version}@.koreanI:{version} 공개된 날짜",
+      "view_dependency_graph": "의존성 그래프 보기",
+      "inspect_dependency_tree": "의존성 트리 검사",
+      "size_tooltip": {
+        "unpacked": "압축 해제 후 크기: {size} (이 패키지만)",
+        "total": "압축 해제 후 총 크기: {size} (linux-x64용 의존성 {count}개 포함)"
+      }
+    },
+    "skills": {
+      "title": "에이전트 스킬",
+      "skills_available": "에이전트 스킬 {count}개 사용 가능",
+      "compatible_with": "{tool}과 호환됨",
+      "install": "설치",
+      "installation_method": "설치 방법",
+      "learn_more": "자세히 보기",
+      "available_skills": "사용 가능한 스킬",
+      "click_to_expand": "클릭하여 펼치기",
+      "no_description": "설명 없음",
+      "file_counts": {
+        "scripts": "스크립트 {count}개",
+        "refs": "참조 {count}개",
+        "assets": "애셋 {count}개"
+      },
+      "view_source": "소스 코드 보기",
+      "skills_cli": "skills CLI"
+    },
+    "links": {
+      "main": "메인",
+      "repo": "리포지터리",
+      "homepage": "홈페이지",
+      "issues": "이슈",
+      "jsr": "jsr",
+      "code": "코드",
+      "docs": "문서",
+      "fund": "후원하기",
+      "compare": "비교",
+      "timeline": "타임라인",
+      "compare_this_package": "다른 패키지와 비교하기",
+      "changelog": "변경 기록"
+    },
+    "likes": {
+      "like": "이 패키지에 좋아요 누르기",
+      "unlike": "이 패키지의 좋아요 해제하기",
+      "top_rank_tooltip": "이 패키지는 npmx에서 가장 좋아요를 많이 받은 상위 10개의 패키지 중 하나입니다! ({rank}위)",
+      "top_rank_label": "#{rank}",
+      "top_rank_link_label": "좋아요 랭킹 페이지를 엽니다. 이 패키지는 {rank}위입니다."
+    },
+    "docs": {
+      "contents": "목차",
+      "default_not_available": "이 버전에서는 문서를 열람할 수 없습니다.",
+      "not_available": "문서를 열람할 수 없습니다.",
+      "not_available_detail": "이 버전의 문서 생성에 실패했습니다.",
+      "page_title": "API 문서 - npmx",
+      "page_title_name": "{name}의 문서 - npmx",
+      "page_title_version": "{name}의 문서 - npmx",
+      "og_title": "{name} - 문서",
+      "view_package": "패키지 보기"
+    },
+    "get_started": {
+      "title": "시작하기",
+      "pm_label": "패키지 매니저",
+      "copy_command": "설치 명령어 복사하기",
+      "copy_dev_command": "개발용 의존성 설치 명령어 복사하기",
+      "dev_dependency_hint": "이 패키지는 보통 개발용 의존성으로 설치됩니다.",
+      "view_types": "{package} 보기"
+    },
+    "create": {
+      "title": "새 프로젝트 생성",
+      "copy_command": "프로젝트 생성 명령어 복사하기",
+      "view": "{packageName}@.koreanEun:{packageName} 이 패키지와 같은 메인테이너가 관리하고 있습니다. 클릭하여 프로젝트 생성 패키지 페이지로 이동할 수 있습니다."
+    },
+    "run": {
+      "title": "실행",
+      "locally": "로컬에서 실행"
+    },
+    "readme": {
+      "title": "Readme",
+      "no_readme": "README가 없습니다.",
+      "toc_title": "목차",
+      "callout": {
+        "note": "메모",
+        "tip": "팁",
+        "important": "중요",
+        "warning": "경고",
+        "caution": "주의"
+      },
+      "copy_as_markdown": "README를 Markdown 형식으로 복사하기",
+      "error_loading": "README를 불러오는 데 실패했습니다."
+    },
+    "provenance_section": {
+      "title": "패키지 출처",
+      "built_and_signed_on": "{provider}로 빌드 및 서명됨",
+      "view_build_summary": "빌드 요약 표시",
+      "source_commit": "소스 커밋",
+      "build_file": "빌드 파일",
+      "public_ledger": "공개 원장 (Public Ledger)",
+      "transparency_log_entry": "투명성 로그 엔트리",
+      "view_more_details": "자세히 보기",
+      "error_loading": "패키지 출처 정보를 불러오는 데 실패했습니다."
+    },
+    "security_downgrade": {
+      "title": "신뢰도 저하",
+      "description_to_none_provenance": "이 버전은 {provenance} 없이 공개되었습니다.",
+      "description_to_none_trustedPublisher": "이 버전은 {trustedPublishing} 없이 공개되었습니다.",
+      "description_to_provenance_trustedPublisher": "이 버전은 {provenance}를 사용하고 있습니다만, {trustedPublishing}는 사용하고 있지 않습니다.",
+      "fallback_install_provenance": "설치 명령어는 패키지 출처 정보가 부여된 마지막 버전 {version}@.koreanRo:{version} 고정되어 있습니다.",
+      "fallback_install_trustedPublisher": "설치 명령어는 신뢰할 수 있는 배포를 통해 공개된 마지막 버전 {version}@.koreanRo:{version} 고정되어 있습니다.",
+      "provenance_link_text": "패키지 출처 정보",
+      "trusted_publishing_link_text": "신뢰할 수 있는 배포"
+    },
+    "keywords_title": "키워드",
+    "compatibility": "호환성",
+    "card": {
+      "publisher": "배포자",
+      "published": "공개됨",
+      "weekly_downloads": "주간 다운로드 수",
+      "keywords": "키워드",
+      "license": "라이선스",
+      "version": "버전",
+      "select": "패키지 선택",
+      "select_maximum": "패키지를 최대 {count}개 선택할 수 있습니다."
+    },
+    "versions": {
+      "title": "버전",
+      "collapse": "{tag} 접기",
+      "expand": "{tag} 펼치기",
+      "collapse_other": "다른 버전 접기",
+      "expand_other": "다른 버전 펼치기",
+      "collapse_major": "메이저 버전 {major} 접기",
+      "expand_major": "메이저 버전 {major} 펼치기",
+      "other_versions": "다른 버전",
+      "more_tagged": "이외 태그 {count}개",
+      "all_covered": "모든 버전이 위 태그에 포함되어 있습니다.",
+      "deprecated_title": "{version} (지원 중단)",
+      "view_all": "버전 {count}개 보기|모든 버전 {count}개 보기",
+      "view_all_versions": "모든 버전 보기",
+      "distribution_title": "Semver 그룹",
+      "distribution_modal_title": "버전",
+      "distribution_range_date_same_year": "{endYear}년 {from}부터 {to}까지",
+      "distribution_range_date_multiple_years": "{startYear}년 {from}부터 {endYear}년 {to}까지",
+      "grouping_major": "메이저",
+      "grouping_minor": "마이너",
+      "grouping_versions_title": "버전",
+      "grouping_versions_about": "버전 그루핑에 대하여",
+      "grouping_versions_all": "모두",
+      "grouping_versions_only_recent": "1년 내",
+      "grouping_usage_title": "사용 현황",
+      "grouping_usage_about": "사용 현황의 그루핑에 대하여",
+      "grouping_usage_all": "모두",
+      "grouping_usage_most_used": "인기 버전",
+      "recent_versions_only_tooltip": "1년 이내에 공개된 버전만 표시합니다.",
+      "show_low_usage_tooltip": "총 다운로드 수의 1% 미만인 버전들도 포함합니다.",
+      "y_axis_label": "다운로드 수",
+      "filter_placeholder": "Semver로 필터링 (예: ^3.0.0)",
+      "filter_invalid": "올바르지 않은 semver 범위입니다.",
+      "filter_help": "Semver 범위 필터 도움말",
+      "filter_tooltip": "{link}를 사용하여 버전을 필터링합니다. 예를 들어, ^3.0.0은 3.x 버전을 모두 포함합니다.",
+      "filter_tooltip_link": "Semver 범위",
+      "license_change_help": "라이선스 변경 상세 정보",
+      "license_change_warning": "이전 버전으로부터 라이선스가 변경되었습니다.",
+      "license_change_record": "이 패키지의 라이선스가 “{from}”에서 “{to}”@.koreanRo:{to} 변경되었습니다.",
+      "no_matches": "이 범위에 해당하는 버전이 없습니다.",
+      "copy_alt": {
+        "per_version_analysis": "버전 {version}@.koreanEun:{version} {downloads}번 다운로드 되었습니다.",
+        "general_description": "패키지 {package_name}의 {semver_grouping_mode} 버전 {versions_count}개에 대한 버전별 다운로드 수 막대 그래프입니다. 기간은 {date_range_label}({first_version}부터 {last_version}까지)입니다. 최다 다운로드 버전은 {max_downloaded_version}이고, 다운로드 수는 {max_version_downloads}입니다. {per_version_analysis} {watermark}"
+      },
+      "page_title": "버전 이력",
+      "current_tags": "현재 태그",
+      "no_match_filter": "{filter}에 해당하는 버전이 없습니다."
+    },
+    "timeline": {
+      "load_more": "더 불러오기",
+      "load_error": "타임라인을 불러오는 데 실패했습니다. 나중에 다시 시도해 주세요.",
+      "size_increase": "설치 시 크기 {percent}% ({size}) 증가",
+      "size_decrease": "설치 시 크기 {percent}% ({size}) 감소",
+      "dep_increase": "의존성 {count}개 증가",
+      "dep_decrease": "의존성 {count}개 감소",
+      "license_change": "라이선스가 {from}에서 {to}@.koreanRo:{to} 변경됨",
+      "esm_added": "모듈 타입이 ESM으로 변경됨",
+      "esm_removed": "모듈 타입이 ESM에서 CJS로 변경됨",
+      "types_added": "TypeScript 타입 정의 추가",
+      "types_removed": "TypeScript 타입 정의 삭제",
+      "trusted_publisher_added": "신뢰할 수 있는 배포 활성화",
+      "trusted_publisher_removed": "신뢰할 수 있는 배포 비활성화",
+      "provenance_added": "패키지 출처 활성화",
+      "provenance_removed": "패키지 출처 비활성화",
+      "chart": {
+        "tab_aria_label": "데이터 선택",
+        "base_scale": "Y축 0부터 시작",
+        "zoom": "범위 지정",
+        "reset_minimap": "미니맵 초기화",
+        "ordered_versions": "안정 버전만",
+        "copy_alt": {
+          "key_changes": "주요 변경 사항: {version_events}",
+          "version_events": "버전 {version}: {events}",
+          "general_description": "패키지 {package}의 {metric}@.koreanEul:{metric} 버전 {first}부터 {last}까지 나타낸 꺾은선 그래프입니다. 버전 {first}의 {metric}@.koreanEun:{metric} {first_value}이고, 버전 {last}에서는 {last_value}(전체적으로 {overall_progress_percentage}% 변화)입니다. {key_changes} {watermark}"
+        }
+      }
+    },
+    "dependencies": {
+      "title": "의존성 ({count})",
+      "list_label": "패키지의 의존성",
+      "show_all": "의존성 {count}개를 모두 표시",
+      "optional": "선택",
+      "view_vulnerabilities": "취약점 정보 표시",
+      "outdated_major": "최신 버전과 비교하여 메이저 버전이 {count}단계 이전 버전입니다. (최신 버전: {latest})",
+      "outdated_minor": "최신 버전과 비교하여 마이너 버전이 {count}단계 이전 버전입니다. (최신 버전: {latest})",
+      "outdated_patch": "패치 업데이트가 있습니다. (최신 버전: {latest})",
+      "has_replacement": "이 의존성은 대체할 수 있는 패키지가 있습니다.",
+      "vulnerabilities_count": "{count}개의 취약점"
+    },
+    "peer_dependencies": {
+      "title": "피어 의존성 ({count})",
+      "list_label": "패키지의 피어 의존성",
+      "show_all": "피어 의존성 {count}개를 모두 표시"
+    },
+    "optional_dependencies": {
+      "title": "선택적 의존성 ({count})",
+      "list_label": "패키지의 선택적 의존성",
+      "show_all": "선택적 의존성 {count}개를 모두 표시"
+    },
+    "maintainers": {
+      "title": "메인테이너",
+      "list_label": "패키지의 메인테이너",
+      "you": "(나)",
+      "via": "{teams}@.koreanEul:{teams} 통해",
+      "remove_owner": "{name}@.koreanEul:{name} 소유자에서 제거",
+      "username_to_add": "소유자에 추가할 사용자 이름",
+      "username_placeholder": "사용자 이름...",
+      "add_button": "추가",
+      "cancel_add": "소유자 추가 취소",
+      "add_owner": "+ 소유자 추가",
+      "show_more": "(이외 {count}명 표시)",
+      "show_less": "(접기)",
+      "maintainer_template": "{avatar} {char126}{name}"
+    },
+    "trends": {
+      "chart_assistive_text": {
+        "keyboard_navigation_horizontal": "좌우 화살표 키로 데이터 포인트 이동이 가능합니다.",
+        "keyboard_navigation_vertical": "상하 화살표 키로 데이터 포인트 이동이 가능합니다.",
+        "table_available": "아래에서 이 차트의 데이터 테이블을 볼 수 있습니다.",
+        "table_caption": "차트 데이터 테이블"
+      },
+      "chart_view_toggle": "표시 방법 선택",
+      "chart_view_combined": "동시 표시",
+      "chart_view_split": "분할 표시",
+      "granularity": "시간 단위",
+      "granularity_daily": "일별",
+      "granularity_weekly": "주별",
+      "granularity_monthly": "월별",
+      "granularity_yearly": "연도별",
+      "start_date": "시작 날짜",
+      "end_date": "마지막 날짜",
+      "loading": "読み込み中...",
+      "date_range": "{start}부터 {end}까지",
+      "date_range_multiline": "{start}부터\n{end}까지",
+      "download_file": "{fileType} 다운로드",
+      "toggle_annotator": "차트 메모 표시/비표시",
+      "toggle_stack_mode": "상하 분할 모드 켜기/끄기",
+      "open_options": "옵션 열기",
+      "close_options": "옵션 닫기",
+      "legend_estimation": "추정치",
+      "no_data": "데이터가 없습니다.",
+      "y_axis_label": "{granularity} {facet}",
+      "facet": "항목",
+      "title": "추이",
+      "contributors_skip": "기여자에 표시되지 않습니다 (GitHub 리포지터리 없음):",
+      "items": {
+        "downloads": "다운로드 수",
+        "likes": "좋아요 수",
+        "contributors": "기여자"
+      },
+      "data_correction": "데이터 보정",
+      "average_window": "이동 평균 윈도우",
+      "smoothing": "평활화",
+      "prediction": "예측치",
+      "known_anomalies": "알려진 이상치 보정",
+      "known_anomalies_description": "봇이나 CI의 이상으로 인해 발생한 알려진 다운로드 수 급증을 보정합니다.",
+      "known_anomalies_ranges": "이상치 범위",
+      "known_anomalies_range": "{start}부터 {end}까지",
+      "known_anomalies_range_named": "{packageName}: {start}부터 {end}까지",
+      "known_anomalies_none": "이 패키지의 알려진 이상치는 없습니다.|이 패키지들의 알려진 이상치는 없습니다.",
+      "known_anomalies_contribute": "이상치 데이터 제공",
+      "apply_correction": "보정 적용",
+      "copy_alt": {
+        "trend_none": "거의 평탄한",
+        "trend_strong": "강한",
+        "trend_weak": "약한",
+        "trend_undefined": "불확실(데이터 부족)한",
+        "button_label": "대체 텍스트 복사하기",
+        "watermark": "하단에 “./npmx @:tagline” 워터마크가 있습니다.",
+        "analysis": "{package_name}@.koreanEun:{package_name} {start_value}에서 시작하여 {end_value}@.koreanRo:{end_value}로 끝남. {trend} 경향을 보여주고, 단위 시간당 다운로드 수의 비율은 {downloads_slope}입니다.",
+        "estimation": "최종 값은 현재 기간의 부분적 데이터에 기반한 추정치입니다.",
+        "estimations": "최종 값은 현재 기간의 부분적 데이터에 기반한 추정치입니다.",
+        "compare": "패키지 다운로드 수 비교용 꺾은선 그래프: {packages}",
+        "single_package": "{package} 패키지의 다운로드 수 꺾은선 그래프",
+        "general_description": "Y축은 다운로드 수, X축은 {start_date}부터 {end_date}까지의 기간(단위: {granularity})을 나타냅니다. {estimation_notice} {packages_analysis} {watermark}",
+        "facet_bar_general_description": "{packages}의 가로 막대그래프: {facet} 비교 ({description}) {facet_analysis} {watermark}",
+        "facet_bar_analysis": "{package_name}의 값은 {value}입니다."
+      }
+    },
+    "downloads": {
+      "title": "주간 다운로드 수",
+      "version_distribution_title": "버전 {version}의 주간 다운로드 수",
+      "community_distribution": "커뮤니티 채택 분포 보기",
+      "subtitle": "모든 버전의 합계",
+      "sparkline_nav_hint": "← → 키를 이용해 주세요."
+    },
+    "install_scripts": {
+      "title": "설치 스크립트",
+      "script_label": "(스크립트)",
+      "npx_packages": "npx 패키지 {count}개",
+      "currently": "현재 {version}"
+    },
+    "playgrounds": {
+      "title": "사용해 보기",
+      "choose": "플레이그라운드 선택"
+    },
+    "metrics": {
+      "esm": "ES 모듈 지원",
+      "cjs": "CommonJS 지원",
+      "no_esm": "ES 모듈 미지원",
+      "wasm": "WebAssembly 포함",
+      "types_label": "타입 정의",
+      "types_included": "타입 정의 포함",
+      "types_available": "“{package}”@.koreanRo:{package} 타입 정의 사용 가능",
+      "no_types": "타입 정의 없음"
+    },
+    "license": {
+      "view_spdx": "SPDX로 라이선스 조문 보기",
+      "none": "없음"
+    },
+    "vulnerabilities": {
+      "tree_found": "패키지 {total}개 중 {packages}개에서 취약점 총 {vulns}개 발견",
+      "show_all_packages": "영향을 받은 패키지 {count}개 모두 보기",
+      "path": "의존성 경로 보기",
+      "more": "이외 {count}개",
+      "packages_failed": "패키지 {count}개를 검사할 수 없었습니다.",
+      "scan_failed": "취약점 검사에 실패했습니다.",
+      "severity": {
+        "critical": "긴급",
+        "high": "높음",
+        "moderate": "중간",
+        "low": "낮음"
+      },
+      "fixed_in_title": "버전 {version}에서 수정됨"
+    },
+    "deprecated": {
+      "label": "지원 중단",
+      "tree_found": "지원 중단된 의존성 {count}개 발견",
+      "show_all": "지원 중단된 의존성 {count}개 모두 보기"
+    },
+    "access": {
+      "title": "팀 접근 권한",
+      "refresh": "팀 접근 권한 새로고침",
+      "list_label": "팀 접근 권한 목록",
+      "owner": "소유자",
+      "rw": "읽고 쓰기(rw)",
+      "ro": "읽기 전용(ro)",
+      "revoke_access": "{name}의 접근 권한 삭제",
+      "no_access": "팀 접근 권한이 설정되어 있지 않습니다.",
+      "select_team_label": "팀 선택",
+      "loading_teams": "팀을 불러오는 중입니다.",
+      "select_team": "팀 선택",
+      "permission_label": "권한 레벨",
+      "permission": {
+        "read_only": "읽기 전용",
+        "read_write": "읽고 쓰기"
+      },
+      "grant_button": "허가",
+      "cancel_grant": "접근 권한 부여를 취소합니다.",
+      "grant_access": "+ 팀 접근 권한 부여"
+    },
+    "list": {
+      "filter_label": "패키지 필터링",
+      "filter_placeholder": "패키지를 필터링해 보세요.",
+      "sort_label": "패키지 정렬",
+      "showing_count": "패키지 {total}개 중 {filtered}개를 표시하는 중"
+    },
+    "skeleton": {
+      "loading": "패키지 상세 정보를 불러오는 중입니다.",
+      "maintainers": "메인테이너",
+      "keywords": "키워드",
+      "versions": "버전",
+      "dependencies": "의존성"
+    },
+    "sort": {
+      "downloads": "다운로드순",
+      "published": "최신순",
+      "name_asc": "이름순(A-Z)",
+      "name_desc": "이름순(Z-A)"
+    },
+    "size": {
+      "b": "{size} B",
+      "kb": "{size} kB",
+      "mb": "{size} MB"
+    },
+    "download": {
+      "button": "다운로드",
+      "tarball": "Tarball (.tar.gz) 다운로드"
+    }
+  },
+  "leaderboard": {
+    "likes": {
+      "title": "좋아요 랭킹",
+      "description": "현재 npmx에서 가장 좋아요를 많이 받은 패키지 10개입니다.",
+      "rank": "순위",
+      "likes": "좋아요 수",
+      "unavailable_title": "좋아요 랭킹이 아직 없습니다.",
+      "unavailable_description": "표시할 수 있는 좋아요 랭킹 데이터가 없습니다."
+    }
+  },
+  "connector": {
+    "modal": {
+      "title": "로컬 커넥터",
+      "connected": "연결됨",
+      "connected_as_user": "~{user}@.koreanRo:{user} 연결됨",
+      "connected_hint": "Web UI에서 패키지와 조직 관리를 할 수 있게 되었습니다.",
+      "disconnect": "연결 해제",
+      "run_hint": "관리 기능을 활성화하려면 로컬 환경에서 커넥터를 실행해 주세요.",
+      "copy_command": "명령어 복사",
+      "copied": "복사했습니다!",
+      "paste_token": "그리고 아래 입력 창에 토큰을 붙여넣어 활성화할 수 있습니다.",
+      "token_label": "토큰",
+      "token_placeholder": "여기에 토큰 붙여넣기...",
+      "advanced": "고급 옵션",
+      "port_label": "포트",
+      "warning": "경고",
+      "warning_text": "아래 버튼을 누르면 npmx가 npm CLI에 접근할 수 있게 됩니다. 신뢰할 수 있는 사이트에만 연결해 주세요.",
+      "connect": "연결",
+      "connecting": "연결 중...",
+      "auto_open_url": "자동으로 인증 페이지 열기"
+    }
+  },
+  "operations": {
+    "queue": {
+      "title": "오퍼레이션 큐",
+      "clear_all": "모두 삭제",
+      "refresh": "오퍼레이션 새로고침",
+      "empty": "오퍼레이션 큐가 비어 있습니다.",
+      "empty_hint": "패키지가 조직 페이지에서 오퍼레이션을 추가해 보세요.",
+      "active_label": "실행 중인 오퍼레이션",
+      "otp_required": "OTP 인증이 필요합니다.",
+      "otp_prompt": "계속하시려면 OTP를 입력해 주세요.",
+      "otp_placeholder": "OTP 코드 입력...",
+      "otp_label": "일회용 비밀번호",
+      "retry_otp": "OTP로 재시도",
+      "retry_web_auth": "웹 인증으로 재시도",
+      "retrying": "재시도 중...",
+      "open_web_auth": "웹 인증 링크 열기",
+      "approve_operation": "오퍼레이션 승인",
+      "remove_operation": "오퍼레이션 삭제",
+      "approve_all": "모두 승인",
+      "execute": "실행",
+      "executing": "실행 중...",
+      "log": "로그",
+      "log_label": "완료된 오퍼레이션 로그",
+      "remove_from_log": "로그에서 삭제"
+    }
+  },
+  "org": {
+    "teams": {
+      "title": "팀",
+      "refresh": "팀 목록 새로고침",
+      "filter_label": "팀 필터링",
+      "filter_placeholder": "팀을 필터링해 보세요.",
+      "sort_by": "정렬",
+      "loading": "팀 정보를 불러오는 중입니다.",
+      "no_teams": "팀 정보를 찾을 수 없습니다.",
+      "list_label": "조직의 팀",
+      "delete_team": "팀 {name} 삭제",
+      "member_count": "멤버 {count}명",
+      "members_of": "{team}의 멤버",
+      "no_members": "멤버가 없습니다.",
+      "remove_user": "팀에서 사용자 {user} 삭제",
+      "username_to_add": "{team}에 추가할 사용자 이름",
+      "username_placeholder": "사용자 이름...",
+      "add_button": "추가",
+      "cancel_add_user": "사용자 추가를 취소합니다.",
+      "add_member": "+ 멤버 추가",
+      "team_name_label": "팀 이름",
+      "team_name_placeholder": "팀 이름...",
+      "create_button": "생성",
+      "no_match": "“{query}”@.koreanWa:{query}　일치하는 팀을 찾을 수 없습니다.",
+      "cancel_create": "팀 생성을 취소합니다.",
+      "create_team": "+ 팀 생성"
+    },
+    "members": {
+      "title": "멤버",
+      "refresh": "멤버 목록 새로고침",
+      "filter_label": "멤버 필터링",
+      "filter_placeholder": "멤버를 필터링해 보세요.",
+      "filter_by_role": "역할로 필터링",
+      "filter_by_team": "팀으로 필터링",
+      "all_teams": "모든 팀",
+      "sort_by": "정렬",
+      "loading": "멤버 정보를 불러오는 중입니다.",
+      "no_members": "멤버 정보를 찾을 수 없습니다.",
+      "list_label": "조직의 멤버",
+      "change_role_for": "{name}의 역할 변경",
+      "remove_from_org": "조직에서 {name} 제거",
+      "view_team": "팀 {team} 보기",
+      "no_match": "조건에 해당하는 멤버가 없습니다.",
+      "username_label": "사용자 이름",
+      "username_placeholder": "사용자 이름...",
+      "role_label": "역할",
+      "role": {
+        "all": "모두",
+        "developer": "개발자",
+        "admin": "관리자",
+        "owner": "소유자"
+      },
+      "team_label": "팀",
+      "no_team": "팀 없음",
+      "add_button": "추가",
+      "cancel_add": "멤버 추가를 취소합니다.",
+      "add_member": "+ 멤버 추가"
+    },
+    "public_packages": "공개된 패키지 {count}개",
+    "page": {
+      "packages_title": "패키지",
+      "members_tab": "멤버",
+      "teams_tab": "팀",
+      "no_packages": "공개된 패키지가 없습니다. 조직: ",
+      "no_packages_hint": "존재하지 않는 조직이거나, 공개된 패키지가 없습니다.",
+      "failed_to_load": "조직의 패키지를 불러오는 데 실패했습니다.",
+      "no_match": "“{query}”@.koreanWa:{query}　일치하는 패키지를 찾을 수 없습니다.",
+      "not_found": "조직을 찾을 수 없습니다.",
+      "not_found_message": "조직 “{'@'}{name}”은 npm에 존재하지 않습니다."
+    }
+  },
+  "user": {
+    "combobox": {
+      "add_to_org_hint": "(조직에도 추가됩니다.)",
+      "press_enter_to_add": "엔터 키를 눌러 {'@'}{username}@.koreanEul:{username} 추가합니다.",
+      "default_placeholder": "사용자 이름...",
+      "suggestions_label": "사용자 추천"
+    },
+    "page": {
+      "packages_title": "패키지",
+      "no_packages": "공개된 패키지가 없습니다. 사용자: ",
+      "no_packages_hint": "존재하지 않는 사용자거나, 공개된 패키지가 없습니다.",
+      "failed_to_load": "사용자의 패키지를 불러오는 데 실패했습니다.",
+      "no_match": "“{query}”@.koreanWa:{query}　일치하는 패키지를 찾을 수 없습니다.",
+      "filter_placeholder": "패키지 {count}개를 필터링해 보세요."
+    },
+    "orgs_page": {
+      "title": "조직",
+      "back_to_profile": "프로필로 돌아가기",
+      "connect_required": "조직 정보를 보시려면 로컬 CLI를 연결해 주세요.",
+      "connect_hint_prefix": "연결하시려면",
+      "connect_hint_suffix": "를 실행해 주세요.",
+      "own_orgs_only": "내 조직만 볼 수 있습니다.",
+      "view_your_orgs": "내 조직 보기",
+      "loading": "조직 정보를 불러오는 중입니다.",
+      "empty": "조직에 소속되어 있지 않습니다.",
+      "empty_hint": "조직은 스코프가 붙은 패키지로부터 검출됩니다.",
+      "count": "조직 {count}개",
+      "packages_count": "패키지 {count}개"
+    }
+  },
+  "claim": {
+    "modal": {
+      "title": "패키지 등록",
+      "success": "패키지를 등록했습니다!",
+      "success_detail": "{name}{'@'}0.0.0이 npm에 공개되었습니다.",
+      "success_hint": "npm publish를 사용하여 이 패키지의 새 버전을 배포할 수 있습니다.",
+      "view_package": "패키지 보기",
+      "invalid_name": "올바르지 않은 패키지 이름:",
+      "available": "이 이름은 사용할 수 있습니다!",
+      "taken": "이 이름의 패키지가 이미 존재합니다.",
+      "missing_permission": "스코프 {'@'}{scope}에 패키지를 추가할 권한이 없습니다.",
+      "similar_warning": "비슷한 이름의 패키지가 있습니다. npm에 의해 거부될 가능성이 있습니다.",
+      "related": "관련된 패키지:",
+      "scope_warning_title": "스코프가 붙은 패키지 이름을 사용해 보는 건 어떠신가요?",
+      "scope_warning_text": "스코프가 붙지 않은 패키지는 모두와 공유하는 패키지입니다. 이 패키지를 공개하고 유지 보수할 의향이 있는 경우에만 등록해 주세요. 개인이나 조직 프로젝트의 경우, {'@'}{username}/{name}@.koreanWa:{name} 같이 스코프가 붙은 이름을 사용해 주세요.",
+      "connect_required": "패키지를 등록하려면 로컬 커넥터에 연결해 주세요.",
+      "connect_button": "로컬 커넥터에 연결하기",
+      "publish_hint": "아래 버튼을 누르면 최소한의 플레이스홀더 파일이 담긴 패키지가 공개됩니다.",
+      "preview_json": "package.json 미리보기",
+      "claim_button": "패키지 등록",
+      "publishing": "등록하는 중입니다.",
+      "checking": "등록 가능 여부를 확인하는 중입니다.",
+      "failed_to_check": "패키지의 등록 가능 여부 확인에 실패했습니다.",
+      "failed_to_claim": "패키지 등록에 실패했습니다."
+    }
+  },
+  "code": {
+    "files_label": "파일",
+    "no_files": "이 폴더에는 파일이 없습니다.",
+    "lines": "{count}줄",
+    "toggle_tree": "파일 트리 열기",
+    "close_tree": "파일 트리 닫기",
+    "copy_content": "파일 내용 복사",
+    "copy_link": "링크 복사",
+    "view_raw": "Raw 파일 보기",
+    "toggle_container": "코드 영역 너비 제한 적용/해제",
+    "open_raw_file": "Raw 파일 열기",
+    "open_path_dropdown": "파일 경로 드롭다운 열기",
+    "file_too_large": "파일이 너무 커서 열 수 없습니다.",
+    "file_size_warning": "{size}는 구문 강조 표시 한도 500 kB를 넘었습니다.",
+    "failed_to_load": "파일을 불러오는 데 실패했습니다.",
+    "unavailable_hint": "파일이 너무 크거나, 파일을 열람할 수 없을 가능성이 있습니다.",
+    "version_required": "코드를 보시려면 버전을 지정하셔야 합니다.",
+    "go_to_package": "패키지 페이지로 이동",
+    "loading_tree": "파일 트리를 불러오는 중입니다.",
+    "failed_to_load_tree": "이 패키지 버전의 파일을 불러오는 데 실패했습니다.",
+    "back_to_package": "패키지 페이지로 돌아가기",
+    "table": {
+      "name": "이름",
+      "size": "크기"
+    },
+    "markdown_view_mode": {
+      "preview": "미리보기",
+      "code": "코드"
+    },
+    "file_path": "파일 경로",
+    "binary_file": "바이너리 파일",
+    "binary_rendering_warning": "파일 타입 “{contentType}”@.koreanEun:{contentType} 미리보기가 지원되지 않습니다."
+  },
+  "badges": {
+    "provenance": {
+      "verified": "검증됨",
+      "verified_title": "패키지 출처 검증됨",
+      "verified_via": "패키지 출처 검증됨: {provider}@.koreanEul:{provider} 통해 공개"
+    },
+    "jsr": {
+      "title": "JSR에서도 사용 가능"
+    }
+  },
+  "filters": {
+    "title": "필터",
+    "search": "검색",
+    "search_scope": "검색 범위",
+    "search_placeholder_name": "패키지 이름으로 필터링해 보세요.",
+    "search_placeholder_description": "패키지 설명으로 필터링해 보세요.",
+    "search_placeholder_keywords": "키워드로 필터링해 보세요.",
+    "search_placeholder_all": "모든 필드로 검색하거나 name: desc: kw: 등을 사용해 보세요.",
+    "scope_name": "이름",
+    "scope_name_description": "패키지 이름으로만 검색",
+    "scope_description": "설명",
+    "scope_description_description": "패키지 설명으로만 검색",
+    "scope_keywords": "키워드",
+    "scope_keywords_description": "키워드로만 검색",
+    "scope_all": "모두",
+    "scope_all_description": "모든 필드로 검색. name: desc: kw: 등을 사용하여 필터링 가능",
+    "weekly_downloads": "주간 다운로드 수",
+    "updated_within": "마지막 업데이트",
+    "security": "보안",
+    "keywords": "키워드",
+    "more_keywords": "이외 {count}개",
+    "clear_all": "모두 삭제",
+    "remove_filter": "{label} 필터 삭제",
+    "chips": {
+      "search": "검색",
+      "downloads": "다운로드 수",
+      "keyword": "키워드",
+      "security": "보안",
+      "updated": "마지막 업데이트"
+    },
+    "download_range": {
+      "any": "모두",
+      "lt100": "< 100",
+      "100_1k": "100 - 1K",
+      "1k_10k": "1K - 10K",
+      "10k_100k": "10K - 100K",
+      "gt100k": "> 100K"
+    },
+    "updated": {
+      "any": "모두",
+      "week": "1주일 이내",
+      "month": "1달 이내",
+      "quarter": "3달 이내",
+      "year": "1년 이내"
+    },
+    "security_options": {
+      "all": "모든 패키지",
+      "secure": "경고 없음",
+      "insecure": "경고 있음"
+    },
+    "view_selected": "선택한 패키지만 표시",
+    "clear_selected_label": "전체 선택 해제",
+    "sort": {
+      "label": "패키지 정렬",
+      "toggle_direction": "정렬 순서 변경",
+      "ascending": "오름차순",
+      "descending": "내림차순",
+      "relevance": "관련도순",
+      "downloads_week": "주간 다운로드순",
+      "downloads_day": "일간 다운로드순",
+      "downloads_month": "월간 다운로드순",
+      "downloads_year": "연간 다운로드순",
+      "published": "공개일 최신순",
+      "name": "패키지 이름순"
+    },
+    "columns": {
+      "title": "열 설정",
+      "show": "표시할 열",
+      "reset": "초기화",
+      "coming_soon": "곧 구현 예정",
+      "name": "이름",
+      "version": "버전",
+      "description": "설명",
+      "downloads": "주간 다운로드 수",
+      "published": "최근 공개일",
+      "maintainers": "메인테이너",
+      "keywords": "키워드",
+      "security": "보안",
+      "selection": "패키지 선택"
+    },
+    "view_mode": {
+      "label": "표시 모드",
+      "cards": "카드 목록",
+      "table": "표"
+    },
+    "pagination": {
+      "mode_label": "페이지네이션 모드",
+      "infinite": "무한 스크롤",
+      "paginated": "페이지 분할",
+      "items_per_page": "페이지당 항목 수",
+      "per_page": "페이지당 {count}개",
+      "showing": "{total}개 중 {range}",
+      "previous": "이전 페이지",
+      "next": "다음 페이지",
+      "nav_label": "페이지네이션"
+    },
+    "count": {
+      "showing_filtered": "패키지 {count}개 중 {filtered}개",
+      "showing_all": "패키지 {count}개",
+      "showing_paginated": "패키지 {count}개 중 {pageSize}개"
+    },
+    "table": {
+      "security_warning": "보안 경고",
+      "secure": "안전",
+      "no_packages": "패키지가 없습니다."
+    }
+  },
+  "about": {
+    "title": "npmx에 대하여",
+    "heading": "이 사이트에 대하여",
+    "meta_description": "npmx는 최신 기술을 사용해 빠른 npm 레지스트리 탐색기입니다. npm 패키지를 탐색하는 데 더 나은 UX/DX를 선사합니다.",
+    "what_we_are": {
+      "title": "npmx란?",
+      "better_ux_dx": "더 나은 UX/DX",
+      "admin_ui": "관리자 UI",
+      "description": "npmx는 npm 패키지 레지스트리와 관련 툴을 위해 {betterUxDx}를 선사합니다. 다크 모드, 키보드를 통한 페이지 이동, 코드 탐색 및 {jsr} 등의 대안 레지스트리와의 연결 기능까지 갖춘 빠르고 현대적인 인터페이스를 제공합니다.",
+      "admin_description": "또한 브라우저에서 패키지, 팀, 조직 등을 관리할 수 있는 더욱 편리한 {adminUi}를 제공하려고 노력합니다. 로컬 npm CLI를 사용하여 동작합니다."
+    },
+    "what_we_are_not": {
+      "title": "npmx가 아닌 것",
+      "not_package_manager": "패키지 매니저는 아닙니다.",
+      "not_registry": "레지스트리도 아닙니다.",
+      "registry_description": "패키지를 호스팅하지는 않습니다. 단지 패키지를 탐색하기 위해 좋은 도구를 제공할 뿐입니다.",
+      "package_managers_exist": "{already} {people} {building} {really} {cool} {package} {managers}.",
+      "words": {
+        "already": "이미",
+        "people": "뛰어난",
+        "building": "패키지",
+        "really": "매니저를",
+        "cool": "만들고 있는",
+        "package": "사람들이",
+        "managers": "있습니다"
+      }
+    },
+    "sponsors": {
+      "title": "후원자"
+    },
+    "oss_partners": {
+      "title": "오픈소스 파트너"
+    },
+    "team": {
+      "title": "팀",
+      "core": "핵심",
+      "maintainers": "메인테이너",
+      "role_core": "핵심",
+      "role_steward": "관리자",
+      "role_maintainer": "메인테이너",
+      "sponsor": "후원자",
+      "sponsor_aria": "GitHub에서 {name} 후원하기"
+    },
+    "contributors": {
+      "title": "기여자",
+      "description": "npmx는 완전히 오픈소스이며, 훌륭한 기여 커뮤니티에 의해 개발되고 있습니다. 꿈꿔왔던 npm 탐색 경험, 저희 함께 만들어 봐요.",
+      "loading": "기여자 목록을 불러오는 중...",
+      "error": "기여자 목록을 불러오는 데 실패했습니다.",
+      "view_profile": "{name}의 GitHub 프로필 보기"
+    },
+    "get_involved": {
+      "title": "참여하기",
+      "contribute": {
+        "title": "기여하기",
+        "description": "더 나은 npm 경험을 위해 동참해 주세요.",
+        "cta": "GitHub에서 보기"
+      },
+      "community": {
+        "title": "커뮤니티 참가하기",
+        "description": "자유롭게 채팅, 질문하며 아이디어를 공유해 주세요.",
+        "cta": "Discord에 참가하기"
+      },
+      "builders": {
+        "title": "개발에 참여하기",
+        "description": "npmx의 미래를 만들어가는 개발자들과 함께해 주세요.",
+        "cta": "개발자 Discord에 참가하기"
+      },
+      "follow": {
+        "title": "최신 정보 얻기",
+        "description": "npmx의 최신 정보를 얻을 수 있습니다.",
+        "cta": "Bluesky 팔로우하기"
+      }
+    }
+  },
+  "account_menu": {
+    "connect": "연결",
+    "account": "계정",
+    "npm_cli": "npm CLI",
+    "atmosphere": "Atmosphere",
+    "npm_cli_desc": "패키지와 조직 관리",
+    "atmosphere_desc": "소셜 기능과 ID",
+    "connect_npm_cli": "npm CLI에 연결",
+    "connect_atmosphere": "Atmosphere에 연결",
+    "connecting": "연결 중...",
+    "ops": "{count}개의 오퍼레이션"
+  },
+  "auth": {
+    "modal": {
+      "title": "Atmosphere",
+      "connected_as": "{'@'}{handle}@.koreanRo:{handle} 연결됨",
+      "disconnect": "연결 해제",
+      "connect_prompt": "Atmosphere 계정으로 연결",
+      "handle_label": "핸들",
+      "handle_placeholder": "alice.npmx.social",
+      "connect": "연결",
+      "create_account": "계정 신규 생성",
+      "connect_bluesky": "Bluesky로 연결",
+      "what_is_atmosphere": "Atmosphere 계정이란？",
+      "atmosphere_explanation": "{npmx}는 소셜 기능을 구현하는 데 {atproto}를 사용하고 있습니다. AT Protocol에 의해 사용자는 자신의 데이터를 소유하고, 1개의 계정으로 AT Protocol을 지원하는 모든 서비스를 사용할 수 있게 됩니다. 계정을 생성하면 {bluesky}나 {tangled} 등의 다른 서비스에서도 같은 계정을 사용할 수 있습니다.",
+      "default_input_error": "올바른 핸들, DID, 혹은 완전한 PDS URL을 입력해 주세요.",
+      "profile": "프로필"
+    }
+  },
+  "header": {
+    "home": "홈",
+    "packages": "패키지",
+    "packages_dropdown": {
+      "title": "내 패키지",
+      "loading": "불러오는 중...",
+      "error": "패키지를 불러오는 데 실패했습니다.",
+      "empty": "패키지가 없습니다.",
+      "view_all": "모두 보기"
+    },
+    "orgs": "조직",
+    "orgs_dropdown": {
+      "title": "내 조직",
+      "loading": "불러오는 중...",
+      "error": "조직을 불러오는 데 실패했습니다.",
+      "empty": "조직이 없습니다.",
+      "view_all": "모두 보기"
+    },
+    "pr": "GitHub의 Pull Request #{prNumber} 열기"
+  },
+  "compare": {
+    "packages": {
+      "title": "패키지 비교",
+      "tagline": "npm 패키지를 나란히 비교하여 가장 알맞은 패키지를 고를 수 있도록 도와줍니다.",
+      "meta_title": "{packages} 비교 - npmx",
+      "meta_title_empty": "패키지 비교 - npmx",
+      "meta_description": "{packages}의 자세한 비교",
+      "meta_description_empty": "npm 패키지를 나란히 비교합니다.",
+      "section_packages": "패키지",
+      "section_facets": "비교 항목",
+      "section_comparison": "비교",
+      "copy_as_markdown": "표 복사하기",
+      "loading": "패키지 데이터를 불러오는 중입니다.",
+      "error": "패키지 데이터를 불러오는 데 실패했습니다. 다시 한번 시도해 주세요.",
+      "empty_title": "비교할 패키지 선택",
+      "empty_description": "상단 검색 창에 두 개 이상의 패키지를 추가하면, 선택한 패키지들을 다양한 측면에서 비교할 수 있습니다.",
+      "table_view": "표",
+      "charts_view": "그래프",
+      "no_chartable_data": "선택한 항목에 사용 가능한 차트 데이터가 없습니다.",
+      "bar_chart_nav_hint": "↑ ↓ 키 사용",
+      "line_chart_nav_hint": "← → 키 사용"
+    },
+    "selector": {
+      "search_label": "패키지 검색",
+      "search_first": "패키지를 검색해 보세요.",
+      "search_add": "패키지를 추가해 보세요.",
+      "searching": "검색 중입니다.",
+      "remove_package": "{package}　삭제",
+      "packages_selected": "패키지 {max} 중 {count}개 선택됨",
+      "add_hint": "비교하기 위해서는 적어도 2개 이상의 패키지를 선택해 주세요."
+    },
+    "scatter_chart": {
+      "title": "{x}에 대한 {y}의 비교",
+      "freshness_score": "새로움 점수",
+      "copy_alt": {
+        "analysis": "{package}: {x_name} ({x_value}) 및 {y_name} ({y_value})",
+        "description": "{packages} 패키지의 {x_name}에 대한 {y_name}의 산점도. {analysis}. {watermark}"
+      },
+      "filename": "{x}-vs-{y}-scatter-chart",
+      "x_axis": "X축 ↦",
+      "y_axis": "Y축 ↥"
+    },
+    "no_dependency": {
+      "label": "(의존성 없음)",
+      "typeahead_title": "James 씨라면 어떻게 하셨을까? (WWJD)",
+      "typeahead_description": "의존성을 사용하지 않았을 경우와 비교합니다! e18e도 인정한 부분입니다.",
+      "tooltip_title": "의존성이 필요하지 않을 지도 모릅니다.",
+      "tooltip_description": "의존성을 사용하지 않았을 경우와 비교해 보세요! {link}에서 네이티브 API나 더 간단한 방법으로 구현할 수 있는 패키지 목록을 확인하실 수 있습니다.",
+      "e18e_community": "e18e 커뮤니티",
+      "add_column": "비교 항목에 “의존성 없음”을 추가"
+    },
+    "facets": {
+      "all": "모두",
+      "none": "없음",
+      "select_all_category_facets": "모든 {category} 항목을 선택",
+      "deselect_all_category_facets": "모든 {category} 항목을 선택 해제",
+      "selected_all_category_facets": "모든 {category} 항목을 선택했습니다.",
+      "deselected_all_category_facets": "모든 {category} 항목을 선택 해제했습니다.",
+      "coming_soon": "곧 구현 예정",
+      "select_all": "모든 항목을 선택",
+      "deselect_all": "모든 항목을 선택 해제",
+      "binary_only_tooltip": "이 패키지는 바이너리만을 제공하며, export는 포함되어 있지 않습니다.",
+      "categories": {
+        "performance": "성능",
+        "health": "유지 보수",
+        "compatibility": "호환성",
+        "security": "보안"
+      },
+      "items": {
+        "packageSize": {
+          "label": "패키지 크기",
+          "description": "패키지 자체의 크기 (압축 해제 후)"
+        },
+        "installSize": {
+          "label": "설치 시 크기",
+          "description": "모든 의존성을 포함하여 설치했을 때의 크기"
+        },
+        "dependencies": {
+          "label": "직접 의존성 수",
+          "description": "패키지가 직접 참조하는 의존성만의 개수"
+        },
+        "totalDependencies": {
+          "label": "모든 의존성 수",
+          "description": "의존성 그래프 위의 모든 의존성의 개수"
+        },
+        "downloads": {
+          "label": "주간 다운로드 수",
+          "description": "1주일 간의 패키지 다운로드 수"
+        },
+        "totalLikes": {
+          "label": "좋아요",
+          "description": "좋아요 수의 합계"
+        },
+        "lastUpdated": {
+          "label": "공개일",
+          "description": "이 버전이 공개된 날짜"
+        },
+        "deprecated": {
+          "label": "지원 중단 여부",
+          "description": "패키지가 지원 중단됐는지 여부"
+        },
+        "engines": {
+          "label": "엔진",
+          "description": "패키지가 지원하는 Node.js 버전 조건"
+        },
+        "types": {
+          "label": "타입 정의",
+          "description": "TypeScript 타입 정의를 사용 가능한지 여부"
+        },
+        "moduleFormat": {
+          "label": "모듈 형식",
+          "description": "ESM과 CJS 지원 여부"
+        },
+        "license": {
+          "label": "라이선스",
+          "description": "패키지 라이선스"
+        },
+        "vulnerabilities": {
+          "label": "취약점",
+          "description": "알려진 보안 취약점"
+        },
+        "githubStars": {
+          "label": "GitHub Stars",
+          "description": "GitHub 리포지터리의 스타 수"
+        },
+        "githubIssues": {
+          "label": "GitHub Issues",
+          "description": "GitHub 리포지터리의 이슈 수"
+        },
+        "createdAt": {
+          "label": "생성일",
+          "description": "패키지가 처음 만들어진 날짜"
+        }
+      },
+      "values": {
+        "any": "모두",
+        "none": "없음",
+        "unknown": "알 수 없음",
+        "deprecated": "지원 중단",
+        "not_deprecated": "지원됨",
+        "types_included": "포함",
+        "types_none": "없음",
+        "vulnerabilities_summary": "{count}개 (긴급 {critical}, 고위험 {high})",
+        "up_to_you": "Up to you!"
+      },
+      "trends": {
+        "title": "추이 비교"
+      }
+    },
+    "file_changes": "변경된 파일",
+    "files_count": "파일 {count}개",
+    "lines_hidden": "{count}개 행 숨기기",
+    "file_too_large": "파일이 너무 커서 비교할 수 없습니다.",
+    "file_size_warning": "{size}는 비교 가능 한도 250 kB를 넘었습니다.",
+    "compare_versions": "비교",
+    "compare_versions_title": "최신 버전과 비교",
+    "comparing_versions_label": "버전을 비교하는 중입니다.",
+    "version_back_to_package": "패키지 페이지로 돌아가기",
+    "version_error_message": "버전 비교에 실패했습니다.",
+    "version_invalid_url_format": {
+      "hint": "올바르지 않은 비교 URL입니다. 올바른 형식: {0}",
+      "from_version": "\\{기준\\}",
+      "to_version": "\\{비교 대상\\}"
+    },
+    "version_selector_title": "아래 버전과 비교하기",
+    "summary": "요약",
+    "deps_count": "의존성 {count}개",
+    "dependencies": "의존성",
+    "dev_dependencies": "개발용 의존성",
+    "peer_dependencies": "피어 의존성",
+    "optional_dependencies": "선택적 의존성",
+    "no_dependency_changes": "의존성 변경 없음",
+    "file_filter_option": {
+      "all": "전체 ({count})",
+      "added": "추가 ({count})",
+      "removed": "삭제 ({count})",
+      "modified": "수정 ({count})"
+    },
+    "search_files_placeholder": "파일을 검색해 보세요.",
+    "no_files_all": "파일 없음",
+    "no_files_search": "“{query}”@.koreanWa:{query} 일치하는 파일을 찾을 수 없습니다.",
+    "no_files_filtered": "{filter} 파일 없음",
+    "filter": {
+      "added": "추가된",
+      "removed": "삭제된",
+      "modified": "수정된"
+    },
+    "files_button": "파일",
+    "select_file_prompt": "사이드바에서 파일을 선택하여 변경 사항 보기",
+    "close_files_panel": "파일 패널 닫기",
+    "filter_files_label": "변경 타입으로 파일 필터링",
+    "change_ratio": "변경률",
+    "char_edits": "수정된 최대 문자 수",
+    "diff_distance": "편집 거리",
+    "loading_diff": "변경 사항을 불러오는 중입니다.",
+    "loading_diff_error": "변경 사항을 불러오는 데 실패했습니다.",
+    "merge_modified_lines": "수정된 행 합치기",
+    "no_content_changes": "변경된 내용이 없습니다.",
+    "options": "설정",
+    "view_file": "파일 보기",
+    "view_in_code_browser": "코드 탐색기로 열기",
+    "word_wrap": "자동 줄 바꿈"
+  },
+  "pds": {
+    "title": "npmx.social",
+    "meta_description": "npmx 커뮤니티를 위한 npmx 공식 AT 프로토콜 퍼스널 데이터 서버(PDS)",
+    "join": {
+      "title": "커뮤니티에 참여하기",
+      "description": "Atmosphere에서 첫 계정을 만들든, 기존 계정을 옮기든, 당신은 이 커뮤니티의 일원입니다. 포스트와 팔로워, 핸들 등 잃어버릴 걱정 없이 npmx PDS로 계정 이관이 가능합니다.",
+      "migrate": "PDS MOOver를 통해 이관하기"
+    },
+    "server": {
+      "title": "서버 상세 정보",
+      "location_label": "서버 위치:",
+      "location_value": "독일 뉘른베르크",
+      "infrastructure_label": "인프라스트럭처:",
+      "infrastructure_value": "Hetzner로 호스팅 중",
+      "privacy_label": "개인정보:",
+      "privacy_value": "엄격한 EU 데이터 보호법 적용",
+      "learn_more": "npmx가 Atmosphere를 이용하는 방법에 대해 알아보기"
+    },
+    "community": {
+      "title": "커뮤니티 멤버",
+      "description": "이미 npmx.social에서 활동하고 있는 계정이 {count}개 있습니다.",
+      "loading": "PDS 커뮤니티를 불러오는 중입니다.",
+      "error": "PDS 커뮤니티를 불러오는 데 실패했습니다.",
+      "empty": "표시할 수 있는 커뮤니티 멤버가 없습니다.",
+      "view_profile": "{handle}의 프로필 보기",
+      "new_accounts": "... 및 Atmosphere에 새로이 참가한 {count}명"
+    }
+  },
+  "privacy_policy": {
+    "title": "개인정보처리방침",
+    "last_updated": "최종 수정일: {date}",
+    "welcome": "{app}에 오신 것을 환영합니다! 저희는 여러분의 개인정보 보호를 위해 노력하고 있습니다. 이 방침에서는 어떤 데이터를 수집하고, 어떻게 사용하고, 또 사용자가 자신의 정보에 대해 가지는 권리에 대해 설명합니다.",
+    "cookies": {
+      "what_are": {
+        "title": "쿠키란?",
+        "p1": "쿠키는 웹사이트를 방문할 때에 기기에 저장되는 작은 텍스트 파일입니다. 웹사이트가 더 좋은 탐색 경험을 제공하기 위해 필요한 개인 설정값을 저장하기 위해 사용됩니다."
+      },
+      "types": {
+        "title": "사용하는 쿠키 목록",
+        "p1": "사이트가 동작하기 위해 반드시 필요한 {bold}만을 사용하고 있습니다. 제3자 쿠키나 광고 목적 쿠키는 일절 사용하고 있지 않습니다.",
+        "bold": "필수 기술적 쿠키",
+        "li1": "{li11}{separator} {li12}",
+        "li2": "{li21}{separator} {li22}",
+        "separator": ":",
+        "cookie_vdpl": "__vdpl",
+        "cookie_vdpl_desc": "이 쿠키는 호스팅 제공 업체(Vercel)가 스큐 프로텍션을 위해 사용합니다. 사용 중에 웹사이트가 업데이트 되었을 때 브라우저가 잘못된 애셋을 가져오지 않도록 하는 데 사용되는 쿠키로, 추적 용도로 사용되지 않습니다.",
+        "cookie_h3": "h3",
+        "cookie_h3_desc": "이 쿠키는 안전한 세션 쿠키입니다. Atmosphere 계정에 연결했을 때 OAuth 액세스 토큰을 여기에 저장합니다. 세션을 인증된 상태로 유지하기 위해 필요한 쿠키입니다."
+      },
+      "local_storage": {
+        "title": "로컬 스토리지",
+        "p1": "세션 쿠키에 더해 브라우저의 {bold}를 사용하여 표시 설정을 저장합니다. 테마 선택(라이트, 다크 모드)이나 기타 {settings}을 저장하여 다음에 접속했을 때에 다시 설정할 필요가 없도록 도와줍니다.",
+        "bold": "로컬 스토리지",
+        "p2": "이 정보는 순수하게 기능적인 목적으로만 사용되며, 서버로 보내지지 않고 기기에만 저장됩니다. {bold2} 웹사이트 경험을 개선하기 위해서만 사용됩니다.",
+        "bold2": "개인정보를 포함하지 않으며, 추적에도 사용되지 않습니다.",
+        "settings": "설정값"
+      },
+      "management": {
+        "title": "쿠키 관리",
+        "p1": "브라우저를 통해 쿠키 사용을 승인, 거부, 혹은 쿠키 삭제를 하실 수 있습니다. 단, {bold}될 수 있습니다.",
+        "bold": "필수 쿠키를 거부하면 사이트의 일부 기능이 제한",
+        "p2": "주요 브라우저의 쿠키 관리 방법은 아래 링크에서 확인하실 수 있습니다.",
+        "chrome": "Google Chrome (새 창에서 열기)",
+        "firefox": "Mozilla Firefox (새 창에서 열기)",
+        "edge": "Microsoft Edge (새 창에서 열기)"
+      }
+    },
+    "analytics": {
+      "title": "분석",
+      "p1": "사용자가 웹사이트를 어떻게 사용하는지 파악하기 위해 {bold}를 사용하고 있습니다. 이 분석 서비스는 사용자 경험을 개선하거나 문제를 특정하는 데 도움이 됩니다.",
+      "bold": "Vercel Web Analytics",
+      "p2": "Vercel Analytics는 아래 개인정보 원칙을 고려하여 설계되어 있습니다.",
+      "li1": "쿠키를 사용하지 않습니다.",
+      "li2": "개인을 식별할 수 있는 정보를 수집하지 않습니다.",
+      "li3": "여러 웹사이트를 오가는 사용자를 추적하지 않습니다.",
+      "li4": "모든 데이터는 종합하여 집계되고 익명화됩니다.",
+      "p3": "수집된 정보는 페이지 URL, 레퍼러, 국가 및 지역, 기기 종류, 브라우저, OS 정보뿐입니다. 이 데이터는 개인을 특정하는 데 쓰일 수 없습니다."
+    },
+    "authenticated": {
+      "title": "인증된 사용자",
+      "p1": "{bold} 계정을 npmx에 연결하면 OAuth 액세스 토큰이 안전한 HTTP-only 세션 쿠키에 저장됩니다. 이 토큰은 사이트에서 당신을 대리하여 인증을 요청하는 데 사용됩니다.",
+      "bold": "Atmosphere",
+      "p2": "인증 정보는 저장되지 않습니다. 또한 기능이 작동하기 위해 필요한 범위를 넘은 데이터를 요청하지 않습니다. Atmosphere 계정은 언제나 {settings} 페이지에서 연결 해제할 수 있습니다.",
+      "settings": "설정"
+    },
+    "data_retention": {
+      "title": "데이터 유지",
+      "p1": "세션 쿠키는 브라우저를 닫거나 일정 시간 조작이 없으면 자동으로 삭제됩니다. 로컬 스토리지의 설정은 브라우저 데이터를 삭제할 때까지 기기에 저장되어 있습니다. 분석 데이터는 집계된 형식으로 유지되며, 개개의 사용자와 관련된 정보는 저장하지 않습니다."
+    },
+    "your_rights": {
+      "title": "사용자의 권리",
+      "p1": "당신에게는 다음과 같은 권리가 있습니다.",
+      "li1": "저희가 수집한 데이터에 관한 정보에 접근할 권리",
+      "li2": "언제나 로컬 스토리지 및 쿠키를 삭제할 권리",
+      "li3": "계정이 연결된 세션을 해제할 권리",
+      "li4": "데이터 취급에 관한 정보를 요구할 권리",
+      "p2": "저희는 개인정보를 수집하고 있지 않기에, 삭제하거나 요구할 개인정보는 보통 없습니다."
+    },
+    "contact": {
+      "title": "문의",
+      "p1": "이 개인정보처리방침에 관한 질문이나 우려가 있다면 {link}에서 이슈를 생성하여 알려주세요.",
+      "link": "GitHub 리포지터리"
+    },
+    "changes": {
+      "title": "개인정보처리방침의 수정",
+      "p1": "이 방침은 경우에 따라서 수정될 수 있습니다. 변경 사항은 수정일과 함께 이 페이지에 공개됩니다."
+    }
+  },
+  "a11y": {
+    "title": "접근성",
+    "footer_title": "접근성",
+    "welcome": "저희는 {app}가 최대한 많은 사람에게 사용될 수 있기를 바랍니다.",
+    "approach": {
+      "title": "접근성의 개선 방법",
+      "p1": "저희는 웹 콘텐츠 접근성 가이드라인(Web Content Accessibility Guidelines, WCAG) 2.2를 만족할 수 있도록 노력하며, 기능을 개발할 때 하나의 지침으로 활용하고 있습니다. WCAG의 모든 수준의 접근성을 만족한다고 주장하지는 않습니다. 접근성은 끊임없는 노력이 필요하고, 언제나 더 개선할 점이 있기 마련입니다.",
+      "p2": "이 사이트는 {about}입니다. 접근성의 개선은 통상적 개발의 과정으로 점차적으로 이루어지고 있습니다.",
+      "about_link": "오픈소스 커뮤니티가 주도하는 프로젝트"
+    },
+    "measures": {
+      "title": "접근성을 위한 노력",
+      "p1": "사이트 전체에서 다음 사항을 만족하기 위해 노력하고 있습니다.",
+      "li1": "적절한 곳에 시맨틱 HTML과 ARIA 속성을 사용",
+      "li2": "브라우저에서 텍스트 크기를 조절할 수 있도록 상대적 텍스트 크기를 사용",
+      "li3": "인터페이스 전체에 대해 키보드 조작을 지원",
+      "li4": "사용자의 prefers-reduced-motion 및 prefers-color-scheme 미디어 쿼리 값을 존중",
+      "li5": "충분한 색상 대비를 고려하여 디자인",
+      "li6": "일부 상호작용 기능은 JavaScript가 필요하지만, 필수적인 내용은 JavaScript 없이도 접근 가능하도록 함"
+    },
+    "limitations": {
+      "title": "알려진 한계",
+      "p1": "사이트의 일부 — 특히 패키지의 README 등에 들어 있는 제3자 콘텐츠 — 는 접근성 기준을 만족하지 못할 수 있습니다. 이 부분도 차차 개선해 나가려고 합니다."
+    },
+    "contact": {
+      "title": "피드백",
+      "p1": "{app}에서 접근성이 나쁜 부분을 발견하셨다면, {link}에서 이슈를 생성하여 알려주세요. 버그 리포트를 진지하게 검토한 후, 문제를 해결하기 위해 가능한 한 노력하겠습니다.",
+      "link": "GitHub 리포지터리"
+    }
+  },
+  "translation_status": {
+    "title": "번역 상황",
+    "generated_at": "생성일: {date}",
+    "welcome": "{npmx}의 번역에 관심이 있으시다면, 잘 오셨습니다! 이 페이지는 자동 갱신되며, 번역에 협조할 수 있는 문자열의 목록이 표시되어 있습니다.",
+    "p1": "npmx는 기본 언어로 {lang}를 사용하고 있고, 번역할 메시지는 총 {count}가 있습니다. 번역에 도움을 주고 싶으시다면, {bylang}에서 해당하는 언어를 찾아서 펼쳐 주시면 상세 정보를 보실 수 있습니다.",
+    "p1_lang": "미국 영어(en-US)",
+    "p1_count": "{count}개",
+    "p2": "開始する前に、翻訳プロセスと参加方法について説明した {guide} を読んでください。",
+    "guide": "ローカライズ (i18n) ガイド",
+    "by_locale": "언어별 진행 상황",
+    "by_file": "파일별 번역 진행 상황",
+    "complete_text": "이 언어는 번역이 완료되었습니다. 수고하셨습니다!",
+    "missing_text": "개의 번역되지 않은 항목",
+    "missing_keys": "번역되지 않은 항목 {count}개",
+    "progress_label": "{locale}의 번역 진행 상황",
+    "table": {
+      "file": "파일",
+      "status": "현황",
+      "error": "파일 리스트를 불러오는 중에 오류가 발생했습니다.",
+      "empty": "파일이 없습니다.",
+      "file_link": "GitHub에서 {file} ({lang}) 편집"
+    }
+  },
+  "vacations": {
+    "title": "휴식 중",
+    "meta_description": "npmx 팀은 재충전 중입니다. Discord는 일주일 후에 다시 열립니다.",
+    "heading": "재충전 시간",
+    "subtitle": "저희 {some}는 npmx를 만들기 위해 잠을 줄이기까지 했습니다. 그게 일상이 되면 안 되겠죠! 그래서 일주일간 재충전을 위해 휴가를 내기로 했습니다. 모두 같이요.",
+    "illustration_alt": "안락한 느낌의 아이콘이 한 행으로 나열되어 있음",
+    "poke_log": "모닥불에 불 붙이기",
+    "what": {
+      "title": "무엇이 일어났나",
+      "p1": "{dates} Discord를 한시적으로 닫았습니다.",
+      "dates": "2026년 2월 14부터 21일까지",
+      "p2": "모든 초대 링크를 삭제했고 채널은 모두 잠겼습니다. — 다만 서로 이야기하며 시간을 보내고 싶어하는 분들을 위해 {garden}을 제외하고요.",
+      "garden": "#garden"
+    },
+    "meantime": {
+      "title": "그동안",
+      "p1": "{site}와 {repo}는 그대로 열려 있었습니다. 사람들은 여전히 프로젝트에 뛰어들고, 이슈를 제보하고, PR을 작성할 수 있었습니다. 하지만 대다수는 따듯한 난방 기구 옆에서 편안한 시간을 보냈습니다.",
+      "repo_link": "리포지터리"
+    },
+    "return": {
+      "title": "그리고 돌아왔습니다!",
+      "p1": "재충전된 상태로 다시 돌아왔고, 3월 3일의 첫 알파 버전 릴리스를 위해 모든 준비를 마쳤습니다. 최신 정보를 얻으시려면 {social}.",
+      "social_link": "Bluesky에서 팔로우하세요"
+    },
+    "stats": {
+      "contributors": "기여자 수",
+      "commits": "커밋 수",
+      "pr": "병합된 PR 수",
+      "subtitle": {
+        "some": "일부",
+        "all": "모두"
+      }
+    }
+  },
+  "action_bar": {
+    "title": "액션 바",
+    "selection": "패키지 {count}개 선택됨",
+    "shortcut": "{key} 키를 눌러 액션 바로 포커스 이동",
+    "button_close_aria_label": "액션 바 닫기"
+  },
+  "logo_menu": {
+    "copy_svg": "로고를 SVG 형식으로 복사",
+    "copied": "복사했습니다!",
+    "browse_brand": "브랜드 아이덴티티(BI) 보기"
+  },
+  "brand": {
+    "title": "브랜드",
+    "heading": "브랜드",
+    "meta_description": "출판 및 미디어를 위한 npmx 브랜드 가이드라인, 로고, 색상 및 타이포그래피",
+    "intro": "프로젝트나 기사, 미디어에 npmx 브랜드를 사용할 때 지켜야 할 가이드라인입니다.",
+    "logos": {
+      "title": "로고",
+      "description": "npmx 로고를 SVG 및 PNG 형식으로 다운로드할 수 있습니다. 배경색에 맞춰 적절한 것으로 사용해 주세요.",
+      "wordmark": "워드마크",
+      "wordmark_alt": "어두운 배경 위의 파란색 슬래시를 포함한 npmx 워드마크",
+      "wordmark_light_alt": "밝은 배경 위의 파란색 슬래시를 포함한 npmx 워드마크",
+      "mark": "로고 마크",
+      "mark_alt": "어두운 배경 위의 흰 마침표와 파란색 슬래시를 포함한 npmx 로고 마크",
+      "mark_light_alt": "밝은 배경 위의 검은 마침표와 파란색 슬래시를 포함한 npmx 로고 마크",
+      "on_dark": "어두운 배경용",
+      "on_light": "밝은 배경용",
+      "download_svg": "SVG",
+      "download_png": "PNG",
+      "download_svg_aria": "{name}를 SVG 형식으로 다운로드",
+      "download_png_aria": "{name}를 PNG 형식으로 다운로드"
+    },
+    "customize": {
+      "title": "커스텀 로고",
+      "description": "강조색과 배경색을 선택하여 npmx 로고 색을 바꿀 수 있습니다. 미리보기에서 색상 설정이 적용된 로고 이미지를 확인한 후, 다운로드해 보세요.",
+      "accent_label": "강조색",
+      "bg_label": "배경색",
+      "download_svg_aria": "커스텀 로고를 SVG 형식으로 다운로드",
+      "download_png_aria": "커스텀 로고를 PNG 형식으로 다운로드"
+    },
+    "typography": {
+      "title": "타이포그래피",
+      "description": "npmx는 UI의 텍스트와 코드 모두에 Vercel의 Geist 서체를 사용하고 있습니다.",
+      "sans": "Geist Sans",
+      "sans_desc": "본문이나 UI 요소에 사용됩니다.",
+      "mono": "Geist Mono",
+      "mono_desc": "코드, 제목 및 기술적인 컨텐츠에 사용됩니다.",
+      "pangram": "The quick brown fox jumps over the lazy dog",
+      "numbers": "0123456789"
+    },
+    "guidelines": {
+      "title": "주의사항",
+      "message": "저희에게 있어 접근성은 정말 중요한 사항입니다. 모두에게 열려 있는 npmx의 미래를 만드는 데 동참해 주세요. 위에서 언급된 로고 이미지를 사용하는 경우 배경색과 충분한 대비가 있도록 하고, 로고 텍스트 크기가 24px 미만이 되지 않도록 주의해 주세요. 또 이 프로젝트의 다른 리소스가 필요한 경우, {link}를 통해 연락해 주시면 감사드리겠습니다.",
+      "discord_link_text": "chat.npmx.dev"
+    }
+  },
+  "alt_logo_kawaii": "귀엽고 동글동글하고 알록달록한 버전의 npmx 로고",
+  "changelog": {
+    "pre_release": "사전 릴리스",
+    "draft": "초안",
+    "no_logs": "이 패키지의 변경 기록은 공개되어 있지 않거나 지원하지 않는 형식입니다.",
+    "error": {
+      "p1": "{package}의 변경 기록을 불러오지 못했습니다.",
+      "p2": "나중에 다시 시도하시거나, {viewon}를 열어 확인해 주세요."
+    },
+    "rate_limit_ungh": "GitHub의 API 호출 제한에 걸렸습니다. 잠시 후에 다시 시도해 주세요.",
+    "version_unavailable": "해당 버전은 현재 이용할 수 없습니다."
+  }
+}

--- a/shared/utils/korean.ts
+++ b/shared/utils/korean.ts
@@ -1,0 +1,70 @@
+import type { LinkedModifiers, VueMessageType } from 'vue-i18n'
+
+/**
+ * Get the correct Korean particle following the given word.
+ *
+ * Korean usually has a pair of two particles, which is chosen depending on
+ * whether a word ends with a consonant or a vowel.
+ * This function deals with such Korean particles, with a plausible heuristic
+ * for non-Korean characters.
+ *
+ * @param text
+ * @param isRo whether the particle pair is 으로/로 or not
+ *        If isRo is true, `withFinalConsonant` excludes ㄹ (L sound) from
+ *        its consonant set.
+ * @param withFinalConsonant a version in case ending with a consonant
+ * @param withoutFinalConsonant a version in case ending with a vowel
+ * @returns the correct particle
+ */
+function getKoreanJosa<T>(
+  text: T,
+  isRo: boolean,
+  withFinalConsonant: string,
+  withoutFinalConsonant: string,
+) {
+  if (typeof text !== 'string') return text
+
+  // Strip out all non-Korean (vowels, consonants, and complete characters)
+  // non-alphanumeric characters.
+  const normalizedText = text.replace(/[^\u3131-\u3163\uac00-\ud7a3a-z0-9]/gi, '')
+
+  if (typeof normalizedText !== 'string' || normalizedText.length === 0)
+    return withoutFinalConsonant
+
+  // If `text` ends with two or more consecutive latin alphabets,
+  // apply the following syllable final sound huristic:
+  if (/[a-z]{2,}$/.test(normalizedText)) {
+    return /(?:\w[lm]|[aeiouwy][ck-npqt])e?$/i.test(normalizedText)
+      ? withFinalConsonant
+      : withoutFinalConsonant
+  }
+
+  // If `text` ends with complete Korean characters,
+  // check if it has a syllable final sound and return the appropriate one.
+  if (/[\uac00-\ud7a3]$/.test(normalizedText)) {
+    const code = normalizedText.charCodeAt(normalizedText.length - 1) - 0xac00
+    const hasFinalConsonant = !(code % 28 === 0 || (isRo && code % 28 === 8))
+    return hasFinalConsonant ? withFinalConsonant : withoutFinalConsonant
+  }
+
+  // The case `text` ends with incomplete Korean characters (consonants or vowels)
+  if (isRo && normalizedText.endsWith('ㄹ')) return withoutFinalConsonant
+  // Consonant cases
+  if (/[\u3131-\u314e]$/.test(normalizedText)) return withFinalConsonant
+  // Vowel cases
+  if (/[\u314f-\u3163]$/.test(normalizedText)) return withoutFinalConsonant
+
+  // The case `text` ends with a single latin alphabet or a digit
+  const singleAlphabetOrNumericRegex = isRo ? /[mn036]$/i : /[lmnr013678]$/i
+  return singleAlphabetOrNumericRegex.test(normalizedText)
+    ? withFinalConsonant
+    : withoutFinalConsonant
+}
+
+export const koreanModifiers = {
+  koreanI: text => getKoreanJosa(text, false, '이', '가'),
+  koreanEun: text => getKoreanJosa(text, false, '은', '는'),
+  koreanEul: text => getKoreanJosa(text, false, '을', '를'),
+  koreanWa: text => getKoreanJosa(text, false, '과', '와'),
+  koreanRo: text => getKoreanJosa(text, true, '으로', '로'),
+} satisfies LinkedModifiers<VueMessageType>

--- a/shared/utils/korean.ts
+++ b/shared/utils/korean.ts
@@ -1,5 +1,3 @@
-import type { LinkedModifiers, VueMessageType } from 'vue-i18n'
-
 /**
  * Get the correct Korean particle following the given word.
  *
@@ -21,8 +19,8 @@ function getKoreanJosa<T>(
   isRo: boolean,
   withFinalConsonant: string,
   withoutFinalConsonant: string,
-) {
-  if (typeof text !== 'string') return text
+): string {
+  if (typeof text !== 'string') return withoutFinalConsonant
 
   // Strip out all non-Korean (vowels, consonants, and complete characters)
   // non-alphanumeric characters.
@@ -62,9 +60,9 @@ function getKoreanJosa<T>(
 }
 
 export const koreanModifiers = {
-  koreanI: text => getKoreanJosa(text, false, '이', '가'),
-  koreanEun: text => getKoreanJosa(text, false, '은', '는'),
-  koreanEul: text => getKoreanJosa(text, false, '을', '를'),
-  koreanWa: text => getKoreanJosa(text, false, '과', '와'),
-  koreanRo: text => getKoreanJosa(text, true, '으로', '로'),
-} satisfies LinkedModifiers<VueMessageType>
+  koreanI: <T>(text: T) => getKoreanJosa(text, false, '이', '가'),
+  koreanEun: <T>(text: T) => getKoreanJosa(text, false, '은', '는'),
+  koreanEul: <T>(text: T) => getKoreanJosa(text, false, '을', '를'),
+  koreanWa: <T>(text: T) => getKoreanJosa(text, false, '과', '와'),
+  koreanRo: <T>(text: T) => getKoreanJosa(text, true, '으로', '로'),
+}

--- a/shared/utils/korean.ts
+++ b/shared/utils/korean.ts
@@ -33,7 +33,7 @@ function getKoreanJosa<T>(
 
   // If `text` ends with two or more consecutive latin alphabets,
   // apply the following syllable final sound huristic:
-  if (/[a-z]{2,}$/.test(normalizedText)) {
+  if (/[a-z]{2,}$/i.test(normalizedText)) {
     return /(?:\w[lm]|[aeiouwy][ck-npqt])e?$/i.test(normalizedText)
       ? withFinalConsonant
       : withoutFinalConsonant

--- a/test/unit/shared/utils/korean.spec.ts
+++ b/test/unit/shared/utils/korean.spec.ts
@@ -61,6 +61,35 @@ describe('getKoreanJosa', () => {
     expect(koreanModifiers.koreanRo({ hello: 'world' })).toBe('로')
   })
 
+  it('excludes ㄹ final consonant for the 으로/로 pair on complete korean characters', () => {
+    // 서울 ends with 울 (final consonant ㄹ, code % 28 === 8)
+    expect(koreanModifiers.koreanI('서울')).toBe('이')
+    expect(koreanModifiers.koreanEun('서울')).toBe('은')
+    expect(koreanModifiers.koreanRo('서울')).toBe('로')
+    // 한글 ends with 글 (final consonant ㄹ)
+    expect(koreanModifiers.koreanI('한글')).toBe('이')
+    expect(koreanModifiers.koreanRo('한글')).toBe('로')
+    // 강원도 ends with 도 (no final consonant) - sanity check the other branch
+    expect(koreanModifiers.koreanRo('강원도')).toBe('로')
+  })
+
+  it('chooses the correct one for words ending with incomplete korean characters', () => {
+    // bare consonant jamo (ㄱ-ㅎ)
+    expect(koreanModifiers.koreanI('ㄱ')).toBe('이')
+    expect(koreanModifiers.koreanI('버전ㅁ')).toBe('이')
+    expect(koreanModifiers.koreanEun('ㅎ')).toBe('은')
+    expect(koreanModifiers.koreanRo('ㅁ')).toBe('으로')
+
+    // bare ㄹ jamo is excluded from the consonant set for the 으로/로 pair
+    expect(koreanModifiers.koreanRo('ㄹ')).toBe('로')
+    expect(koreanModifiers.koreanI('ㄹ')).toBe('이')
+
+    // bare vowel jamo (ㅏ-ㅣ)
+    expect(koreanModifiers.koreanI('ㅏ')).toBe('가')
+    expect(koreanModifiers.koreanEul('ㅣ')).toBe('를')
+    expect(koreanModifiers.koreanRo('ㅗ')).toBe('로')
+  })
+
   it('i/ga and other regular particle pairs behave in the same way', () => {
     expect(koreanModifiers.koreanI('한국어')).toBe('가')
     expect(koreanModifiers.koreanEun('한국어')).toBe('는')

--- a/test/unit/shared/utils/korean.spec.ts
+++ b/test/unit/shared/utils/korean.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { koreanModifiers } from '#shared/utils/korean'
+
+describe('getKoreanJosa', () => {
+  it('chooses the correct one for words ending with korean characters', () => {
+    expect(koreanModifiers.koreanI('')).toBe('가')
+    expect(koreanModifiers.koreanI('한국어')).toBe('가')
+    expect(koreanModifiers.koreanI('얼룩말')).toBe('이')
+    expect(koreanModifiers.koreanI('엔피엠엑스')).toBe('가')
+    expect(koreanModifiers.koreanI('자바스크립트')).toBe('가')
+    expect(koreanModifiers.koreanI('로봇')).toBe('이')
+    expect(koreanModifiers.koreanI('관련')).toBe('이')
+  })
+
+  it('chooses the correct one for words ending with digits', () => {
+    expect(koreanModifiers.koreanI('테스트123')).toBe('이')
+    expect(koreanModifiers.koreanI('3500')).toBe('이')
+    expect(koreanModifiers.koreanI('ax18')).toBe('이')
+    expect(koreanModifiers.koreanI('10935')).toBe('가')
+    expect(koreanModifiers.koreanI('is-number-2024')).toBe('가')
+    expect(koreanModifiers.koreanRo('테스트123')).toBe('으로')
+    expect(koreanModifiers.koreanRo('ax18')).toBe('로')
+    expect(koreanModifiers.koreanRo('2017')).toBe('로')
+    expect(koreanModifiers.koreanRo('10935')).toBe('로')
+  })
+
+  it('chooses the correct one for words ending with latin alphabets', () => {
+    expect(koreanModifiers.koreanI('test')).toBe('가') // 테스트 - vowel
+    expect(koreanModifiers.koreanI('neighbor')).toBe('가') // 네이버 - vowel
+    expect(koreanModifiers.koreanI('one')).toBe('이') // 원 - consonant
+    expect(koreanModifiers.koreanI('robot')).toBe('이') // 로봇 - consonant
+    expect(koreanModifiers.koreanI('art')).toBe('가') // 아트 - vowel
+    expect(koreanModifiers.koreanI('korean')).toBe('이') // 코리안 - consonant
+    expect(koreanModifiers.koreanI('버전R')).toBe('이') // 버전알 - consonant ㄹ
+    expect(koreanModifiers.koreanRo('버전R')).toBe('로') // 버전알 - consonant ㄹ
+  })
+
+  it('chooses the correct one for null cases', () => {
+    expect(koreanModifiers.koreanI('')).toBe('가')
+  })
+})

--- a/test/unit/shared/utils/korean.spec.ts
+++ b/test/unit/shared/utils/korean.spec.ts
@@ -31,11 +31,33 @@ describe('getKoreanJosa', () => {
     expect(koreanModifiers.koreanI('robot')).toBe('이') // 로봇 - consonant
     expect(koreanModifiers.koreanI('art')).toBe('가') // 아트 - vowel
     expect(koreanModifiers.koreanI('korean')).toBe('이') // 코리안 - consonant
+
+    // single alphabet cases
+    expect(koreanModifiers.koreanI('마징가Z')).toBe('가') // 마징가제트 - vowel
+    expect(koreanModifiers.koreanRo('마징가Z')).toBe('로') // 마징가제트 - vowel
     expect(koreanModifiers.koreanI('버전R')).toBe('이') // 버전알 - consonant ㄹ
     expect(koreanModifiers.koreanRo('버전R')).toBe('로') // 버전알 - consonant ㄹ
+    expect(koreanModifiers.koreanI('버전M')).toBe('이') // 버전엠 - consonant
+    expect(koreanModifiers.koreanRo('버전M')).toBe('으로') // 버전엔 - consonant
   })
 
   it('chooses the correct one for null cases', () => {
     expect(koreanModifiers.koreanI('')).toBe('가')
+    expect(koreanModifiers.koreanEun('')).toBe('는')
+    expect(koreanModifiers.koreanEul('')).toBe('를')
+    expect(koreanModifiers.koreanWa('')).toBe('와')
+    expect(koreanModifiers.koreanRo('')).toBe('로')
+  })
+
+  it('i/ga and other regular particle pairs behave in the same way', () => {
+    expect(koreanModifiers.koreanI('한국어')).toBe('가')
+    expect(koreanModifiers.koreanEun('한국어')).toBe('는')
+    expect(koreanModifiers.koreanEul('한국어')).toBe('를')
+    expect(koreanModifiers.koreanWa('한국어')).toBe('와')
+
+    expect(koreanModifiers.koreanI('얼룩말')).toBe('이')
+    expect(koreanModifiers.koreanEun('얼룩말')).toBe('은')
+    expect(koreanModifiers.koreanEul('얼룩말')).toBe('을')
+    expect(koreanModifiers.koreanWa('얼룩말')).toBe('과')
   })
 })

--- a/test/unit/shared/utils/korean.spec.ts
+++ b/test/unit/shared/utils/korean.spec.ts
@@ -47,6 +47,18 @@ describe('getKoreanJosa', () => {
     expect(koreanModifiers.koreanEul('')).toBe('를')
     expect(koreanModifiers.koreanWa('')).toBe('와')
     expect(koreanModifiers.koreanRo('')).toBe('로')
+
+    expect(koreanModifiers.koreanI(null)).toBe('가')
+    expect(koreanModifiers.koreanEun(null)).toBe('는')
+    expect(koreanModifiers.koreanEul(null)).toBe('를')
+    expect(koreanModifiers.koreanWa(null)).toBe('와')
+    expect(koreanModifiers.koreanRo(null)).toBe('로')
+
+    expect(koreanModifiers.koreanI({ hello: 'world' })).toBe('가')
+    expect(koreanModifiers.koreanEun({ hello: 'world' })).toBe('는')
+    expect(koreanModifiers.koreanEul({ hello: 'world' })).toBe('를')
+    expect(koreanModifiers.koreanWa({ hello: 'world' })).toBe('와')
+    expect(koreanModifiers.koreanRo({ hello: 'world' })).toBe('로')
   })
 
   it('i/ga and other regular particle pairs behave in the same way', () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->
Adds Korean (ko-KR) translations and registers the locale.

<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

- added a new ko-KR.json locale and updated config/i18n.ts accordingly
- added custom modifiers in `i18n/i18n.config.ts` to choose correct Korean particles (조사, josa) which changes depending on whether the previous word ends with a consonant or a vowel. Context:
  - 은/는, 이/가, 을/를, 과/와 - takes the first one if the previous word ends with a consonant; otherwise the second one
  - 으로/로 - takes the first one if the previous word ends with a consonant different from ㄹ (L sound); otherwise the second one
- I'm not sure about the right place of custom modifiers for Korean, so I placed it in utils directory and import it from the i18n config file. Feel free to ask me to move those to a better place!

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
