### PR TITLE
fix: data label collisions in compare downloads chart

### DIFF
--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { VueUiXy, type VueUiXyConfig } from 'vue-data-ui/vue-ui-xy'
+import { VueUiXy, type VueUiXyConfig, type VueUiXySvgSlotProps } from 'vue-data-ui/vue-ui-xy'
 import { useDebounceFn, useElementSize, useTimeoutFn } from '@vueuse/core'
 import { useColors } from '~/composables/useColors'
 import { OKLCH_NEUTRAL_FALLBACK, transparentizeOklch } from '~/utils/colors'
@@ -25,6 +25,7 @@ import {
   getTrendsDatetimeFormatterOptions,
 } from '#shared/utils/trends-chart'
 import { downloadFileLink } from '~/utils/download'
+import { createLastDatapointLabelsSvg } from '#shared/utils/download-chart-last-label'
 
 import('vue-data-ui/style.css')
 
@@ -980,41 +981,32 @@ function drawEstimationLine(svg: Record<string, any>) {
  * - renders a text label slightly offset to the right of the point
  * - formats the value using the compact number formatter
  *
+ * In case of label collisions for multiple series:
+ * - labels are evenly distributed vertically
+ * - an elbowed marker connects the last point to its label
+ *
  * Return an empty string when no series data is available.
  *
  * @param svg - SVG context object provided by `VueUiXy` via the `#svg` slot
  * @returns A string containing SVG `<text>` elements, or an empty string when
  * no labels should be rendered.
  */
-function drawLastDatapointLabel(svg: Record<string, any>) {
-  const data = Array.isArray(svg?.data) ? svg.data : []
-  if (!data.length) return ''
-
-  const dataLabels: string[] = []
-
-  for (const serie of data) {
-    const lastPlot = serie.plots.at(-1)
-
-    dataLabels.push(`
-      <text
-        text-anchor="start"
-        dominant-baseline="middle"
-        x="${lastPlot.x + 12}"
-        y="${lastPlot.y}"
-        font-size="24"
-        fill="${colors.value.fg}"
-        stroke="${colors.value.bg}"
-        stroke-width="1"
-        paint-order="stroke fill"
-      >
-        ${compactNumberFormatter.value.format(Number.isFinite(lastPlot.value) ? lastPlot.value : 0)}
-      </text>
-    `)
-  }
-
-  return dataLabels.join('\n')
+function drawLastDatapointLabel(svg: VueUiXySvgSlotProps['svg']) {
+  return createLastDatapointLabelsSvg({
+    series: Array.isArray(svg?.data) ? svg.data : [],
+    drawingArea: svg.drawingArea,
+    svgWidth: svg.width,
+    fontSize: isMultiPackageMode.value ? 20 : 24,
+    labelOffset: isMultiPackageMode.value ? 24 : 16,
+    colors: {
+      foreground: colors.value.fg!,
+      background: colors.value.bg!,
+      fallbackSerieColor: colors.value.fg!,
+    },
+    formatValue: value => compactNumberFormatter.value.format(value),
+    isDarkMode: isDarkMode.value,
+  })
 }
-
 /**
  * Build and return a legend to be injected during the SVG export only, since the custom legend is
  * displayed as an independent div, content has to be injected within the chart's viewBox.

--- a/server/utils/embed-downloads-svg.ts
+++ b/server/utils/embed-downloads-svg.ts
@@ -1,7 +1,7 @@
 import { createError } from 'h3'
 import { createStaticVueUiXy } from 'vue-data-ui/ssr/vue-ui-xy'
 import { mergeConfigs } from 'vue-data-ui/utils'
-import { generateWatermarkLogo } from '#shared/utils/trends-chart'
+import { generateWatermarkLogo, LOCALES_WITH_EXTRA_SPACE } from '#shared/utils/trends-chart'
 import {
   buildNormalisedTrendsDataset,
   buildTrendsChartConfig,
@@ -11,6 +11,7 @@ import { resolveEmbedChartColors } from '#shared/utils/embed-chart-colors'
 import { OKLCH_NEUTRAL_FALLBACK } from '~/utils/colors'
 import { getEffectiveEndDateIso, isLastDayOfMonth, isLastDayOfYear } from '~/utils/date'
 import { fetchDownloadsEvolution } from '~~/server/utils/download-evolution'
+import { createLastDatapointLabelsSvg } from '#shared/utils/download-chart-last-label'
 
 type FetchGranularity = 'day' | 'week' | 'month' | 'year'
 type ChartGranularity = 'daily' | 'weekly' | 'monthly' | 'yearly'
@@ -254,7 +255,8 @@ export async function createDownloadsSvgResponse(query: QueryParameters): Promis
         height,
         padding: {
           left: 12,
-          right: 120,
+          right:
+            packageNames.length > 1 ? (LOCALES_WITH_EXTRA_SPACE.includes(locale) ? 180 : 160) : 145,
         },
         legend: {
           show: true,
@@ -301,29 +303,17 @@ export async function createDownloadsSvgResponse(query: QueryParameters): Promis
     }),
     config,
     additionalSvgContent: ({ series, drawingArea }) => {
-      const lastPlotValues = series
-        .map(serie => {
-          const lastPlot = (serie.plots || []).at(-1)
-
-          if (!lastPlot) return ''
-
-          return `
-              <text
-                  x="${lastPlot.x + 8}"
-                  y="${lastPlot.y}"
-                  fill="${colors.fg}"
-                  stroke="${colors.bg}"
-                  stroke-width="1"
-                  paint-order="stroke fill"
-                  font-size="18"
-                  dominant-baseline="middle"
-                  text-anchor="start"
-              >
-                  ${compactNumberFormatter.format(Number(lastPlot.value ?? 0))}
-              </text>
-          `
-        })
-        .join('')
+      const lastPlotValues = createLastDatapointLabelsSvg({
+        series,
+        drawingArea,
+        colors: {
+          foreground: colors.fg,
+          background: colors.bg,
+          fallbackSerieColor: colors.fg,
+        },
+        formatValue: value => compactNumberFormatter.format(value),
+        isDarkMode,
+      })
 
       const logo = generateWatermarkLogo({
         x: 12,

--- a/shared/utils/download-chart-last-label.ts
+++ b/shared/utils/download-chart-last-label.ts
@@ -1,0 +1,160 @@
+/**
+ * Utility to be used in vue-data-ui line charts (`VueUiXy`) using the `#svg` slot to display the last value as data label.
+ * In case of mutliple series, if label collisions are detected, labels are evenly distributed vertically,
+ * and linked to the last datapoint with an elbowed marker
+ */
+export function createLastDatapointLabelsSvg({
+  series,
+  drawingArea,
+  colors,
+  formatValue,
+  isDarkMode,
+  fontSize = 20,
+  labelOffset = 24,
+  labelHeight = 30,
+}: {
+  series: LastDatapointLabelSerie[]
+  drawingArea: {
+    top: number
+    height?: number
+    bottom?: number
+  }
+  colors: LastDatapointLabelColors
+  formatValue: (value: number) => string
+  isDarkMode: boolean
+  svgWidth?: number
+  fontSize?: number
+  labelOffset?: number
+  labelHeight?: number
+}) {
+  const drawingAreaTop = Number(drawingArea.top ?? 0)
+  const drawingAreaHeight = Number(
+    drawingArea.height ?? Number(drawingArea.bottom ?? 0) - drawingAreaTop,
+  )
+  const drawingAreaBottom = drawingAreaTop + drawingAreaHeight
+
+  const labels = series
+    .map(serie => {
+      const lastPlot = Array.isArray(serie.plots) ? serie.plots.at(-1) : null
+      if (!lastPlot) return null
+
+      const value = Number(lastPlot.value ?? 0)
+      const safeValue = Number.isFinite(value) ? value : 0
+      const text = formatValue(safeValue)
+
+      return {
+        x: Number(lastPlot.x ?? 0),
+        y: Number(lastPlot.y ?? 0),
+        value: safeValue,
+        color: String(serie.color ?? colors.fallbackSerieColor),
+        text,
+        width: text.length * fontSize * 0.58,
+      }
+    })
+    .filter(isLastDatapointLabel)
+
+  if (!labels.length) return ''
+
+  const hasCollision = labels.some((label, labelIndex) =>
+    labels.some((otherLabel, otherLabelIndex) => {
+      if (labelIndex === otherLabelIndex) return false
+
+      return (
+        label.x + labelOffset < otherLabel.x + labelOffset + otherLabel.width &&
+        label.x + labelOffset + label.width > otherLabel.x + labelOffset &&
+        label.y - labelHeight / 2 < otherLabel.y + labelHeight / 2 &&
+        label.y + labelHeight / 2 > otherLabel.y - labelHeight / 2
+      )
+    }),
+  )
+
+  if (!hasCollision) {
+    return labels
+      .map(
+        label => `
+          <text
+            text-anchor="start"
+            dominant-baseline="middle"
+            x="${label.x + labelOffset}"
+            y="${label.y}"
+            font-size="${fontSize}"
+            fill="${colors.foreground}"
+            stroke="${colors.background}"
+            stroke-width="1"
+            paint-order="stroke fill"
+          >
+            ${label.text}
+          </text>
+        `,
+      )
+      .join('\n')
+  }
+
+  const sortedLabels = [...labels].sort((firstLabel, secondLabel) => {
+    return secondLabel.value - firstLabel.value
+  })
+
+  const availableHeight = drawingAreaBottom - drawingAreaTop - labelHeight
+  const verticalStep = availableHeight / (sortedLabels.length - 1)
+
+  const labelX = Math.max(...sortedLabels.map(label => label.x)) + labelOffset + 10
+
+  return sortedLabels
+    .map((label, index) => {
+      const labelY = drawingAreaTop + labelHeight / 2 + verticalStep * index
+      const connectorStartX = label.x + 5
+      const connectorEndX = labelX
+
+      return `
+        <path
+          d="M${connectorStartX},${label.y} ${connectorStartX + 6},${label.y} ${connectorEndX},${labelY} ${connectorEndX + 6},${labelY}"
+          stroke="${label.color}"
+          stroke-width="1"
+          opacity="${isDarkMode ? '0.7' : '1'}"
+          fill="none"
+        />
+        <text
+          text-anchor="start"
+          dominant-baseline="middle"
+          x="${connectorEndX + 12}"
+          y="${labelY}"
+          font-size="${fontSize}"
+          fill="${colors.foreground}"
+          stroke="${colors.background}"
+          stroke-width="1"
+          paint-order="stroke fill"
+        >
+          ${label.text}
+        </text>
+      `
+    })
+    .join('\n')
+}
+
+export type LastDatapointLabelColors = {
+  foreground: string
+  background: string
+  fallbackSerieColor: string
+}
+
+export type LastDatapointLabelSerie = {
+  color?: string
+  plots?: {
+    x?: number | null
+    y?: number | null
+    value?: number | null
+  }[]
+}
+
+type LastDatapointLabel = {
+  x: number
+  y: number
+  value: number
+  color: string
+  text: string
+  width: number
+}
+
+function isLastDatapointLabel(label: LastDatapointLabel | null): label is LastDatapointLabel {
+  return label !== null
+}

--- a/shared/utils/trends-chart.ts
+++ b/shared/utils/trends-chart.ts
@@ -348,6 +348,25 @@ export function getTrendsDatetimeFormatterOptions(granularity: ChartTimeGranular
   }[granularity]
 }
 
+// Some locales require more spacing for the last label value displayed on the chart, and for which some extra padding is reserved in the chart config.
+export const LOCALES_WITH_EXTRA_SPACE = [
+  'bg-BG',
+  'ru-RU',
+  'cs-CZ',
+  'de-AT',
+  'de-DE',
+  'id-ID',
+  'it-IT',
+  'ja-JP',
+  'nb-NO',
+  'nl-NL',
+  'pl-PL',
+  'pt-BR',
+  'ro-RO',
+  'sr-Latn-RS',
+  'uk-UA',
+]
+
 export function buildTrendsChartConfig(
   options: TrendChartConfigOptions & {
     dates: number[]
@@ -372,7 +391,11 @@ export function buildTrendsChartConfig(
       backgroundColor: options.colors.bg,
       padding: {
         bottom: options.displayedGranularity === 'yearly' ? 84 : 64,
-        right: 145,
+        right: options.isMultiPackageMode
+          ? LOCALES_WITH_EXTRA_SPACE.includes(options.locale)
+            ? 180
+            : 160
+          : 145,
       },
       userOptions: {
         buttons: {

--- a/test/unit/server/utils/embed-downloads-svg.spec.ts
+++ b/test/unit/server/utils/embed-downloads-svg.spec.ts
@@ -20,6 +20,7 @@ vi.mock('#server/utils/download-evolution', () => ({
 }))
 
 vi.mock('#shared/utils/trends-chart', () => ({
+  LOCALES_WITH_EXTRA_SPACE: ['fr', 'fr-FR'],
   buildTrendsChartData: mocks.buildTrendsChartData,
   buildNormalisedTrendsDataset: mocks.buildNormalisedTrendsDataset,
   buildTrendsChartConfig: mocks.buildTrendsChartConfig,

--- a/test/unit/shared/utils/download-chart-last-label.spec.ts
+++ b/test/unit/shared/utils/download-chart-last-label.spec.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createLastDatapointLabelsSvg } from '#shared/utils/download-chart-last-label'
+
+const colors = {
+  foreground: '#000000',
+  background: '#FFFFFF',
+  fallbackSerieColor: '#999999',
+}
+
+describe('createLastDatapointLabelsSvg', () => {
+  it('returns an empty string when there are no series', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [],
+      drawingArea: { top: 10, height: 100 },
+      colors,
+      formatValue: value => String(value),
+      isDarkMode: false,
+    })
+    expect(result).toBe('')
+  })
+
+  it('returns an empty string when no serie has plots', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [{ color: '#FF0000' }, { color: '#00FF00', plots: [] }],
+      drawingArea: { top: 10, height: 100 },
+      colors,
+      formatValue: value => String(value),
+      isDarkMode: false,
+    })
+
+    expect(result).toBe('')
+  })
+
+  it('renders regular labels when there is no collision', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { color: '#FF0000', plots: [{ x: 100, y: 20, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 90, value: 20 }] },
+      ],
+      drawingArea: { top: 0, height: 120 },
+      colors,
+      formatValue: value => `${value}`,
+      isDarkMode: false,
+    })
+    expect(result).toContain('<text')
+    expect(result).not.toContain('<path')
+    expect(result).toContain('x="124"')
+    expect(result).toContain('y="20"')
+    expect(result).toContain('y="90"')
+    expect(result).toContain('10')
+    expect(result).toContain('20')
+  })
+
+  it('uses custom font size, label offset, and colors in regular labels', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [{ plots: [{ x: 10, y: 20, value: 42 }] }],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue: value => `${value}`,
+      isDarkMode: false,
+      fontSize: 12,
+      labelOffset: 10,
+    })
+    expect(result).toContain('x="20"')
+    expect(result).toContain('font-size="12"')
+    expect(result).toContain('fill="#000000"')
+    expect(result).toContain('stroke="#FFFFFF"')
+  })
+
+  it('uses only the last plot of each serie', () => {
+    const formatValue = vi.fn((value: number) => `${value}`)
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        {
+          color: '#FF0000',
+          plots: [
+            { x: 10, y: 10, value: 1 },
+            { x: 50, y: 50, value: 99 },
+          ],
+        },
+      ],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue,
+      isDarkMode: false,
+    })
+    expect(formatValue).toHaveBeenCalledTimes(1)
+    expect(formatValue).toHaveBeenCalledWith(99)
+    expect(result).toContain('x="74"')
+    expect(result).toContain('y="50"')
+    expect(result).not.toContain('x="34"')
+  })
+
+  it('formats safe numeric values and falls back to zero for invalid values', () => {
+    const formatValue = vi.fn((value: number) => `value:${value}`)
+    const result = createLastDatapointLabelsSvg({
+      series: [{ plots: [{ x: 10, y: 20, value: Number.NaN }] }],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue,
+      isDarkMode: false,
+    })
+    expect(formatValue).toHaveBeenCalledWith(0)
+    expect(result).toContain('value:0')
+  })
+
+  it('renders collision labels as a vertically distributed label rack', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 55, value: 30 }] },
+        { color: '#0000FF', plots: [{ x: 100, y: 60, value: 20 }] },
+      ],
+      drawingArea: { top: 10, height: 120 },
+      colors,
+      formatValue: value => `value-${value}`,
+      isDarkMode: false,
+    })
+    expect(result).toContain('<path')
+    expect(result).toContain('opacity="1"')
+    expect(result).toContain('stroke="#00FF00"')
+    expect(result).toContain('stroke="#0000FF"')
+    expect(result).toContain('stroke="#FF0000"')
+    expect(result.indexOf('value-30')).toBeLessThan(result.indexOf('value-20'))
+    expect(result.indexOf('value-20')).toBeLessThan(result.indexOf('value-10'))
+    expect(result).toContain('y="25"')
+    expect(result).toContain('y="70"')
+    expect(result).toContain('y="115"')
+  })
+
+  it('uses drawingArea.bottom when height is not provided', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 55, value: 20 }] },
+      ],
+      drawingArea: { top: 20, bottom: 120 },
+      colors,
+      formatValue: value => `${value}`,
+      isDarkMode: false,
+    })
+    expect(result).toContain('y="35"')
+    expect(result).toContain('y="105"')
+  })
+
+  it('centers the collision label when only one label is rendered in rack mode', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 50, value: 20 }] },
+      ],
+      drawingArea: { top: 20, height: 100 },
+      colors,
+      formatValue: value => `${value}`,
+      isDarkMode: false,
+    })
+    expect(result).toContain('y="35"')
+    expect(result).toContain('y="105"')
+  })
+
+  it('uses dark-mode opacity in collision mode', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 50, value: 20 }] },
+      ],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue: value => `${value}`,
+      isDarkMode: true,
+    })
+
+    expect(result).toContain('opacity="0.7"')
+  })
+
+  it('uses the fallback serie color when no color is provided', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { plots: [{ x: 100, y: 50, value: 10 }] },
+        { plots: [{ x: 100, y: 50, value: 20 }] },
+      ],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue: value => `${value}`,
+      isDarkMode: false,
+    })
+
+    expect(result).toContain('stroke="#999999"')
+  })
+
+  it('supports null plot values from SSR slot data', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [{ plots: [{ x: 10, y: 20, value: null }] }],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue: value => `formatted:${value}`,
+      isDarkMode: false,
+    })
+
+    expect(result).toContain('formatted:0')
+  })
+
+  it('uses zero defaults when plot coordinates are nullish', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [{ plots: [{ x: null, y: null, value: undefined }] }],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue: value => `value-${value}`,
+      isDarkMode: false,
+    })
+    expect(result).toContain('x="24"')
+    expect(result).toContain('y="0"')
+    expect(result).toContain('value-0')
+  })
+
+  it('uses zero drawing area height when neither height nor bottom is provided', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 50, value: 20 }] },
+      ],
+      drawingArea: { top: 20 },
+      colors,
+      formatValue: value => `${value}`,
+      isDarkMode: false,
+    })
+    expect(result).toContain('y="35"')
+    expect(result).toContain('y="-15"')
+  })
+
+  it('uses the fallback serie color in regular label mode', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [{ plots: [{ x: 100, y: 50, value: 10 }] }],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue: value => `${value}`,
+      isDarkMode: false,
+    })
+    expect(result).toContain('10')
+  })
+
+  it('supports custom labelHeight in collision rack mode', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 50, value: 20 }] },
+      ],
+      drawingArea: { top: 10, height: 110 },
+      colors,
+      formatValue: value => `${value}`,
+      isDarkMode: false,
+      labelHeight: 20,
+    })
+    expect(result).toContain('y="20"')
+    expect(result).toContain('y="110"')
+  })
+})

