### PR TITLE
feat(ui): add visible keyboard shortcut hints to the command palette

### DIFF
--- a/app/components/CommandPalette.client.vue
+++ b/app/components/CommandPalette.client.vue
@@ -303,7 +303,7 @@ useEventListener(document, 'keydown', handleGlobalKeydown)
           {{ statusMessage }}
         </p>
 
-        <div class="border-b border-border/70 bg-bg-subtle/60 px-4 py-4 sm:px-5">
+        <div class="bg-bg-subtle/60 px-4 py-4 sm:px-5">
           <button
             v-if="viewMeta.canGoBack"
             type="button"
@@ -330,6 +330,41 @@ useEventListener(document, 'keydown', handleGlobalKeydown)
             :aria-describedby="inputDescribedBy"
             :aria-controls="RESULTS_ID"
           />
+        </div>
+
+        <div
+          class="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-border/70 bg-bg-subtle/60 px-4 py-3 text-xs text-fg-subtle sm:px-5"
+          data-command-palette-footer="true"
+        >
+          <span class="inline-flex items-center gap-1.5">
+            <kbd
+              class="inline-flex min-w-6 items-center justify-center rounded border border-border bg-bg px-1.5 py-0.5 font-mono text-[0.7rem] text-fg-muted"
+            >
+              ↑
+            </kbd>
+            <kbd
+              class="inline-flex min-w-6 items-center justify-center rounded border border-border bg-bg px-1.5 py-0.5 font-mono text-[0.7rem] text-fg-muted"
+            >
+              ↓
+            </kbd>
+            <span class="lowercase">{{ $t('command_palette.footer.navigate') }}</span>
+          </span>
+          <span class="inline-flex items-center gap-1.5">
+            <kbd
+              class="inline-flex min-w-6 items-center justify-center rounded border border-border bg-bg px-1.5 py-0.5 font-mono text-[0.7rem] text-fg-muted"
+            >
+              ↵
+            </kbd>
+            <span class="lowercase">{{ $t('command_palette.footer.select') }}</span>
+          </span>
+          <span class="inline-flex items-center gap-1.5">
+            <kbd
+              class="inline-flex min-w-6 items-center justify-center rounded border border-border bg-bg px-1.5 py-0.5 font-mono text-[0.7rem] text-fg-muted"
+            >
+              Esc
+            </kbd>
+            <span class="lowercase">{{ $t('command_palette.footer.close') }}</span>
+          </span>
         </div>
 
         <div

--- a/app/components/CommandPalette.client.vue
+++ b/app/components/CommandPalette.client.vue
@@ -334,7 +334,7 @@ useEventListener(document, 'keydown', handleGlobalKeydown)
 
         <div
           class="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-border/70 bg-bg-subtle/60 px-4 py-3 text-xs text-fg-subtle sm:px-5"
-          data-command-palette-footer="true"
+          data-command-palette-keyboard-shortcuts="true"
         >
           <span class="inline-flex items-center gap-1.5">
             <kbd
@@ -347,7 +347,7 @@ useEventListener(document, 'keydown', handleGlobalKeydown)
             >
               ↓
             </kbd>
-            <span class="lowercase">{{ $t('command_palette.footer.navigate') }}</span>
+            <span class="lowercase">{{ $t('command_palette.keyboard_shortcuts.navigate') }}</span>
           </span>
           <span class="inline-flex items-center gap-1.5">
             <kbd
@@ -355,7 +355,7 @@ useEventListener(document, 'keydown', handleGlobalKeydown)
             >
               ↵
             </kbd>
-            <span class="lowercase">{{ $t('command_palette.footer.select') }}</span>
+            <span class="lowercase">{{ $t('command_palette.keyboard_shortcuts.select') }}</span>
           </span>
           <span class="inline-flex items-center gap-1.5">
             <kbd
@@ -363,7 +363,7 @@ useEventListener(document, 'keydown', handleGlobalKeydown)
             >
               Esc
             </kbd>
-            <span class="lowercase">{{ $t('command_palette.footer.close') }}</span>
+            <span class="lowercase">{{ $t('command_palette.keyboard_shortcuts.close') }}</span>
           </span>
         </div>
 

