### PR TITLE
fix: align docs page layout with container width

### DIFF
--- a/app/pages/package-docs/[...path].vue
+++ b/app/pages/package-docs/[...path].vue
@@ -206,14 +206,14 @@ const stickyStyle = computed(() => {
 
       <!-- Main content -->
       <main class="flex-1 min-w-0">
-        <div v-if="showLoading" class="p-6 sm:p-8 lg:p-12 space-y-4">
+        <div v-if="showLoading" class="container mx-auto py-6 sm:py-8 lg:py-12 space-y-4">
           <SkeletonBlock class="h-8 w-64 rounded" />
           <SkeletonBlock class="h-4 w-full max-w-2xl rounded" />
           <SkeletonBlock class="h-4 w-5/6 max-w-2xl rounded" />
           <SkeletonBlock class="h-4 w-3/4 max-w-2xl rounded" />
         </div>
 
-        <div v-else-if="showEmptyState" class="p-6 sm:p-8 lg:p-12">
+        <div v-else-if="showEmptyState" class="container mx-auto py-6 sm:py-8 lg:py-12">
           <div class="max-w-xl rounded-lg border border-border bg-bg-muted p-6">
             <h2 class="font-mono text-lg mb-2">{{ $t('package.docs.not_available') }}</h2>
             <p class="text-fg-subtle text-sm">
@@ -232,7 +232,9 @@ const stickyStyle = computed(() => {
         </div>
 
         <!-- eslint-disable vue/no-v-html -->
-        <div v-else class="docs-content p-6 sm:p-8 lg:p-12" v-html="docsData?.html" />
+        <div v-else class="p-6 sm:p-8 lg:p-12">
+          <div class="docs-content" v-html="docsData?.html" />
+        </div>
       </main>
     </div>
   </div>

--- a/app/pages/package-docs/[...path].vue
+++ b/app/pages/package-docs/[...path].vue
@@ -231,8 +231,8 @@ const stickyStyle = computed(() => {
           </div>
         </div>
 
-        <!-- eslint-disable vue/no-v-html -->
-        <div v-else class="p-6 sm:p-8 lg:p-12">
+        <div v-else class="container mx-auto py-6 sm:py-8 lg:py-12">
+          <!-- eslint-disable vue/no-v-html -->
           <div class="docs-content" v-html="docsData?.html" />
         </div>
       </main>


### PR DESCRIPTION
### 🔗 Linked issue
Closes #2894
See also #2895

### 🧭 Context
The docs page content area wasn't aligned with the rest of the page layout
loading skeletons and empty state stretched full-width inconsistently.
PR #2895 addressed this by centering the empty state, but @trueberryless 
suggested aligning with the container width instead, and also fixing the 
skeleton offset.

### 📚 Description
- Added `container mx-auto` to the loading skeleton and empty state divs
- Wrapped `docs-content` in a parent div to separate layout from content concerns

This aligns all three states (loading, empty, content) consistently with 
the container width used across the rest of the page.

### Screenshots

## before:

laptop:
<img width="1870" height="954" alt="laptop-before" src="https://github.com/user-attachments/assets/c5654bc6-1c20-47e3-8546-e4eba4606a2e" />

iphone-14-promax:
<img width="792" height="936" alt="iphone14-before" src="https://github.com/user-attachments/assets/423bfd0f-de54-4c00-a886-44fe28b1bfa2" />

## after

laptop:
<img width="1870" height="954" alt="laptop-after" src="https://github.com/user-attachments/assets/a12e49ac-9d10-4da7-b8f1-7cf9a52d2eed" />

iphone-14-promax:
<img width="718" height="930" alt="iphone14-after" src="https://github.com/user-attachments/assets/883e05a1-9fa6-4187-9815-e94491b1c21c" />
