### PR TITLE
ci: block compromised npm packages with Socket Firewall Free

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -26,10 +26,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: 🎨 Check for non-RTL/non-a11y CSS classes
         run: vp run lint:css

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -33,11 +33,11 @@ jobs:
           cache: true
           sfw: true
 
-      - name: 🟧 Install pnpm globally
-        run: vp install -g pnpm
-
       - name: 🧪 Run Chromatic Visual and Accessibility Tests
         uses: chromaui/action@8a2b82547aef5a3efc8ec3c7905f4ab09a76ed0b # v16.1.0
+        with:
+          buildCommand: vp run build-storybook
+          outputDir: storybook-static
         env:
           CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
           CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -27,10 +27,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: 🟧 Install pnpm globally
         run: vp install -g pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
-          run-install: false
-
-      - name: 📦 Install dependencies (root only, no scripts)
-        run: vp install --filter . --ignore-scripts
+          sfw: true
+          # root only, no scripts
+          run-install: |
+            - args: ['--filter', '.', '--ignore-scripts']
 
       - name: 🔠 Lint project
         run: vp run lint
@@ -50,10 +50,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: 💪 Type check
         run: vp run test:types
@@ -67,10 +68,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: 🧪 Unit tests
         run: vp test --project unit --coverage --reporter=default --reporter=junit --outputFile=test-report.junit.xml
@@ -105,10 +107,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: 🌐 Install browser
         run: vp exec playwright install chromium-headless-shell
@@ -151,10 +154,11 @@ jobs:
       - name: 👑 Fix Git ownership
         run: git config --global --add safe.directory /__w/npmx.dev/npmx.dev
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: 🏗️ Build project
         run: vp run build:test
@@ -188,10 +192,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: 🏗️ Build project
         run: vp run build:test
@@ -211,10 +216,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: 🧹 Check for unused code
         run: vp run knip
@@ -228,13 +234,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
-          run-install: false
-
-      - name: 📦 Install dependencies (root only, no scripts)
-        run: vp install --filter . --ignore-scripts
+          sfw: true
+          # root only, no scripts
+          run-install: |
+            - args: ['--filter', '.', '--ignore-scripts']
 
       - name: 🌐 Check for missing or dynamic i18n keys
         run: vp run i18n:report

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -27,7 +27,12 @@ jobs:
           node-version: lts/*
           run-install: false
 
-      - run: vp install -g vercel
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          firewall-version: v1.12.0
+
+      - run: sfw vp i -g vercel@54.12.2
       - run: vercel deploy --target=canary
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 2
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           run-install: false

--- a/.github/workflows/lunaria.yml
+++ b/.github/workflows/lunaria.yml
@@ -29,10 +29,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: Generate Lunaria Overview
         uses: lunariajs/action@4911ad0736d1e3b20af4cb70f5079aea2327ed8e # astro-docs

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           run-install: false

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           run-install: false
@@ -66,7 +66,11 @@ jobs:
 
       - name: 📦 Install dependencies
         if: steps.check.outputs.skip == 'false'
-        run: vp install --filter . --ignore-scripts
+        uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
+        with:
+          sfw: true
+          run-install: |
+            - args: ['--filter', '.', '--ignore-scripts']
 
       - name: 📝 Generate release notes
         if: steps.check.outputs.skip == 'false'
@@ -101,14 +105,18 @@ jobs:
           ref: release
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           registry-url: https://registry.npmjs.org
           run-install: false
 
       - name: 📦 Install dependencies
-        run: vp install --filter npmx-connector...
+        uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
+        with:
+          sfw: true
+          run-install: |
+            - args: ['--filter', 'npmx-connector...']
 
       - name: 🔢 Set connector version
         env:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,7 +4,7 @@ rules:
   stale-action-refs:
     ignore:
       # lunariajs/action has no tag refs; keep the branch commit hash-pinned.
-      - lunaria.yml:38
+      - lunaria.yml:39
   dangerous-triggers:
     ignore:
       - enforce-release-source.yml


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

See https://docs.socket.dev/docs/socket-firewall-free.

Using `sfw pnpm i` instead of `pnpm i` prevents any known malicious package versions from being installed at all, and will cause the install to fail if any are encountered.

As we've seen these last few months, the npm ecosystem is unfortunately frequently victim to supply chain attacks, and this is a simple way to add a layer of protection against such. Socket has built a reputation for detecting these malicious packages within ~5 mins of them being published to the npm registry, so this is a pretty reliable solution for the ~3-36 hour period before these get unpublished by npm.

Socket Firewall Free is 100% free to use, and does not require a licence, account, or attribution:
https://github.com/SocketDev/sfw-free/blob/164c32dcbe3bbebcc0b091fd6a31ff93883545b2/README.md#license.

Originally, this wasn't going to be possible with vite-plus `vp install`, but I chatted with the maintainers and they added built-in support for this in v1.12.0:
https://github.com/voidzero-dev/setup-vp/pull/72.

### 📚 Description

Bump to v1.12.0 of the action and use `sfw: true` to opt in to Socket Firewall Free.