--- a/docs/app/components/BadgeGeneratorParameters.vue
+++ b/docs/app/components/BadgeGeneratorParameters.vue
@@ -253,9 +253,11 @@ const copyToClipboard = async () => {
         >
         <select
           v-model="badgeStyle"
-          class="min-w-30 px-3 py-1.5 rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-black/20 text-xs outline-none cursor-pointer hover:border-emerald-500 transition-colors"
+          class="min-w-30 px-3 py-1.5 rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-black/20 text-gray-900 dark:text-gray-100 text-xs outline-none cursor-pointer hover:border-emerald-500 transition-colors"
         >
-          <option v-for="s in styles" :key="s" :value="s">{{ s }}</option>
+          <option v-for="s in styles" :key="s" :value="s" class="dark:bg-gray-900">
+            {{ s }}
+          </option>
         </select>
       </div>
     </div>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -99,7 +99,7 @@
     "current": "current",
     "here": "you are here",
     "connected": "connected",
-    "footer": {
+    "keyboard_shortcuts": {
       "navigate": "to navigate",
       "select": "to select",
       "close": "to close"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -99,6 +99,11 @@
     "current": "current",
     "here": "you are here",
     "connected": "connected",
+    "footer": {
+      "navigate": "to navigate",
+      "select": "to select",
+      "close": "to close"
+    },
     "state": {
       "on": "on",
       "off": "off"

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -301,6 +301,21 @@
         "connected": {
           "type": "string"
         },
+        "footer": {
+          "type": "object",
+          "properties": {
+            "navigate": {
+              "type": "string"
+            },
+            "select": {
+              "type": "string"
+            },
+            "close": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "state": {
           "type": "object",
           "properties": {

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -301,7 +301,7 @@
         "connected": {
           "type": "string"
         },
-        "footer": {
+        "keyboard_shortcuts": {
           "type": "object",
           "properties": {
             "navigate": {

--- a/test/nuxt/components/CommandPalette.spec.ts
+++ b/test/nuxt/components/CommandPalette.spec.ts
@@ -98,6 +98,17 @@ describe('CommandPalette', () => {
     expect(input?.getAttribute('aria-controls')).toBe('command-palette-modal-results')
   })
 
+  it('shows keyboard shortcut hints in the palette footer', async () => {
+    await mountPalette()
+
+    const footer = document.querySelector('[data-command-palette-footer="true"]')
+
+    expect(footer).not.toBeNull()
+    expect(footer?.textContent).toContain('to navigate')
+    expect(footer?.textContent).toContain('to select')
+    expect(footer?.textContent).toContain('to close')
+  })
+
   it('updates the live region when the query changes', async () => {
     await mountPalette()
 

--- a/test/nuxt/components/CommandPalette.spec.ts
+++ b/test/nuxt/components/CommandPalette.spec.ts
@@ -98,15 +98,15 @@ describe('CommandPalette', () => {
     expect(input?.getAttribute('aria-controls')).toBe('command-palette-modal-results')
   })
 
-  it('shows keyboard shortcut hints in the palette footer', async () => {
+  it('shows keyboard shortcut hints in the command palette', async () => {
     await mountPalette()
 
-    const footer = document.querySelector('[data-command-palette-footer="true"]')
+    const shortcuts = document.querySelector('[data-command-palette-keyboard-shortcuts="true"]')
 
-    expect(footer).not.toBeNull()
-    expect(footer?.textContent).toContain('to navigate')
-    expect(footer?.textContent).toContain('to select')
-    expect(footer?.textContent).toContain('to close')
+    expect(shortcuts).not.toBeNull()
+    expect(shortcuts?.textContent).toContain('to navigate')
+    expect(shortcuts?.textContent).toContain('to select')
+    expect(shortcuts?.textContent).toContain('to close')
   })
 
   it('updates the live region when the query changes', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

#2910 

### 🧭 Context

<img width="1731" height="933" alt="image" src="https://github.com/user-attachments/assets/515a2daf-1d0d-45fc-9b09-12ca833dc55e" />

### 📚 Description

The command palette supports keyboard navigation, but the available shortcuts are not visible to users.

Currently users can navigate with:

↑ / ↓ to move between results
Enter to select
Esc to close
However, these shortcuts are not displayed anywhere in the command palette UI.


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
