### PR TITLE
docs: add missing changelog and timeline routes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -435,23 +435,24 @@ The command palette is a first-class navigation surface. When you add a new user
 
 #### Available route names
 
-| Route name        | URL pattern                       | Parameters                |
-| ----------------- | --------------------------------- | ------------------------- |
-| `index`           | `/`                               | &mdash;                   |
-| `about`           | `/about`                          | &mdash;                   |
-| `compare`         | `/compare`                        | &mdash;                   |
-| `privacy`         | `/privacy`                        | &mdash;                   |
-| `search`          | `/search`                         | &mdash;                   |
-| `settings`        | `/settings`                       | &mdash;                   |
-| `package`         | `/package/:org?/:name`            | `org?`, `name`            |
-| `package-version` | `/package/:org?/:name/v/:version` | `org?`, `name`, `version` |
-| `code`            | `/package-code/:path+`            | `path` (array)            |
-| `docs`            | `/package-docs/:path+`            | `path` (array)            |
-| `changelog`       | `/package-changelog/:path+`       | `path` (array)            |
-| `timeline`        | `/package-timeline/:path+`        | `path` (array)            |
-| `org`             | `/org/:org`                       | `org`                     |
-| `~username`       | `/~:username`                     | `username`                |
-| `~username-orgs`  | `/~:username/orgs`                | `username`                |
+| Route name          | URL pattern                                       | Parameters                       |
+| ------------------- | ------------------------------------------------- | -------------------------------- |
+| `index`             | `/`                                               | &mdash;                          |
+| `about`             | `/about`                                          | &mdash;                          |
+| `compare`           | `/compare`                                        | &mdash;                          |
+| `privacy`           | `/privacy`                                        | &mdash;                          |
+| `search`            | `/search`                                         | &mdash;                          |
+| `settings`          | `/settings`                                       | &mdash;                          |
+| `package`           | `/package/:org?/:name`                            | `org?`, `name`                   |
+| `package-version`   | `/package/:org?/:name/v/:version`                 | `org?`, `name`, `version`        |
+| `code`              | `/package-code/:path+`                            | `path` (array)                   |
+| `docs`              | `/package-docs/:path+`                            | `path` (array)                   |
+| `changelog`         | `/package-changelog/:org?/:name`                  | `org?`, `name`                   |
+| `changelog-version` | `/package-changelog/:org?/:name/v/:version`       | `org?`, `name`, `version`        |
+| `timeline`          | `/package-timeline/:org?/:packageName/v/:version` | `org?`, `packageName`, `version` |
+| `org`               | `/org/:org`                                       | `org`                            |
+| `~username`         | `/~:username`                                     | `username`                       |
+| `~username-orgs`    | `/~:username/orgs`                                | `username`                       |
 
 ### Cursor and navigation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -447,6 +447,8 @@ The command palette is a first-class navigation surface. When you add a new user
 | `package-version` | `/package/:org?/:name/v/:version` | `org?`, `name`, `version` |
 | `code`            | `/package-code/:path+`            | `path` (array)            |
 | `docs`            | `/package-docs/:path+`            | `path` (array)            |
+| `changelog`       | `/package-changelog/:path+`       | `path` (array)            |
+| `timeline`        | `/package-timeline/:path+`        | `path` (array)            |
 | `org`             | `/org/:org`                       | `org`                     |
 | `~username`       | `/~:username`                     | `username`                |
 | `~username-orgs`  | `/~:username/orgs`                | `username`                |


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

Adds the missing route entries for package changelog and timeline pages to the route reference table in `CONTRIBUTING.md`.
- Added `/package-changelog/:path+`
- Added `/package-timeline/:path+`

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