--- a/test/unit/shared/utils/download-chart-last-label.spec.ts
+++ b/test/unit/shared/utils/download-chart-last-label.spec.ts
@@ -228,7 +228,7 @@ describe('createLastDatapointLabelsSvg', () => {
     expect(result).toContain('y="-15"')
   })
 
-  it('uses the fallback serie color in regular label mode', () => {
+  it('renders a regular label when serie color is omitted', () => {
     const result = createLastDatapointLabelsSvg({
       series: [{ plots: [{ x: 100, y: 50, value: 10 }] }],
       drawingArea: { top: 0, height: 100 },
@@ -236,6 +236,9 @@ describe('createLastDatapointLabelsSvg', () => {
       formatValue: value => `${value}`,
       isDarkMode: false,
     })
+    expect(result).toContain('<text')
+    expect(result).not.toContain('<path')
+    expect(result).toContain('x="124"')
     expect(result).toContain('10')
   })
 


### PR DESCRIPTION
Resolves #2868 

Add labels collision detection in compare downloads chart and if so:
- distributes evenly the labels vertically
- connects them to the last point with an elbowed marker
- additional padding-right is used for certain locales for which abbreviated units or number format require more space

<img width="723" height="483" alt="image" src="https://github.com/user-attachments/assets/7cf2cab1-f798-461d-86d2-9c45bdb3bce4" />

The fix is also applied to the embed version.