### PR TITLE
docs: add keyboard shortcut for opening timeline

### DIFF
--- a/docs/content/2.guide/2.keyboard-shortcuts.md
+++ b/docs/content/2.guide/2.keyboard-shortcuts.md
@@ -51,3 +51,4 @@ These shortcuts work anywhere on the site. Press `/` from any page to quickly se
 | `f` | Open diff view   |
 | `c` | Compare package  |
 | `-` | open changelog   |
+| `t` | open timeline    |

--- a/docs/content/2.guide/2.keyboard-shortcuts.md
+++ b/docs/content/2.guide/2.keyboard-shortcuts.md
@@ -50,5 +50,5 @@ These shortcuts work anywhere on the site. Press `/` from any page to quickly se
 | `d` | Open docs        |
 | `f` | Open diff view   |
 | `c` | Compare package  |
-| `-` | open changelog   |
-| `t` | open timeline    |
+| `-` | Open changelog   |
+| `t` | Open timeline    |


### PR DESCRIPTION
### 🔗 Linked issue

#2865 

### 🧭 Context

The t shortcut for opening the Timeline tab is shown in the UI but missing from the Keyboard Shortcuts documentation.

### 📚 Description

Added the missing t → Open timeline entry to the Keyboard Shortcuts page to keep the documentation consistent with the available shortcuts.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
