### PR TITLE
fix: prevent tooltip from being hidden behind navbar

### DIFF
--- a/app/components/Tooltip/Base.vue
+++ b/app/components/Tooltip/Base.vue
@@ -58,7 +58,7 @@ const { floatingStyles } = useFloating(triggerRef, tooltipRef, {
         <div
           v-if="props.isVisible"
           ref="tooltipRef"
-          class="px-2 py-1 font-mono text-xs text-fg bg-bg-elevated border border-border rounded shadow-lg whitespace-pre-line break-words max-w-xs z-[40]"
+          class="px-2 py-1 font-mono text-xs text-fg bg-bg-elevated border border-border rounded shadow-lg whitespace-pre-line break-words max-w-xs z-[60]"
           :class="{ 'pointer-events-none': !interactive }"
           :style="floatingStyles"
           v-bind="tooltipAttr"


### PR DESCRIPTION
### 🔗 Linked issue

Closes #2864 

### 🧭 Context

The tooltip shown when hovering over the Tetris image was partially hidden behind the navbar, making some of the content unreadable.

### 📚 Description

Updated the tooltip styling so it renders above the navbar and remains fully visible on hover.

This improves readability and prevents the tooltip content from being clipped.

<img width="1654" height="882" alt="image" src="https://github.com/user-attachments/assets/93c0f628-904f-4a18-bb49-cace9f792f3d" />

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
