### PR TITLE
docs: add URL fragment note for color/labelColor in badges

### DIFF
--- a/docs/content/2.guide/6.badges.md
+++ b/docs/content/2.guide/6.badges.md
@@ -87,12 +87,28 @@ Overrides the default label color. You can pass a standard hex code (with or wit
 - **Default**: `#0a0a0a`
 - **Usage**: `?labelColor=HEX_CODE`
 
+::note
+In URLs, `#` starts the fragment part. If you write `?labelColor=#000000`, the `#000000` part is treated as a fragment and the query value is lost.
+
+- Wrong: `.../badge/version/nuxt?labelColor=#000000`
+- Correct (URL-encoded `#`): `.../badge/version/nuxt?labelColor=%23000000`
+- Also correct (no prefix): `.../badge/version/nuxt?labelColor=000000`
+  ::
+
 ### `color`
 
 Overrides the default strategy color. You can pass a standard hex code (with or without the `#` prefix). The text color is automatically chosen (black or white) based on WCAG contrast ratio, so the badge remains readable.
 
 - **Default**: Depends on the badge type (e.g., version is blue, downloads are orange).
 - **Usage**: `?color=HEX_CODE`
+
+::note
+In URLs, `#` starts the fragment part. If you write `?color=#000000`, the `#000000` part is treated as a fragment and the query value is lost.
+
+- Wrong: `.../badge/version/nuxt?color=#000000`
+- Correct (URL-encoded `#`): `.../badge/version/nuxt?color=%23000000`
+- Also correct (no prefix): `.../badge/version/nuxt?color=000000`
+  ::
 
 | Example        | URL                                   |
 | :------------- | :------------------------------------ |


### PR DESCRIPTION
This pull request improves the documentation for badge color customization by clarifying how to correctly use hex codes in URL query parameters. It adds helpful notes and examples to prevent common mistakes with URL encoding.

Documentation improvements:

* Added notes explaining that using `#` in query parameters (e.g., `?labelColor=#000000`) will cause the value to be ignored, and provided correct usage with URL-encoded `#` (`%23`) or by omitting the prefix.
* Included clear examples of both incorrect and correct URL formats for `labelColor` and `color` parameters.Adds a note explaining that # in query values is treated as a URL fragment start, causing the value to be lost. Includes wrong and correct usage examples (URL-encoded %23 or omitting the prefix).

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
