### PR TITLE
fix: disable transitions on dots when resizing zoom range

### DIFF
--- a/app/components/Package/TimelineChart.vue
+++ b/app/components/Package/TimelineChart.vue
@@ -914,6 +914,10 @@ const indexSelection = computed(() => {
   transition: all 0.5s var(--super-ease-out) !important;
 }
 
+:deep(.vdui-shape-no-transition) {
+  transition: none !important;
+}
+
 @media (prefers-reduced-motion: reduce) {
   ::deep(.vue-data-ui-component .serie_line_0 path),
   .svg-element-transition,

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "0.1.20",
     "vue": "3.5.34",
-    "vue-data-ui": "3.21.1",
+    "vue-data-ui": "3.21.5",
     "vue-router": "5.0.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,8 +253,8 @@ importers:
         specifier: 3.5.34
         version: 3.5.34(typescript@6.0.2)
       vue-data-ui:
-        specifier: 3.21.1
-        version: 3.21.1(vue@3.5.34)
+        specifier: 3.21.5
+        version: 3.21.5(vue@3.5.34)
       vue-router:
         specifier: 5.0.4
         version: 5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.34)
@@ -11226,8 +11226,11 @@ packages:
   vue-component-type-helpers@3.3.3:
     resolution: {integrity: sha512-x4nsFpy5Pe8fqPzp/5vkTPeTTDBpAx4WVtV47Ejt0+2FQrq4pRRsJs7JmYRqMFzTu/LW+pCWEjQ3YVCkPV7f9g==}
 
-  vue-data-ui@3.21.1:
-    resolution: {integrity: sha512-iInl5SNpQXuCF5pGrzJkdr83kfYevUP3slu9d4QMSK1qNc8WejLYeC/HHDDobei7hJvUqy8zSuZt/4vs7lhxWw==}
+  vue-component-type-helpers@3.3.5:
+    resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
+
+  vue-data-ui@3.21.5:
+    resolution: {integrity: sha512-+aIsMphMdTdWpNncgflZlJO2ZsyAvzJbYkCTn9g89o8YYW4PpGS5DbO5aKwEo1Nho2DsBSTtKRp6vVY9PelYuw==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -16102,7 +16105,7 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
       type-fest: 2.19.0
       vue: 3.5.34(typescript@6.0.2)
-      vue-component-type-helpers: 3.3.3
+      vue-component-type-helpers: 3.3.5
 
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
@@ -23830,7 +23833,9 @@ snapshots:
 
   vue-component-type-helpers@3.3.3: {}
 
-  vue-data-ui@3.21.1(vue@3.5.34):
+  vue-component-type-helpers@3.3.5: {}
+
+  vue-data-ui@3.21.5(vue@3.5.34):
     dependencies:
       vue: 3.5.34(typescript@6.0.2)
 


### PR DESCRIPTION
Resolves #2916 

- Update vue-data-ui to latest with a fix to disable dot transitions when resizing the zoom range ([release notes](https://github.com/graphieros/vue-data-ui/releases))
- Impact on the timeline chart

**Notes on why the lines and dots animate only when moving the zoom range, and why lines do not when moving a single handle:**
_Line paths and dots are transitioned when their size remain the same (for example when sliding a range selection without changing its length). When the range changes, a new svg path is computed, therefore cannot be transitioned from a previous state. However, since dot circles are reused, when changing the range size, remaining ones were transitioned to their new position. The fix therefore consists in preventing this transition for circles in the case of a range size change._