### PR TITLE
fix: use `npx` to run lex build command for windows compat

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         command: 'knip && knip --production --exclude dependencies',
       },
       'generate:lexicons': {
-        command: 'lex build --lexicons lexicons --out shared/types/lexicons --clear',
+        command: 'npx lex build --lexicons lexicons --out shared/types/lexicons --clear',
       },
       'generate:sprite': {
         command: 'node scripts/generate-file-tree-sprite.ts',


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

none

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

Resolved an issue during `pnpm install` on Windows

```console
│ $ lex build --lexicons lexicons --out shared/types/lexicons --clear ◉ cache hit, replaying
│ ---
│ vp run: cache hit, 419ms saved.
│ $ node scripts/generate-file-tree-sprite.ts ◉ cache hit, replaying
│ ---
│ vp run: cache hit, 193ms saved.
│  ERROR  [unhandledRejection] Error while importing module C:/Users/24306/git_learning/npmx-dev/modules/security-headers.…
│ Require stack:
│ - C:\Users\24306\git_learning\npmx-dev\shared\utils\constants.ts
│     at loadNuxtModuleInstance (/C:/Users/24306/git_learning/npmx-dev/node_modules/.pnpm/@nuxt+kit@4.4.5_magicast@0.5.2/n…
│  ERROR  [unhandledRejection] Error while importing module C:/Users/24306/git_learning/npmx-dev/modules/standard-site-syn…
│ Require stack:
│ - C:\Users\24306\git_learning\npmx-dev\shared\utils\constants.ts
│     at loadNuxtModuleInstance (/C:/Users/24306/git_learning/npmx-dev/node_modules/.pnpm/@nuxt+kit@4.4.5_magicast@0.5.2/n…
│  ERROR  [unhandledRejection] Error while importing module C:/Users/24306/git_learning/npmx-dev/modules/blog.ts: Error: C…
│ Require stack:
│ - C:\Users\24306\git_learning\npmx-dev\shared\utils\constants.ts
│     at loadNuxtModuleInstance (/C:/Users/24306/git_learning/npmx-dev/node_modules/.pnpm/@nuxt+kit@4.4.5_magicast@0.5.2/n…
│  ERROR  Error while importing module C:/Users/24306/git_learning/npmx-dev/modules/blog.ts: Error: Cannot find module '..…
│ Require stack:
│ - C:\Users\24306\git_learning\npmx-dev\shared\utils\constants.ts
│     at loadNuxtModuleInstance (/C:/Users/24306/git_learning/npmx-dev/node_modules/.pnpm/@nuxt+kit@4.4.5_magicast@0.5.2/n…
└─ Failed in 3.3s at C:\Users\24306\git_learning\npmx-dev
[ELIFECYCLE] Command failed with exit code 1.
[ERROR] Command failed with exit code 1: "C:\Program Files\nodejs\node.exe" "C:\Users\24306\AppData\Local\pnpm\store\v11\links\@\pnpm\11.1.1\609303f0ed14bcc46c877b61a14f10e5fc0e12baa6026268fd68c5a6e134d86c\node_modules\pnpm\bin\pnpm.mjs" install
```

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

Just add `npx` in front of `lex build --lexicons lexicons --out shared/types/lexicons --clear` in `vite.config.ts`

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
