### PR TITLE
fix(docs): align empty and skeleton docs tab on package page

### DIFF
--- a/app/pages/package-docs/[...path].vue
+++ b/app/pages/package-docs/[...path].vue
@@ -206,14 +206,14 @@ const stickyStyle = computed(() => {
 
       <!-- Main content -->
       <main class="flex-1 min-w-0">
-        <div v-if="showLoading" class="p-6 sm:p-8 lg:p-12 space-y-4">
+        <div v-if="showLoading" class="docs-page-content space-y-4">
           <SkeletonBlock class="h-8 w-64 rounded" />
           <SkeletonBlock class="h-4 w-full max-w-2xl rounded" />
           <SkeletonBlock class="h-4 w-5/6 max-w-2xl rounded" />
           <SkeletonBlock class="h-4 w-3/4 max-w-2xl rounded" />
         </div>
 
-        <div v-else-if="showEmptyState" class="p-6 sm:p-8 lg:p-12">
+        <div v-else-if="showEmptyState" class="docs-page-content">
           <div class="max-w-xl rounded-lg border border-border bg-bg-muted p-6">
             <h2 class="font-mono text-lg mb-2">{{ $t('package.docs.not_available') }}</h2>
             <p class="text-fg-subtle text-sm">
@@ -232,13 +232,16 @@ const stickyStyle = computed(() => {
         </div>
 
         <!-- eslint-disable vue/no-v-html -->
-        <div v-else class="docs-content p-6 sm:p-8 lg:p-12" v-html="docsData?.html" />
+        <div v-else class="docs-page-content docs-content" v-html="docsData?.html" />
       </main>
     </div>
   </div>
 </template>
 
 <style>
+.docs-page-content {
+  @apply container w-full py-6 lg:py-12;
+}
 .docs-header {
   top: var(--app-header-height);
 }


### PR DESCRIPTION
### 🔗 Linked issue

#2903 

### 🧭 Context

<img width="1919" height="888" alt="image" src="https://github.com/user-attachments/assets/311a0193-4428-4478-a89c-add8aa87b70e" />
<img width="1919" height="963" alt="image" src="https://github.com/user-attachments/assets/dd21b7b8-7eea-474a-b1eb-473208ec4741" />


### 📚 Description

In docs tab empty state and skeleton is not aligned with the package header and docs content area.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
