### PR TITLE
ci: fix in invalid `firewall-version` in deploy-canary.yml

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -30,7 +30,8 @@ jobs:
       - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
-          firewall-version: v1.12.0
+          # Version of the underlying sfw to use (no `v` prefix): https://github.com/SocketDev/sfw-free/releases
+          firewall-version: 1.12.0
 
       - run: sfw vp i -g vercel@54.12.2
       - run: vercel deploy --target=canary


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Follow-up to #2889.

The deploy-canary workflow (only runs on `main`) failed on merge: https://github.com/npmx-dev/npmx.dev/actions/runs/27503413651/job/81290268327.

The version needs to be specified without the `v` prefix.

This isn't well documented, but you can see it here: https://github.com/SocketDev/action/blob/ba6de6cc0565af1f42295590380973573297e31f/src/tools/firewall.js#L47.

### 📚 Description

Remove `v` prefix