### PR TITLE
style: center align the docs not available

### DIFF
--- a/app/pages/package-docs/[...path].vue
+++ b/app/pages/package-docs/[...path].vue
@@ -189,7 +189,7 @@ const stickyStyle = computed(() => {
       page="docs"
     />
 
-    <div class="flex" dir="ltr">
+    <div class="flex flex-1" dir="ltr">
       <!-- Sidebar TOC -->
       <aside
         v-if="docsData?.toc && !showEmptyState"
@@ -205,7 +205,7 @@ const stickyStyle = computed(() => {
       </aside>
 
       <!-- Main content -->
-      <main class="flex-1 min-w-0">
+      <main class="flex-1 min-w-0 flex flex-col">
         <div v-if="showLoading" class="p-6 sm:p-8 lg:p-12 space-y-4">
           <SkeletonBlock class="h-8 w-64 rounded" />
           <SkeletonBlock class="h-4 w-full max-w-2xl rounded" />
@@ -213,7 +213,10 @@ const stickyStyle = computed(() => {
           <SkeletonBlock class="h-4 w-3/4 max-w-2xl rounded" />
         </div>
 
-        <div v-else-if="showEmptyState" class="p-6 sm:p-8 lg:p-12">
+        <div
+          v-else-if="showEmptyState"
+          class="p-6 sm:p-8 lg:p-12 flex flex-1 items-center justify-center"
+        >
           <div class="max-w-xl rounded-lg border border-border bg-bg-muted p-6">
             <h2 class="font-mono text-lg mb-2">{{ $t('package.docs.not_available') }}</h2>
             <p class="text-fg-subtle text-sm">


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
closes https://github.com/npmx-dev/npmx.dev/issues/2894

### 🧭 Context

<!-- Brief background and why this change is needed -->

- I just came across this npmx.dev from @patak-cat - great project!.

While exploring the docs pages, I noticed the “Docs not available” empty state is left-aligned. It feels off compared to the rest of the site; centering the card would look much better.



<img width="1725" height="993" alt="Screenshot 2026-06-12 at 8 37 46 PM" src="https://github.com/user-attachments/assets/8fff5c30-afb9-4cb7-9dc6-7d70180cb548" />


<!-- High-level summary of what changed -->

The Docs not found is now center aligned matching rest of the layout

<img width="1714" height="993" alt="Screenshot 2026-06-12 at 8 37 38 PM" src="https://github.com/user-attachments/assets/adc0ecbf-bfdb-42d9-99b0-7aba945ee96a" />


### 📚 Description

Styling fix to ensure it matches rest of the layout of the page

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
