### PR TITLE
feat(i18n): add Korean translations

### DIFF
--- a/config/i18n.ts
+++ b/config/i18n.ts
@@ -306,12 +306,12 @@ const locales: (LocaleObjectData | (Omit<LocaleObjectData, 'code'> & { code: str
       code: 'gl-ES',
       file: 'gl-ES.json',
       name: 'Galego',
-    },
-    {
-      code: 'ko-KR',
-      file: 'ko-KR.json',
-      name: '한국어',
     },*/
+  {
+    code: 'ko-KR',
+    file: 'ko-KR.json',
+    name: '한국어',
+  },
   {
     code: 'id-ID',
     file: 'id-ID.json',

--- a/i18n/locales/ko-KR.json
+++ b/i18n/locales/ko-KR.json
@@ -1,0 +1,1788 @@
+{
+  "$schema": "../schema.json",
+  "seo": {
+    "home": {
+      "title": "npmx - npm 레지스트리를 위한 패키지 브라우저",
+      "description": "npm 레지스트리를 위한 빠르고 현대적인 브라우저입니다. 현대적인 인터페이스로 패키지를 검색하고, 둘러보고, 탐색하세요."
+    }
+  },
+  "built_at": "빌드 {0}",
+  "alt_logo": "npmx 로고",
+  "tagline": "npm 레지스트리를 위한 빠르고 현대적인 브라우저",
+  "non_affiliation_disclaimer": "npm, Inc.와 관련이 없습니다.",
+  "trademark_disclaimer": "npm은 npm, Inc.의 등록 상표입니다. 이 사이트는 npm, Inc.와 관련이 없습니다.",
+  "footer": {
+    "about": "소개",
+    "blog": "블로그",
+    "docs": "문서",
+    "source": "소스",
+    "social": "소셜",
+    "chat": "채팅",
+    "builders_chat": "빌더",
+    "keyboard_shortcuts": "키보드 단축키",
+    "brand": "브랜드",
+    "resources": "리소스",
+    "features": "기능",
+    "other": "기타"
+  },
+  "shortcuts": {
+    "section": {
+      "global": "전역",
+      "search": "검색",
+      "package": "패키지"
+    },
+    "ctrl_key": "Ctrl",
+    "command_palette": "명령 팔레트 열기",
+    "command_palette_description": "명령 팔레트로 키보드에서 손을 떼지 않고 페이지, 패키지 보기, 설정, 외부 링크 사이를 이동할 수 있습니다. macOS에서는 ⌘K를, Windows와 Linux에서는 {ctrlKey}+K를 누르세요.",
+    "focus_search": "검색에 포커스",
+    "show_kbd_hints": "키보드 힌트 강조",
+    "settings": "설정 열기",
+    "compare": "비교 열기",
+    "compare_from_package": "비교 열기(현재 패키지로 자동 입력)",
+    "navigate_results": "결과 탐색",
+    "go_to_result": "결과로 이동",
+    "open_code_view": "코드 보기 열기",
+    "open_docs": "문서 열기",
+    "disable_shortcuts": "{settings}에서 키보드 단축키를 비활성화할 수 있습니다.",
+    "open_main": "주요 정보 열기",
+    "open_diff": "버전 차이 열기",
+    "open_timeline": "타임라인 열기",
+    "open_stats": "통계 열기"
+  },
+  "search": {
+    "label": "npm 패키지 검색",
+    "placeholder": "패키지 검색...",
+    "button": "검색",
+    "searching": "검색 중...",
+    "found_packages": "패키지를 찾을 수 없습니다 | 패키지 1개를 찾았습니다 | 패키지 {count}개를 찾았습니다",
+    "found_packages_sorted": "결과를 찾을 수 없습니다 | 상위 {count}개 결과 정렬 중 | 상위 {count}개 결과 정렬 중",
+    "updating": "(업데이트 중...)",
+    "no_results": "\"{query}\"에 대한 패키지를 찾을 수 없습니다",
+    "rate_limited": "npm 요청 제한에 도달했습니다. 잠시 후 다시 시도하세요",
+    "title": "검색",
+    "title_search": "검색: {search}",
+    "title_packages": "패키지 검색",
+    "meta_description": "'{search}' 검색 결과",
+    "meta_description_packages": "npm 패키지 검색",
+    "not_taken": "{name}은 아직 사용되지 않았습니다",
+    "claim_prompt": "npm에서 이 패키지 이름 등록하기",
+    "claim_button": "\"{name}\" 등록",
+    "want_to_claim": "이 패키지 이름을 등록하시겠습니까?",
+    "start_typing": "패키지를 검색하려면 입력을 시작하세요",
+    "algolia_disclaimer": "Algolia 제공",
+    "exact_match": "정확히 일치",
+    "suggestion": {
+      "user": "사용자",
+      "org": "조직",
+      "view_user_packages": "이 사용자의 패키지 보기",
+      "view_org_packages": "이 조직의 패키지 보기"
+    },
+    "instant_search": "즉시 검색",
+    "instant_search_on": "켜짐",
+    "instant_search_off": "꺼짐",
+    "instant_search_turn_on": "켜기",
+    "instant_search_turn_off": "끄기",
+    "instant_search_advisory": "{label} {state} — {action}"
+  },
+  "command_palette": {
+    "title": "명령 팔레트",
+    "quick_actions": "이동...",
+    "subtitle": "npmx 안에서 빠르게 이동하고 설정을 전환하세요",
+    "subtitle_languages": "언어를 선택하거나 번역 개선을 도와주세요",
+    "instructions": "명령을 필터링하려면 입력하세요. 화살표 키로 결과를 이동하고 Enter로 실행합니다.",
+    "input_label": "명령 팔레트 검색",
+    "results_label": "명령 결과",
+    "placeholder": "명령 입력...",
+    "back": "뒤로",
+    "empty": "일치하는 명령이 없습니다",
+    "empty_search_hint": "\"{query}\"를 검색하려면 Enter를 누르세요.",
+    "current": "현재",
+    "here": "현재 위치",
+    "connected": "연결됨",
+    "keyboard_shortcuts": {
+      "navigate": "탐색",
+      "select": "선택",
+      "close": "닫기"
+    },
+    "state": {
+      "on": "켜짐",
+      "off": "꺼짐"
+    },
+    "groups": {
+      "actions": "작업",
+      "help": "도움말",
+      "language": "언어",
+      "connections": "연결",
+      "navigation": "탐색",
+      "links": "링크",
+      "npmx": "npmx",
+      "package": "패키지",
+      "package_with_name": "패키지 ({name})",
+      "versions": "버전",
+      "versions_with_name": "{name}의 버전"
+    },
+    "actions": {
+      "search": "검색",
+      "search_for": "\"{query}\" 검색",
+      "keyboard_shortcuts": "키보드 단축키",
+      "help_translate": "번역 도와주기"
+    },
+    "connections": {
+      "npm_connect": "npm CLI에 연결",
+      "npm_connected": "npm CLI (~{username})",
+      "npm_disconnect": "npm CLI 연결 해제",
+      "atmosphere_connect": "Atmosphere에 연결",
+      "atmosphere_connected": "atmosphere ({'@'}{handle})",
+      "atmosphere_disconnect": "Atmosphere 연결 해제"
+    },
+    "navigation": {
+      "home": "홈",
+      "packages": "패키지 (~{username})",
+      "orgs": "조직 (~{username})",
+      "profile": "프로필 ({'@'}{handle})"
+    },
+    "links": {
+      "external": "외부 링크"
+    },
+    "package_links": {
+      "stars": "저장소 스타 수",
+      "forks": "저장소 포크 수"
+    },
+    "theme": {
+      "system": "시스템 테마 사용",
+      "light": "라이트 테마 사용",
+      "dark": "다크 테마 사용"
+    },
+    "package": {
+      "main": "패키지 페이지",
+      "docs": "문서",
+      "code": "코드",
+      "diff": "차이",
+      "compare": "이 패키지 비교",
+      "download": "패키지 압축파일 다운로드",
+      "changelog": "변경 기록",
+      "stats": "통계"
+    },
+    "package_actions": {
+      "copy_run": "실행 명령 복사"
+    },
+    "code": {
+      "copy_file": "파일 내용 복사"
+    },
+    "diff": {
+      "merge_modified_lines": "수정된 줄 병합",
+      "word_wrap": "자동 줄바꿈"
+    },
+    "version": {
+      "label": "{version}"
+    },
+    "status": {
+      "available_in_context": "{context}. 사용 가능한 명령이 없습니다 | {context}. 사용 가능한 명령 1개 | {context}. 사용 가능한 명령 {count}개",
+      "matching_in_context": "{context}. 일치하는 명령이 없습니다 | {context}. 일치하는 명령 1개 | {context}. 일치하는 명령 {count}개",
+      "no_matches_search_in_context": "{context}. 일치하는 명령이 없습니다. \"{query}\"를 검색하려면 Enter를 누르세요."
+    },
+    "announcements": {
+      "language_changed": "언어가 {language}(으)로 설정되었습니다.",
+      "relative_dates_on": "상대 날짜가 켜졌습니다.",
+      "relative_dates_off": "상대 날짜가 꺼졌습니다.",
+      "theme_changed": "테마가 {theme}(으)로 설정되었습니다.",
+      "accent_color_changed": "강조 색상이 {color}(으)로 설정되었습니다.",
+      "background_theme_changed": "배경 음영이 {theme}(으)로 설정되었습니다.",
+      "download_started": "{package} 패키지 압축 파일을 다운로드하는 중입니다.",
+      "copied_to_clipboard": "클립보드에 복사했습니다.",
+      "npm_disconnected": "npm CLI 연결이 해제되었습니다.",
+      "atmosphere_disconnected": "Atmosphere 연결이 해제되었습니다.",
+      "facets_all_deselected": "모든 항목 선택을 해제했습니다.",
+      "facets_all_selected": "모든 항목을 선택했습니다.",
+      "view_switched": "{view} 보기로 전환했습니다.",
+      "setting_toggled": "{setting} {state}."
+    }
+  },
+  "nav": {
+    "main_navigation": "메인",
+    "popular_packages": "인기 패키지",
+    "settings": "설정",
+    "compare": "비교",
+    "back": "뒤로",
+    "menu": "메뉴",
+    "mobile_menu": "탐색 메뉴",
+    "open_menu": "메뉴 열기",
+    "links": "링크",
+    "tap_to_search": "탭해서 검색"
+  },
+  "blog": {
+    "title": "블로그",
+    "heading": "블로그",
+    "meta_description": "npmx 커뮤니티의 인사이트와 업데이트",
+    "author": {
+      "view_profile": "Bluesky에서 {name}의 프로필 보기"
+    },
+    "draft_badge": "초안",
+    "draft_banner": "게시되지 않은 초안입니다. 내용이 불완전하거나 부정확할 수 있습니다.",
+    "no_posts": "게시물을 찾을 수 없습니다.",
+    "atproto": {
+      "view_on_bluesky": "Bluesky에서 보기",
+      "reply_on_bluesky": "Bluesky에서 답글 달기",
+      "likes_on_bluesky": "Bluesky 좋아요",
+      "like_or_reply_on_bluesky": "Bluesky에서 이 게시물에 좋아요를 누르거나 댓글을 남기세요",
+      "no_comments_yet": "아직 댓글이 없습니다.",
+      "could_not_load_comments": "댓글을 불러올 수 없습니다.",
+      "comments": "댓글",
+      "loading_comments": "댓글을 불러오는 중...",
+      "updating": "업데이트 중...",
+      "reply_count": "답글 {count}개 | 답글 {count}개",
+      "like_count": "좋아요 {count}개 | 좋아요 {count}개",
+      "repost_count": "재게시 {count}개 | 재게시 {count}개",
+      "more_replies": "답글 {count}개 더 보기... | 답글 {count}개 더 보기..."
+    }
+  },
+  "noodles": {
+    "title": "noodles",
+    "meta_description": "npmx에서 선보였던 모든 noodles, 시즌 로고와 이스터에그, 그리고 그 뒤의 이야기를 모았습니다.",
+    "latest": "최신 noodles",
+    "what_is": "noodles란?",
+    "what_is_body": "noodles은 릴리스, 휴일, 이벤트, 기념할 만한 순간을 표시하기 위해 홈페이지에 사용하는 npmx 로고의 장난스러운 변형입니다. npm 패키지를 위한 Google Doodles 같은 것으로 생각하면 됩니다.",
+    "empty": "아직 noodles가 없습니다.",
+    "load_more": "{count}개 더 불러오기",
+    "dates": "활성 날짜",
+    "shipped_in": "포함된 릴리스",
+    "credits": "크레딧",
+    "learn_more": "자세히 알아보기",
+    "carousel_prev": "이전 이미지",
+    "carousel_next": "다음 이미지",
+    "carousel_dots": "변형 이미지 탐색",
+    "carousel_jump": "이미지 {index}(으)로 이동",
+    "lens_label": "{title} — 이미지 릴",
+    "lens_slide": "이미지 {index}",
+    "lens_slide_position": "{total}개 중 {index}번째 슬라이드",
+    "back_to_archive": "모든 noodles로 돌아가기",
+    "missing": {
+      "title": "이 noodles는 그릇 밖으로 나오지 못했습니다.",
+      "body": "메뉴에 “{slug}” noodles가 없습니다. 아직 준비 중이거나 처음부터 작성되지 않았을 수 있습니다. 어느 쪽이든 아카이브로 돌아가세요."
+    }
+  },
+  "settings": {
+    "title": "설정",
+    "tagline": "npmx 경험을 맞춤 설정하세요",
+    "meta_description": "테마, 언어, 표시 환경설정으로 npmx.dev 경험을 맞춤 설정하세요.",
+    "sections": {
+      "appearance": "외형",
+      "display": "표시",
+      "search": "검색 기능",
+      "language": "언어",
+      "keyboard_shortcuts": "키보드 단축키"
+    },
+    "data_source": {
+      "label": "데이터 소스",
+      "description": "npmx가 검색 데이터를 가져올 위치를 선택하세요. 개별 패키지 페이지는 항상 npm 레지스트리를 직접 사용합니다.",
+      "npm": "npm 레지스트리",
+      "npm_description": "공식 npm 레지스트리에서 검색, 조직, 사용자 목록을 직접 가져옵니다. 가장 신뢰할 수 있지만 느릴 수 있습니다.",
+      "algolia": "Algolia",
+      "algolia_description": "검색, 조직, 사용자 페이지를 더 빠르게 표시하기 위해 Algolia를 사용합니다."
+    },
+    "instant_search": "즉시 검색",
+    "instant_search_description": "입력하는 동안 검색 페이지로 이동하고 결과를 업데이트합니다.",
+    "relative_dates": "상대 날짜",
+    "include_types": "설치 명령에 {'@'}types 포함",
+    "include_types_description": "타입이 없는 패키지의 설치 명령에 {'@'}types 패키지를 추가합니다",
+    "hide_platform_packages": "검색에서 플랫폼별 패키지 숨기기",
+    "hide_platform_packages_description": "{'@'}esbuild/linux-x64 같은 네이티브 바이너리 패키지를 결과에서 숨깁니다",
+    "enable_graph_pulse_loop": "미니 그래프의 펄스 효과 반복 켜기",
+    "enable_graph_pulse_loop_description": "주간 다운로드 그래프에 지속적인 펄스 애니메이션을 활성화합니다. 이 애니메이션은 일부 사용자에게 산만하게 느껴질 수 있습니다.",
+    "theme": "테마",
+    "theme_light": "라이트",
+    "theme_dark": "다크",
+    "theme_system": "시스템",
+    "language": "언어",
+    "help_translate": "npmx 번역 도와주기",
+    "translation_status": "전체 번역 상태 확인",
+    "accent_colors": {
+      "label": "강조 색상",
+      "neutral": "뉴트럴",
+      "sky": "스카이",
+      "coral": "코랄",
+      "amber": "앰버",
+      "emerald": "에메랄드",
+      "violet": "바이올렛",
+      "magenta": "마젠타"
+    },
+    "clear_accent": "강조 색상 지우기",
+    "translation_progress": "번역 진행률",
+    "background_themes": {
+      "label": "배경 음영",
+      "neutral": "뉴트럴",
+      "stone": "스톤",
+      "zinc": "징크",
+      "slate": "슬레이트",
+      "black": "블랙"
+    },
+    "keyboard_shortcuts_enabled": "키보드 단축키 켜기",
+    "keyboard_shortcuts_enabled_description": "브라우저나 시스템 단축키와 충돌하는 경우 키보드 단축키를 비활성화할 수 있습니다",
+    "enable_code_ligatures": "코드에서 리가처 켜기",
+    "enable_changelog_autoscroll": "요청한 버전으로 자동 스크롤",
+    "enable_changelog_autoscroll_description": "패키지 변경 기록에서 요청한 버전 또는 그 근처로 자동 스크롤합니다"
+  },
+  "i18n": {
+    "missing_keys": "누락된 번역 {count}건 | 누락된 번역 {count}개",
+    "copy_keys": "키 복사",
+    "show_more_keys": "{count}개 더 보기...",
+    "contribute_hint": "누락된 키를 추가해 이 번역을 개선해 주세요.",
+    "edit_on_github": "GitHub에서 편집",
+    "view_guide": "번역 가이드"
+  },
+  "error": {
+    "401": "권한이 없습니다",
+    "404": "페이지를 찾을 수 없습니다",
+    "500": "내부 서버 에러",
+    "503": "서비스를 사용할 수 없습니다",
+    "default": "문제가 발생했습니다"
+  },
+  "common": {
+    "loading": "로딩 중...",
+    "loading_more": "더 불러오는 중...",
+    "loading_packages": "패키지를 불러오는 중...",
+    "end_of_results": "결과의 끝",
+    "try_again": "다시 시도",
+    "close": "닫기",
+    "or": "또는",
+    "retry": "재시도",
+    "copy": "복사",
+    "copied": "복사됨!",
+    "skip_link": "본문으로 건너뛰기",
+    "warnings": "경고:",
+    "go_back_home": "홈으로 돌아가기",
+    "per_week": "/ 주",
+    "per_week_short": "/주",
+    "vanity_downloads_hint": "표시용 숫자: 표시된 패키지 없음 | 표시용 숫자: 표시된 패키지 기준 | 표시용 숫자: 표시된 패키지 {count}개의 합계",
+    "sort": {
+      "name": "이름",
+      "role": "역할",
+      "members": "멤버"
+    },
+    "scroll_to_top": "맨 위로 스크롤",
+    "cancel": "취소",
+    "save": "저장",
+    "edit": "편집",
+    "error": "에러",
+    "view_on": {
+      "npm": "npm에서 보기",
+      "github": "GitHub에서 보기",
+      "gitlab": "GitLab에서 보기",
+      "bitbucket": "Bitbucket에서 보기",
+      "codeberg": "Codeberg에서 보기",
+      "git_repo": "Git 저장소에서 보기",
+      "forgejo": "Forgejo에서 보기",
+      "gitea": "Gitea에서 보기",
+      "gitee": "Gitee에서 보기",
+      "radicle": "Radicle에서 보기",
+      "socket_dev": "socket.dev에서 보기",
+      "sourcehut": "SourceHut에서 보기",
+      "tangled": "Tangled에서 보기"
+    },
+    "collapse": "접기",
+    "collapse_with_name": "{name} 접기",
+    "expand": "펼치기",
+    "expand_with_name": "{name} 펼치기"
+  },
+  "profile": {
+    "display_name": "표시 이름",
+    "description": "설명",
+    "no_description": "설명 없음",
+    "website": "웹사이트",
+    "website_placeholder": "https://example.com",
+    "likes": "좋아요",
+    "seo_title": "{handle} - npmx",
+    "seo_description": "{handle}의 npmx 프로필",
+    "not_found": "프로필을 찾을 수 없습니다",
+    "not_found_message": "{handle}의 프로필을 찾을 수 없습니다.",
+    "invite": {
+      "message": "아직 npmx를 사용하지 않는 것 같습니다. 알려주시겠어요?",
+      "share_button": "Bluesky에 공유",
+      "compose_text": "안녕하세요 {'@'}{handle}! npmx.dev를 확인해 보셨나요? 빠르고 현대적인 오픈소스 npm 레지스트리 브라우저입니다.\nhttps://npmx.dev"
+    }
+  },
+  "package": {
+    "not_found": "패키지를 찾을 수 없습니다",
+    "not_found_message": "패키지를 찾을 수 없습니다.",
+    "no_description": "제공된 설명 없음",
+    "verified_provenance": "검증된 출처",
+    "navigation": "패키지",
+    "copy_name": "패키지 이름 복사",
+    "deprecation": {
+      "package": "이 패키지는 사용 중단되었습니다.",
+      "version": "이 버전은 사용 중단되었습니다.",
+      "no_reason": "제공된 사유 없음"
+    },
+    "size_increase": {
+      "title_size": "v{version} 이후 크기가 크게 증가했습니다",
+      "title_deps": "v{version} 이후 의존성 수가 크게 증가했습니다",
+      "title_both": "v{version} 이후 크기와 의존성이 크게 증가했습니다",
+      "size": "설치 크기가 {percent} 증가했습니다({size} 더 큼)",
+      "deps": "의존성 {count}개 증가 | 의존성 {count}개 증가"
+    },
+    "size_decrease": {
+      "title_size": "v{version} 이후 패키지 크기가 줄었습니다!",
+      "title_deps": "v{version} 이후 의존성 수가 줄었습니다!",
+      "title_both": "v{version} 이후 패키지 크기와 의존성 수가 줄었습니다!",
+      "size": "설치 크기가 {percent} 감소했습니다({size} 더 작음)",
+      "deps": "의존성 {count}개 감소 | 의존성 {count}개 감소"
+    },
+    "replacement": {
+      "title": "이 의존성이 필요하지 않을 수 있습니다.",
+      "example": "예:",
+      "native": "이 패키지는 Node {nodeVersion}부터 사용할 수 있는 {replacement}(으)로 대체할 수 있습니다.",
+      "native_no_version": "이 패키지는 {replacement}(으)로 대체할 수 있습니다.",
+      "simple": "이 패키지는 중복으로 표시되었으며 다음 권장 사항이 있습니다: {replacement}",
+      "documented": "이 패키지는 더 성능 좋은 대안이 있는 것으로 표시되었습니다.",
+      "none": "이 패키지는 더 이상 필요하지 않은 것으로 표시되었으며, 해당 기능은 대부분 모든 엔진에서 네이티브로 제공될 가능성이 높습니다.",
+      "learn_more": "자세히 알아보기",
+      "learn_more_above": "위에서 자세히 알아보세요.",
+      "consider_no_dep": "+ 무의존성 고려?"
+    },
+    "stats": {
+      "license": "라이선스",
+      "deps": "의존성",
+      "install_size": "설치 크기",
+      "vulns": "취약점",
+      "published": "게시됨",
+      "published_tooltip": "{package}{'@'}{version}이 게시된 날짜",
+      "view_dependency_graph": "의존성 그래프 보기",
+      "inspect_dependency_tree": "의존성 트리 검사",
+      "size_tooltip": {
+        "unpacked": "{size} 압축 해제 크기(이 패키지)",
+        "total": "{size} 전체 압축 해제 크기(linux-x64용 의존성 {count}개 포함) | {size} 전체 압축 해제 크기(linux-x64용 모든 의존성 {count}개 포함)"
+      },
+      "main_information": "주요 정보",
+      "trends": "트렌드",
+      "version_distribution": "버전 분포"
+    },
+    "skills": {
+      "title": "에이전트 스킬",
+      "skills_available": "사용 가능한 스킬 {count}개 | 사용 가능한 스킬 {count}개",
+      "compatible_with": "{tool}와 호환",
+      "install": "설치",
+      "installation_method": "설치 방법",
+      "learn_more": "자세히 알아보기",
+      "available_skills": "사용 가능한 스킬",
+      "click_to_expand": "클릭해서 펼치기",
+      "no_description": "설명 없음",
+      "file_counts": {
+        "scripts": "스크립트 {count}개 | 스크립트 {count}개",
+        "refs": "참조 {count}개 | 참조 {count}개",
+        "assets": "에셋 {count}개 | 에셋 {count}개"
+      },
+      "view_source": "소스 보기",
+      "skills_cli": "스킬 CLI"
+    },
+    "links": {
+      "main": "메인",
+      "repo": "저장소",
+      "homepage": "홈페이지",
+      "issues": "이슈",
+      "jsr": "JSR",
+      "code": "코드",
+      "docs": "문서",
+      "fund": "후원",
+      "compare": "비교",
+      "timeline": "타임라인",
+      "stats": "통계",
+      "compare_this_package": "이 패키지 비교",
+      "changelog": "변경 기록"
+    },
+    "likes": {
+      "like": "이 패키지 좋아요",
+      "unlike": "이 패키지 좋아요 취소",
+      "top_rank_tooltip": "npmx에서 좋아요가 가장 많은 상위 10개 패키지 중 하나입니다! (#{rank})",
+      "top_rank_label": "#{rank}",
+      "top_rank_link_label": "좋아요 리더보드 보기. 이 패키지는 #{rank}위입니다."
+    },
+    "docs": {
+      "contents": "목차",
+      "default_not_available": "이 버전의 문서를 사용할 수 없습니다.",
+      "not_available": "문서를 사용할 수 없습니다",
+      "not_available_detail": "이 버전의 문서를 생성할 수 없습니다.",
+      "page_title": "API 문서 - npmx",
+      "page_title_name": "{name} 문서 - npmx",
+      "page_title_version": "{name} 문서 - npmx",
+      "og_title": "{name} - 문서",
+      "view_package": "패키지 보기"
+    },
+    "get_started": {
+      "title": "시작하기",
+      "pm_label": "패키지 매니저",
+      "copy_command": "설치 명령 복사",
+      "copy_dev_command": "개발 의존성 설치 명령 복사",
+      "dev_dependency_hint": "일반적으로 개발 의존성으로 설치됩니다",
+      "view_types": "{package} 보기"
+    },
+    "create": {
+      "title": "새 프로젝트 만들기",
+      "copy_command": "생성 명령 복사",
+      "view": "{packageName}은 같은 메인테이너가 관리합니다. 자세한 내용을 보려면 클릭하세요."
+    },
+    "run": {
+      "title": "실행",
+      "locally": "로컬에서 실행"
+    },
+    "readme": {
+      "title": "README",
+      "no_readme": "사용 가능한 README가 없습니다.",
+      "toc_title": "개요",
+      "callout": {
+        "note": "참고",
+        "tip": "팁",
+        "important": "중요",
+        "warning": "경고",
+        "caution": "주의"
+      },
+      "copy_as_markdown": "README를 Markdown으로 복사",
+      "error_loading": "README 세부 정보를 불러오지 못했습니다"
+    },
+    "provenance_section": {
+      "title": "출처 증명",
+      "built_and_signed_on": "{provider}에서 빌드 및 서명됨",
+      "view_build_summary": "빌드 요약 보기",
+      "source_commit": "소스 커밋",
+      "build_file": "빌드 파일",
+      "public_ledger": "공개 원장",
+      "transparency_log_entry": "투명성 로그 항목",
+      "view_more_details": "자세한 내용 보기",
+      "error_loading": "출처 세부 정보를 불러오지 못했습니다"
+    },
+    "security_downgrade": {
+      "title": "신뢰도 하락",
+      "description_to_none_provenance": "이 버전은 {provenance}를 사용하지 않고 게시되었습니다.",
+      "description_to_none_trustedPublisher": "이 버전은 {trustedPublishing}를 사용하지 않고 게시되었습니다.",
+      "description_to_provenance_trustedPublisher": "이 버전은 {provenance}를 사용하지만 {trustedPublishing}를 사용하지 않습니다.",
+      "fallback_install_provenance": "설치 명령은 출처가 포함된 마지막 버전인 {version}에 고정됩니다.",
+      "fallback_install_trustedPublisher": "설치 명령은 신뢰할 수 있는 게시가 포함된 마지막 버전인 {version}에 고정됩니다.",
+      "provenance_link_text": "출처",
+      "trusted_publishing_link_text": "신뢰할 수 있는 게시"
+    },
+    "keywords_title": "키워드",
+    "compatibility": "호환성",
+    "card": {
+      "publisher": "게시자",
+      "published": "게시됨",
+      "weekly_downloads": "주간 다운로드",
+      "keywords": "키워드",
+      "license": "라이선스",
+      "version": "버전",
+      "select": "패키지 선택",
+      "select_maximum": "최대 {count}개 패키지를 선택할 수 있습니다"
+    },
+    "versions": {
+      "title": "버전",
+      "collapse": "{tag} 접기",
+      "expand": "{tag} 펼치기",
+      "collapse_other": "다른 버전 접기",
+      "expand_other": "다른 버전 펼치기",
+      "collapse_major": "메이저 {major} 접기",
+      "expand_major": "메이저 {major} 펼치기",
+      "other_versions": "다른 버전",
+      "more_tagged": "태그된 항목 {count}개 더 있음",
+      "all_covered": "모든 버전이 위 태그에 포함됩니다",
+      "deprecated_title": "{version} (사용 중단됨)",
+      "view_all": "{count}개 버전 보기 | 전체 {count}개 버전 보기",
+      "view_all_versions": "모든 버전 보기",
+      "distribution_title": "Semver 그룹",
+      "distribution_range_date_same_year": "{from}부터 {to}, {endYear}까지",
+      "distribution_range_date_multiple_years": "{from}, {startYear}부터 {to}, {endYear}까지",
+      "grouping_major": "메이저",
+      "grouping_minor": "마이너",
+      "grouping_versions_title": "버전",
+      "grouping_versions_about": "버전 그룹화 정보",
+      "grouping_versions_all": "전체",
+      "grouping_versions_only_recent": "최근만",
+      "grouping_usage_title": "사용량",
+      "grouping_usage_about": "사용량 그룹화 정보",
+      "grouping_usage_all": "전체",
+      "grouping_usage_most_used": "가장 많이 사용됨",
+      "recent_versions_only_tooltip": "지난 1년 안에 게시된 버전만 표시합니다.",
+      "show_low_usage_tooltip": "전체 다운로드의 1% 미만인 버전 그룹도 포함합니다.",
+      "y_axis_label": "다운로드",
+      "filter_placeholder": "semver로 필터링(예: ^3.0.0)",
+      "filter_invalid": "잘못된 semver 범위",
+      "filter_help": "Semver 범위 필터 도움말",
+      "filter_tooltip": "{link}로 버전을 필터링합니다. 예를 들어 ^3.0.0은 모든 3.x 버전을 표시합니다.",
+      "filter_tooltip_link": "semver 범위",
+      "license_change_help": "라이선스 변경 세부 정보",
+      "license_change_warning": "이전 버전 이후 라이선스가 변경되었습니다.",
+      "license_change_record": "이 패키지의 라이선스가 \"{from}\"에서 \"{to}\"(으)로 변경되었습니다.",
+      "no_matches": "이 범위와 일치하는 버전이 없습니다",
+      "copy_alt": {
+        "per_version_analysis": "{version} 버전은 {downloads}회 다운로드되었습니다",
+        "general_description": "{package_name} 패키지의 {semver_grouping_mode} 버전 {versions_count}개에 대한 버전별 다운로드를 보여주는 막대 차트입니다. 범위는 {date_range_label}, {first_version} 버전부터 {last_version} 버전까지입니다. 가장 많이 다운로드된 버전은 {max_downloaded_version}이며 다운로드 수는 {max_version_downloads}회입니다. {per_version_analysis}. {watermark}."
+      },
+      "page_title": "버전 기록",
+      "current_tags": "현재 태그",
+      "no_match_filter": "{filter}와 일치하는 버전이 없습니다"
+    },
+    "timeline": {
+      "load_more": "더 불러오기",
+      "load_error": "타임라인을 불러오지 못했습니다. 나중에 다시 시도하세요.",
+      "size_increase": "설치 크기가 {percent}% 증가했습니다({size})",
+      "size_decrease": "설치 크기가 {percent}% 감소했습니다({size})",
+      "dep_increase": "의존성 {count}개 추가 | 의존성 {count}개 추가",
+      "dep_decrease": "의존성 {count}개 제거 | 의존성 {count}개 제거",
+      "license_change": "라이선스가 {from}에서 {to}(으)로 변경됨",
+      "esm_added": "모듈 타입이 ESM으로 변경됨",
+      "esm_removed": "모듈 타입이 ESM에서 CJS로 변경됨",
+      "types_added": "TypeScript 타입 추가됨",
+      "types_removed": "TypeScript 타입 제거됨",
+      "trusted_publisher_added": "신뢰할 수 있는 게시 활성화됨",
+      "trusted_publisher_removed": "신뢰할 수 있는 게시 제거됨",
+      "provenance_added": "출처 증명 활성화됨",
+      "provenance_removed": "출처 증명 제거됨",
+      "chart": {
+        "tab_aria_label": "지표 선택",
+        "base_scale": "y축을 0에서 시작",
+        "zoom": "확대",
+        "reset_minimap": "미니맵 재설정",
+        "ordered_versions": "안정 버전만",
+        "copy_alt": {
+          "key_changes": "주요 변경 사항: {version_events}.",
+          "version_events": "버전 {version}: {events}",
+          "general_description": "{package} 패키지의 {metric}을 {first} 버전부터 {last} 버전까지 보여주는 선 차트입니다. {first} 버전의 {metric}은 {first_value}, {last} 버전의 값은 {last_value}입니다(전체 {overall_progress_percentage}%). {key_changes} {watermark}."
+        }
+      }
+    },
+    "dependencies": {
+      "title": "의존성({count}) | 의존성({count})",
+      "list_label": "패키지 의존성",
+      "show_all": "의존성 {count}개 보기 | 전체 의존성 {count}개 보기",
+      "optional": "선택 사항",
+      "view_vulnerabilities": "취약점 보기",
+      "outdated_major": "메이저 버전 {count}개 뒤처짐(최신: {latest}) | 메이저 버전 {count}개 뒤처짐(최신: {latest})",
+      "outdated_minor": "마이너 버전 {count}개 뒤처짐(최신: {latest}) | 마이너 버전 {count}개 뒤처짐(최신: {latest})",
+      "outdated_patch": "패치 업데이트 사용 가능(최신: {latest})",
+      "has_replacement": "이 의존성에는 권장 대체 항목이 있습니다",
+      "vulnerabilities_count": "취약점 {count}개 | 취약점 {count}개"
+    },
+    "peer_dependencies": {
+      "title": "피어 의존성({count}) | 피어 의존성({count})",
+      "list_label": "패키지 피어 의존성",
+      "show_all": "피어 의존성 {count}개 보기 | 전체 피어 의존성 {count}개 보기"
+    },
+    "optional_dependencies": {
+      "title": "선택 의존성({count}) | 선택 의존성({count})",
+      "list_label": "패키지 선택 의존성",
+      "show_all": "선택 의존성 {count}개 보기 | 전체 선택 의존성 {count}개 보기"
+    },
+    "maintainers": {
+      "title": "메인테이너",
+      "list_label": "패키지 메인테이너",
+      "you": "(나)",
+      "via": "via {teams}",
+      "remove_owner": "{name}을(를) 소유자에서 제거",
+      "username_to_add": "소유자로 추가할 사용자 이름",
+      "username_placeholder": "사용자 이름...",
+      "add_button": "추가",
+      "cancel_add": "소유자 추가 취소",
+      "add_owner": "+ 소유자 추가",
+      "show_more": "({count}개 더 보기)",
+      "show_less": "(줄여 보기)",
+      "maintainer_template": "{avatar} {char126}{name}"
+    },
+    "trends": {
+      "chart_assistive_text": {
+        "keyboard_navigation_horizontal": "왼쪽/오른쪽 화살표 키로 데이터 포인트를 이동하세요.",
+        "keyboard_navigation_vertical": "위/아래 화살표 키로 데이터 포인트를 이동하세요.",
+        "table_available": "이 차트의 데이터 표가 아래에 있습니다.",
+        "table_caption": "차트 데이터 표"
+      },
+      "chart_view_toggle": "보기 전환",
+      "chart_view_combined": "통합 보기",
+      "chart_view_split": "분할 보기",
+      "granularity": "단위",
+      "granularity_daily": "일별",
+      "granularity_weekly": "주별",
+      "granularity_monthly": "월별",
+      "granularity_yearly": "연별",
+      "start_date": "시작",
+      "end_date": "끝",
+      "loading": "로딩 중...",
+      "date_range": "{start}부터 {end}까지",
+      "date_range_multiline": "{start}\n부터 {end}까지",
+      "download_file": "{fileType} 다운로드",
+      "toggle_annotator": "주석 도구 전환",
+      "toggle_stack_mode": "스택 모드 전환",
+      "open_options": "옵션 열기",
+      "close_options": "옵션 닫기",
+      "legend_estimation": "추정치",
+      "no_data": "사용 가능한 데이터가 없습니다",
+      "y_axis_label": "{granularity} {facet}",
+      "facet": "항목",
+      "title": "트렌드",
+      "contributors_skip": "기여자에 표시되지 않음(GitHub 저장소 없음):",
+      "items": {
+        "downloads": "다운로드",
+        "likes": "좋아요",
+        "contributors": "기여자"
+      },
+      "data_correction": "데이터 보정",
+      "average_window": "평균 구간",
+      "smoothing": "스무딩",
+      "prediction": "예측",
+      "known_anomalies": "알려진 이상치",
+      "known_anomalies_description": "봇 또는 CI 문제로 발생한 알려진 다운로드 급증 구간을 보간합니다.",
+      "known_anomalies_ranges": "이상치 범위",
+      "known_anomalies_range": "{start}부터 {end}까지",
+      "known_anomalies_range_named": "{packageName}: {start}부터 {end}까지",
+      "known_anomalies_none": "이 패키지에는 알려진 이상치가 없습니다. | 이 패키지들에는 알려진 이상치가 없습니다.",
+      "known_anomalies_contribute": "이상치 데이터 기여",
+      "apply_correction": "보정 적용",
+      "copy_alt": {
+        "trend_none": "대체로 평탄함",
+        "trend_strong": "강함",
+        "trend_weak": "약함",
+        "trend_undefined": "정의되지 않음(데이터 부족)",
+        "button_label": "대체 텍스트 복사",
+        "watermark": "하단에는 \"./npmx a fast, modern browser for the npm registry\" 워터마크가 있습니다",
+        "analysis": "{package_name}은 {start_value}에서 시작해 {end_value}로 끝나며, 시간 간격당 {downloads_slope} 다운로드 기울기의 {trend} 추세를 보입니다",
+        "estimation": "마지막 값은 현재 기간의 부분 데이터를 기반으로 한 추정치입니다.",
+        "estimations": "마지막 값들은 현재 기간의 부분 데이터를 기반으로 한 추정치입니다.",
+        "compare": "다음 패키지의 다운로드 비교 선 차트: {packages}.",
+        "single_package": "{package} 패키지의 다운로드 선 차트입니다.",
+        "general_description": "Y축은 다운로드 수를 나타냅니다. X축은 {start_date}부터 {end_date}까지의 날짜 범위를 {granularity} 기간 단위로 나타냅니다.{estimation_notice} {packages_analysis}. {watermark}.",
+        "facet_bar_general_description": "{packages}에 대한 가로 막대 차트로, {facet}({description})을 비교합니다. {facet_analysis} {watermark}.",
+        "facet_bar_analysis": "{package_name}의 값은 {value}입니다."
+      },
+      "embedding": {
+        "chart": "이 차트 삽입",
+        "copy_url": "웹사이트에 차트를 삽입하려면 이 URL을 복사하세요",
+        "preview": "미리보기",
+        "tip": "startDate와 endDate를 제공하지 않으면 차트는 기본적으로 최근 12개월을 사용합니다."
+      }
+    },
+    "downloads": {
+      "title": "주간 다운로드",
+      "version_distribution_title": "{version} 버전의 주간 다운로드",
+      "community_distribution": "커뮤니티 채택 분포 보기",
+      "subtitle": "모든 버전 기준",
+      "sparkline_nav_hint": "← → 사용"
+    },
+    "install_scripts": {
+      "title": "설치 스크립트",
+      "script_label": "(스크립트)",
+      "npx_packages": "npx 패키지 {count}개 | npx 패키지 {count}개",
+      "currently": "현재 {version}"
+    },
+    "playgrounds": {
+      "title": "사용해 보기",
+      "choose": "플레이그라운드 선택"
+    },
+    "metrics": {
+      "esm": "ES 모듈 지원",
+      "cjs": "CommonJS 지원",
+      "no_esm": "ES 모듈 미지원",
+      "wasm": "WebAssembly 포함",
+      "types_label": "타입",
+      "types_included": "타입 포함",
+      "types_available": "{package}를 통해 타입 사용 가능",
+      "no_types": "타입 없음"
+    },
+    "license": {
+      "view_spdx": "SPDX에서 라이선스 텍스트 보기",
+      "none": "없음"
+    },
+    "vulnerabilities": {
+      "tree_found": "{packages}/{total}개 패키지에서 취약점 {vulns}개 | {packages}/{total}개 패키지에서 취약점 {vulns}개",
+      "show_all_packages": "영향받는 패키지 {count}개 보기 | 영향받는 모든 패키지 {count}개 보기",
+      "path": "경로",
+      "more": "+{count}개 더",
+      "packages_failed": "패키지 {count}개를 확인할 수 없습니다 | 패키지 {count}개를 확인할 수 없습니다",
+      "scan_failed": "취약점을 스캔할 수 없습니다",
+      "severity": {
+        "critical": "치명적",
+        "high": "높음",
+        "moderate": "보통",
+        "low": "낮음"
+      },
+      "fixed_in_title": "{version} 버전에서 수정됨"
+    },
+    "deprecated": {
+      "label": "사용 중단됨",
+      "tree_found": "사용 중단된 의존성 {count}개 | 사용 중단된 의존성 {count}개",
+      "show_all": "사용 중단된 패키지 {count}개 보기 | 사용 중단된 모든 패키지 {count}개 보기"
+    },
+    "access": {
+      "title": "팀 접근 권한",
+      "refresh": "팀 접근 권한 새로고침",
+      "list_label": "팀 접근 권한 목록",
+      "owner": "소유자",
+      "rw": "rw",
+      "ro": "ro",
+      "revoke_access": "{name} 접근 권한 취소",
+      "no_access": "설정된 팀 접근 권한이 없습니다",
+      "select_team_label": "팀 선택",
+      "loading_teams": "팀을 불러오는 중...",
+      "select_team": "팀 선택",
+      "permission_label": "권한 수준",
+      "permission": {
+        "read_only": "읽기 전용",
+        "read_write": "읽기/쓰기"
+      },
+      "grant_button": "부여",
+      "cancel_grant": "접근 권한 부여 취소",
+      "grant_access": "+ 팀 접근 권한 부여"
+    },
+    "list": {
+      "filter_label": "패키지 필터링",
+      "filter_placeholder": "패키지 필터링...",
+      "sort_label": "패키지 정렬",
+      "showing_count": "전체 {total}개 중 {filtered}개 표시"
+    },
+    "skeleton": {
+      "loading": "패키지 세부 정보 로딩 중",
+      "maintainers": "메인테이너",
+      "keywords": "키워드",
+      "versions": "버전",
+      "dependencies": "의존성"
+    },
+    "sort": {
+      "downloads": "다운로드 많은 순",
+      "published": "최근 게시순",
+      "name_asc": "이름(A-Z)",
+      "name_desc": "이름(Z-A)"
+    },
+    "size": {
+      "b": "{size} B",
+      "kb": "{size} kB",
+      "mb": "{size} MB"
+    },
+    "download": {
+      "button": "다운로드",
+      "tarball": ".tar.gz 패키지 압축 파일 다운로드"
+    }
+  },
+  "leaderboard": {
+    "likes": {
+      "title": "좋아요 리더보드",
+      "description": "현재 npmx에서 좋아요를 가장 많이 받은 패키지 10개입니다.",
+      "rank": "순위",
+      "likes": "좋아요",
+      "unavailable_title": "아직 좋아요 리더보드가 없습니다",
+      "unavailable_description": "지금 표시할 좋아요 리더보드가 없습니다."
+    }
+  },
+  "connector": {
+    "modal": {
+      "title": "로컬 커넥터",
+      "connected": "연결됨",
+      "connected_as_user": "~{user}(으)로 연결됨",
+      "connected_hint": "이제 웹 UI에서 패키지와 조직을 관리할 수 있습니다.",
+      "disconnect": "연결 해제",
+      "run_hint": "관리 기능을 사용하려면 내 컴퓨터에서 커넥터를 실행하세요.",
+      "copy_command": "명령 복사",
+      "copied": "복사됨",
+      "paste_token": "그런 다음 아래에 토큰을 붙여넣어 연결하세요:",
+      "token_label": "토큰",
+      "token_placeholder": "여기에 토큰 붙여넣기...",
+      "advanced": "고급 옵션",
+      "port_label": "포트",
+      "warning": "경고",
+      "warning_text": "이 기능은 npmx가 내 npm CLI에 접근할 수 있게 합니다. 신뢰하는 사이트에만 연결하세요.",
+      "connect": "연결",
+      "connecting": "연결 중...",
+      "auto_open_url": "인증 페이지 자동 열기"
+    }
+  },
+  "operations": {
+    "queue": {
+      "title": "작업 대기열",
+      "clear_all": "모두 지우기",
+      "refresh": "작업 새로고침",
+      "empty": "대기 중인 작업이 없습니다",
+      "empty_hint": "패키지 또는 조직 페이지에서 작업을 추가하세요",
+      "active_label": "활성 작업",
+      "otp_required": "OTP 필요",
+      "otp_prompt": "계속하려면 OTP를 입력하세요",
+      "otp_placeholder": "OTP 코드 입력...",
+      "otp_label": "일회용 비밀번호",
+      "retry_otp": "OTP로 재시도",
+      "retry_web_auth": "웹 인증으로 재시도",
+      "retrying": "재시도 중...",
+      "open_web_auth": "웹 인증 링크 열기",
+      "approve_operation": "작업 승인",
+      "remove_operation": "작업 제거",
+      "approve_all": "모두 승인",
+      "execute": "실행",
+      "executing": "실행 중...",
+      "log": "로그",
+      "log_label": "완료된 작업 로그",
+      "remove_from_log": "로그에서 제거"
+    }
+  },
+  "org": {
+    "teams": {
+      "title": "팀",
+      "refresh": "팀 새로고침",
+      "filter_label": "팀 필터링",
+      "filter_placeholder": "팀 필터링...",
+      "sort_by": "정렬 기준",
+      "loading": "팀을 불러오는 중...",
+      "no_teams": "팀을 찾을 수 없습니다",
+      "list_label": "조직 팀",
+      "delete_team": "{name} 팀 삭제",
+      "member_count": "멤버 {count}명 | 멤버 {count}명",
+      "members_of": "{team}의 멤버",
+      "no_members": "멤버 없음",
+      "remove_user": "팀에서 {user} 제거",
+      "username_to_add": "{team}에 추가할 사용자 이름",
+      "username_placeholder": "사용자 이름...",
+      "add_button": "추가",
+      "cancel_add_user": "사용자 추가 취소",
+      "add_member": "+ 멤버 추가",
+      "team_name_label": "팀 이름",
+      "team_name_placeholder": "team-name...",
+      "create_button": "생성",
+      "no_match": "\"{query}\"와 일치하는 팀이 없습니다",
+      "cancel_create": "팀 생성 취소",
+      "create_team": "+ 팀 생성"
+    },
+    "members": {
+      "title": "멤버",
+      "refresh": "멤버 새로고침",
+      "filter_label": "멤버 필터링",
+      "filter_placeholder": "멤버 필터링...",
+      "filter_by_role": "역할로 필터링",
+      "filter_by_team": "팀으로 필터링",
+      "all_teams": "모든 팀",
+      "sort_by": "정렬 기준",
+      "loading": "멤버를 불러오는 중...",
+      "no_members": "멤버를 찾을 수 없습니다",
+      "list_label": "조직 멤버",
+      "change_role_for": "{name}의 역할 변경",
+      "remove_from_org": "조직에서 {name} 제거",
+      "view_team": "{team} 팀 보기",
+      "no_match": "필터와 일치하는 멤버가 없습니다",
+      "username_label": "사용자 이름",
+      "username_placeholder": "사용자 이름...",
+      "role_label": "역할",
+      "role": {
+        "all": "전체",
+        "developer": "개발자",
+        "admin": "관리자",
+        "owner": "소유자"
+      },
+      "team_label": "팀",
+      "no_team": "팀 없음",
+      "add_button": "추가",
+      "cancel_add": "멤버 추가 취소",
+      "add_member": "+ 멤버 추가"
+    },
+    "public_packages": "공개 패키지 {count}개 | 공개 패키지 {count}개",
+    "page": {
+      "packages_title": "패키지",
+      "members_tab": "멤버",
+      "teams_tab": "팀",
+      "no_packages": "공개 패키지를 찾을 수 없음:",
+      "no_packages_hint": "이 조직이 존재하지 않거나 공개 패키지가 없을 수 있습니다.",
+      "failed_to_load": "조직 패키지를 불러오지 못했습니다",
+      "no_match": "\"{query}\"와 일치하는 패키지가 없습니다",
+      "not_found": "조직을 찾을 수 없습니다",
+      "not_found_message": "{'@'}{name} 조직은 npm에 존재하지 않습니다"
+    }
+  },
+  "user": {
+    "combobox": {
+      "add_to_org_hint": "(조직에도 추가됨)",
+      "press_enter_to_add": "{'@'}{username}을(를) 추가하려면 Enter를 누르세요",
+      "default_placeholder": "사용자 이름...",
+      "suggestions_label": "사용자 제안"
+    },
+    "page": {
+      "packages_title": "패키지",
+      "no_packages": "공개 패키지를 찾을 수 없음:",
+      "no_packages_hint": "이 사용자가 존재하지 않거나 공개 패키지가 없을 수 있습니다.",
+      "failed_to_load": "사용자 패키지를 불러오지 못했습니다",
+      "no_match": "\"{query}\"와 일치하는 패키지가 없습니다",
+      "filter_placeholder": "패키지 {count}개 필터링... | 패키지 {count}개 필터링..."
+    },
+    "orgs_page": {
+      "title": "조직",
+      "back_to_profile": "프로필로 돌아가기",
+      "connect_required": "내 조직을 보려면 로컬 CLI를 연결하세요.",
+      "connect_hint_prefix": "시작하려면",
+      "connect_hint_suffix": "을(를) 실행하세요.",
+      "own_orgs_only": "본인의 조직만 볼 수 있습니다.",
+      "view_your_orgs": "내 조직 보기",
+      "loading": "조직을 불러오는 중...",
+      "empty": "조직을 찾을 수 없습니다.",
+      "empty_hint": "조직은 스코프 패키지에서 감지됩니다.",
+      "count": "조직 {count}개 | 조직 {count}개",
+      "packages_count": "패키지 {count}개 | 패키지 {count}개"
+    }
+  },
+  "claim": {
+    "modal": {
+      "title": "패키지 이름 등록",
+      "success": "패키지를 등록했습니다!",
+      "success_detail": "{name}{'@'}0.0.0이 npm에 게시되었습니다.",
+      "success_hint": "이제 npm publish를 사용해 이 패키지에 새 버전을 게시할 수 있습니다.",
+      "view_package": "패키지 보기",
+      "invalid_name": "잘못된 패키지 이름:",
+      "available": "이 이름은 사용할 수 있습니다!",
+      "taken": "이 이름은 이미 사용 중입니다.",
+      "missing_permission": "{'@'}{scope} 스코프에 패키지를 추가할 권한이 없습니다.",
+      "similar_warning": "비슷한 패키지가 있습니다. npm이 이 이름을 거부할 수 있습니다:",
+      "related": "관련 패키지:",
+      "scope_warning_title": "대신 스코프 패키지 사용을 고려하세요",
+      "scope_warning_text": "스코프 없는 패키지 이름은 공유 자원입니다. 패키지를 게시하고 유지보수할 의도가 있을 때만 이름을 등록하세요. 개인 또는 조직 프로젝트에는 {'@'}{username}/{name} 같은 스코프 이름을 사용하세요.",
+      "connect_required": "이 패키지 이름을 등록하려면 로컬 커넥터에 연결하세요.",
+      "connect_button": "커넥터에 연결",
+      "publish_hint": "최소 구성의 플레이스홀더 패키지를 게시합니다.",
+      "preview_json": "package.json 미리보기",
+      "claim_button": "패키지 이름 등록",
+      "publishing": "게시 중...",
+      "checking": "사용 가능 여부 확인 중...",
+      "failed_to_check": "이름 사용 가능 여부를 확인하지 못했습니다",
+      "failed_to_claim": "패키지를 등록하지 못했습니다"
+    }
+  },
+  "code": {
+    "files_label": "파일",
+    "no_files": "이 디렉터리에 파일이 없습니다",
+    "lines": "{count}줄 | {count}줄",
+    "toggle_tree": "파일 트리 전환",
+    "close_tree": "파일 트리 닫기",
+    "copy_content": "파일 내용 복사",
+    "copy_link": "링크 복사",
+    "view_raw": "원본 파일 보기",
+    "toggle_container": "코드 컨테이너 너비 전환",
+    "open_raw_file": "원본 파일 열기",
+    "open_path_dropdown": "경로 세그먼트 드롭다운 열기",
+    "file_too_large": "파일이 너무 커서 미리볼 수 없습니다",
+    "file_size_warning": "{size}이(가) 구문 강조 500KB 제한을 초과합니다",
+    "failed_to_load": "파일을 불러오지 못했습니다",
+    "unavailable_hint": "파일이 너무 크거나 사용할 수 없을 수 있습니다",
+    "version_required": "코드를 탐색하려면 버전이 필요합니다",
+    "go_to_package": "패키지로 이동",
+    "loading_tree": "파일 트리를 불러오는 중...",
+    "failed_to_load_tree": "이 패키지 버전의 파일을 불러오지 못했습니다",
+    "back_to_package": "패키지로 돌아가기",
+    "table": {
+      "name": "이름",
+      "size": "크기"
+    },
+    "markdown_view_mode": {
+      "preview": "미리보기",
+      "code": "코드"
+    },
+    "file_path": "파일 경로",
+    "binary_file": "바이너리 파일",
+    "binary_rendering_warning": "\"{contentType}\" 파일 형식은 미리보기를 지원하지 않습니다."
+  },
+  "badges": {
+    "provenance": {
+      "verified": "검증됨",
+      "verified_title": "검증된 출처",
+      "verified_via": "검증됨: {provider}를 통해 게시됨"
+    },
+    "jsr": {
+      "title": "JSR에서도 사용 가능"
+    }
+  },
+  "filters": {
+    "title": "필터",
+    "search": "검색",
+    "search_scope": "검색 범위",
+    "search_placeholder_name": "패키지 이름으로 필터링...",
+    "search_placeholder_description": "설명으로 필터링...",
+    "search_placeholder_keywords": "키워드로 필터링...",
+    "search_placeholder_all": "전체 검색 또는 name: desc: kw: 사용",
+    "scope_name": "이름",
+    "scope_name_description": "패키지 이름만 검색",
+    "scope_description": "설명",
+    "scope_description_description": "설명만 검색",
+    "scope_keywords": "키워드",
+    "scope_keywords_description": "키워드만 검색",
+    "scope_all": "전체",
+    "scope_all_description": "모든 필드를 검색하며 name: desc: kw: 연산자를 지원합니다",
+    "weekly_downloads": "주간 다운로드",
+    "updated_within": "업데이트 기간",
+    "security": "보안",
+    "keywords": "키워드",
+    "more_keywords": "+{count}개 더",
+    "clear_all": "모두 지우기",
+    "remove_filter": "{label} 필터 제거",
+    "chips": {
+      "search": "검색",
+      "downloads": "다운로드",
+      "keyword": "키워드",
+      "security": "보안",
+      "updated": "업데이트됨"
+    },
+    "download_range": {
+      "any": "전체",
+      "lt100": "< 100",
+      "100_1k": "100 - 1K",
+      "1k_10k": "1K - 10K",
+      "10k_100k": "10K - 100K",
+      "gt100k": "> 100K"
+    },
+    "updated": {
+      "any": "전체 기간",
+      "week": "지난주",
+      "month": "지난달",
+      "quarter": "지난 3개월",
+      "year": "지난해"
+    },
+    "security_options": {
+      "all": "모든 패키지",
+      "secure": "경고 없음",
+      "insecure": "경고 있음"
+    },
+    "view_selected": "선택 항목 보기",
+    "clear_selected_label": "선택 지우기",
+    "sort": {
+      "label": "패키지 정렬",
+      "toggle_direction": "정렬 방향 전환",
+      "ascending": "오름차순",
+      "descending": "내림차순",
+      "relevance": "관련도",
+      "downloads_week": "다운로드/주",
+      "downloads_day": "다운로드/일",
+      "downloads_month": "다운로드/월",
+      "downloads_year": "다운로드/년",
+      "published": "마지막 게시",
+      "name": "이름"
+    },
+    "columns": {
+      "title": "열",
+      "show": "열 표시",
+      "reset": "기본값으로 재설정",
+      "coming_soon": "곧 제공 예정",
+      "name": "이름",
+      "version": "버전",
+      "description": "설명",
+      "downloads": "다운로드/주",
+      "published": "마지막 게시",
+      "maintainers": "메인테이너",
+      "keywords": "키워드",
+      "security": "보안",
+      "selection": "패키지 선택"
+    },
+    "view_mode": {
+      "label": "보기 모드",
+      "cards": "카드 보기",
+      "table": "표 보기"
+    },
+    "pagination": {
+      "mode_label": "페이지네이션 모드",
+      "infinite": "무한 스크롤",
+      "paginated": "페이지 방식",
+      "items_per_page": "페이지당 항목 수",
+      "per_page": "페이지당 {count}개",
+      "showing": "전체 {total}개 중 {range}",
+      "previous": "이전 페이지",
+      "next": "다음 페이지",
+      "nav_label": "페이지네이션"
+    },
+    "count": {
+      "showing_filtered": "패키지 {count}개 중 {filtered}개 | 패키지 {count}개 중 {filtered}개",
+      "showing_all": "패키지 {count}개 | 패키지 {count}개",
+      "showing_paginated": "패키지 {count}개 중 {pageSize}개 | 패키지 {count}개 중 {pageSize}개"
+    },
+    "table": {
+      "security_warning": "보안 경고",
+      "secure": "안전",
+      "no_packages": "패키지를 찾을 수 없습니다"
+    }
+  },
+  "about": {
+    "title": "소개",
+    "heading": "소개",
+    "meta_description": "npmx는 npm 레지스트리를 위한 빠르고 현대적인 브라우저입니다. npm 패키지를 탐색하기 좋은 UX/DX를 제공합니다.",
+    "what_we_are": {
+      "title": "npmx가 지향하는 것",
+      "better_ux_dx": "훌륭한 UX/DX",
+      "admin_ui": "관리 UI",
+      "description": "npmx는 npm 패키지 레지스트리와 도구를 위한 {betterUxDx}입니다. 다크 모드, 키보드 탐색, 코드 브라우징, {jsr} 같은 대체 레지스트리 연결 등 패키지 탐색을 위한 빠르고 현대적인 인터페이스를 제공하려고 합니다.",
+      "admin_description": "또한 로컬 npm CLI를 기반으로 브라우저에서 패키지, 팀, 조직을 관리할 수 있는 훌륭한 {adminUi}도 제공하려고 합니다."
+    },
+    "what_we_are_not": {
+      "title": "npmx가 아닌 것",
+      "not_package_manager": "패키지 매니저가 아닙니다.",
+      "not_registry": "레지스트리가 아닙니다.",
+      "registry_description": "패키지를 호스팅하지 않습니다. 패키지를 빠르고 현대적으로 둘러보는 방법일 뿐입니다.",
+      "package_managers_exist": "{already} {people} {building} {really} {cool} {package} {managers}.",
+      "words": {
+        "already": "이미",
+        "people": "훌륭한",
+        "building": "사람들이",
+        "really": "정말",
+        "cool": "멋진",
+        "package": "패키지",
+        "managers": "매니저를 만들고 있습니다"
+      }
+    },
+    "sponsors": {
+      "title": "스폰서"
+    },
+    "oss_partners": {
+      "title": "OSS 파트너"
+    },
+    "team": {
+      "title": "팀",
+      "core": "코어",
+      "maintainers": "메인테이너",
+      "role_core": "코어",
+      "role_steward": "스튜어드",
+      "role_maintainer": "메인테이너",
+      "sponsor": "스폰서",
+      "sponsor_aria": "GitHub에서 {name} 후원하기"
+    },
+    "contributors": {
+      "title": "... 그리고 기여자 {count}명 더 | ... 그리고 기여자 {count}명 더",
+      "description": "npmx는 완전한 오픈소스이며 멋진 기여자 커뮤니티가 함께 만들고 있습니다. 함께 참여해서 우리가 늘 원하던 npm 브라우징 경험을 만들어 보세요.",
+      "loading": "기여자를 불러오는 중...",
+      "error": "기여자를 불러오지 못했습니다",
+      "view_profile": "{name}의 GitHub 프로필 보기"
+    },
+    "get_involved": {
+      "title": "참여하기",
+      "contribute": {
+        "title": "기여하기",
+        "description": "우리 모두가 원하는 npm 경험을 만드는 데 함께해 주세요.",
+        "cta": "GitHub에서 보기"
+      },
+      "community": {
+        "title": "커뮤니티 참여",
+        "description": "대화하고, 질문하고, 아이디어를 공유하세요.",
+        "cta": "Discord 참여"
+      },
+      "builders": {
+        "title": "npmx 만들기 돕기",
+        "description": "npmx의 미래를 만들어 가는 빌더들과 함께하세요.",
+        "cta": "빌더 Discord 참여"
+      },
+      "follow": {
+        "title": "최신 소식 받기",
+        "description": "npmx의 최신 소식을 확인하세요.",
+        "cta": "Bluesky에서 팔로우"
+      }
+    }
+  },
+  "account_menu": {
+    "connect": "연결",
+    "account": "계정",
+    "npm_cli": "npm CLI",
+    "atmosphere": "Atmosphere",
+    "npm_cli_desc": "패키지 및 조직 관리",
+    "atmosphere_desc": "소셜 기능 및 ID",
+    "connect_npm_cli": "npm CLI에 연결",
+    "connect_atmosphere": "Atmosphere에 연결",
+    "connecting": "연결 중...",
+    "ops": "작업 {count}개 | 작업 {count}개"
+  },
+  "auth": {
+    "modal": {
+      "title": "Atmosphere",
+      "connected_as": "{'@'}{handle}(으)로 연결됨",
+      "disconnect": "연결 해제",
+      "connect_prompt": "Atmosphere 계정으로 연결",
+      "handle_label": "핸들",
+      "handle_placeholder": "alice.npmx.social",
+      "connect": "연결",
+      "create_account": "새 계정 만들기",
+      "connect_bluesky": "Bluesky로 연결",
+      "what_is_atmosphere": "Atmosphere 계정이란?",
+      "atmosphere_explanation": "{npmx}는 여러 소셜 기능을 위해 {atproto}를 사용하며, 사용자가 자신의 데이터를 소유하고 호환되는 모든 애플리케이션에서 하나의 계정을 사용할 수 있게 합니다. 계정을 만들면 같은 계정으로 {bluesky}, {tangled} 같은 다른 앱도 사용할 수 있습니다.",
+      "default_input_error": "올바른 핸들, DID 또는 전체 PDS URL을 입력하세요",
+      "profile": "프로필"
+    }
+  },
+  "header": {
+    "home": "npmx 홈",
+    "packages": "패키지",
+    "packages_dropdown": {
+      "title": "내 패키지",
+      "loading": "로딩 중...",
+      "error": "패키지를 불러오지 못했습니다",
+      "empty": "패키지를 찾을 수 없습니다",
+      "view_all": "모두 보기"
+    },
+    "orgs": "조직",
+    "orgs_dropdown": {
+      "title": "내 조직",
+      "loading": "로딩 중...",
+      "error": "조직을 불러오지 못했습니다",
+      "empty": "조직을 찾을 수 없습니다",
+      "view_all": "모두 보기"
+    },
+    "pr": "GitHub Pull Request #{prNumber} 열기"
+  },
+  "compare": {
+    "packages": {
+      "title": "패키지 비교",
+      "tagline": "npm 패키지를 나란히 비교해 적절한 패키지를 선택하세요.",
+      "meta_title": "{packages} 비교 - npmx",
+      "meta_title_empty": "패키지 비교 - npmx",
+      "meta_description": "{packages} 나란히 비교",
+      "meta_description_empty": "npm 패키지를 나란히 비교",
+      "section_packages": "패키지",
+      "section_facets": "항목",
+      "section_comparison": "비교",
+      "copy_as_markdown": "표 복사",
+      "loading": "패키지 데이터를 불러오는 중...",
+      "error": "패키지 데이터를 불러오지 못했습니다. 다시 시도하세요.",
+      "empty_title": "비교할 패키지를 선택하세요",
+      "empty_description": "위에서 패키지를 검색해 2개 이상 추가하면 지표를 나란히 비교할 수 있습니다.",
+      "table_view": "표",
+      "charts_view": "차트",
+      "no_chartable_data": "선택한 항목에 사용할 수 있는 차트 데이터가 없습니다.",
+      "bar_chart_nav_hint": "↑ ↓ 사용",
+      "line_chart_nav_hint": "← → 사용"
+    },
+    "selector": {
+      "search_label": "패키지 검색",
+      "search_first": "패키지 검색...",
+      "search_add": "다른 패키지 추가...",
+      "searching": "검색 중...",
+      "remove_package": "{package} 제거",
+      "packages_selected": "{count}/{max}개 패키지 선택됨.",
+      "add_hint": "비교하려면 패키지를 2개 이상 추가하세요."
+    },
+    "scatter_chart": {
+      "title": "{x}와 {y} 비교",
+      "freshness_score": "최신성 점수",
+      "copy_alt": {
+        "analysis": "{package}: {x_name}({x_value}) 및 {y_name}({y_value})",
+        "description": "{packages} 패키지의 {x_name}와 {y_name}을 매핑한 산점도 차트입니다. {analysis}. {watermark}"
+      },
+      "filename": "{x}-vs-{y}-scatter-chart",
+      "x_axis": "X축 ↦",
+      "y_axis": "Y축 ↥"
+    },
+    "no_dependency": {
+      "label": "(의존성 없음)",
+      "typeahead_title": "James라면 어떻게 했을까?",
+      "typeahead_description": "의존성을 사용하지 않는 경우와 비교하세요! e18e 인증.",
+      "tooltip_title": "의존성이 필요하지 않을 수 있습니다",
+      "tooltip_description": "의존성을 사용하지 않는 경우와 비교하세요! {link}는 네이티브 API 또는 더 단순한 대안으로 대체할 수 있는 패키지 목록을 관리합니다.",
+      "e18e_community": "e18e 커뮤니티",
+      "add_column": "비교에 의존성 없음 열 추가"
+    },
+    "facets": {
+      "all": "전체",
+      "none": "없음",
+      "select_all_category_facets": "{category} 항목 모두 선택",
+      "deselect_all_category_facets": "{category} 항목 모두 선택 해제",
+      "selected_all_category_facets": "{category} 항목을 모두 선택했습니다",
+      "deselected_all_category_facets": "{category} 항목 선택을 모두 해제했습니다",
+      "coming_soon": "곧 제공 예정",
+      "select_all": "모든 항목 선택",
+      "deselect_all": "모든 항목 선택 해제",
+      "binary_only_tooltip": "이 패키지는 바이너리만 노출하고 exports가 없습니다",
+      "categories": {
+        "performance": "성능",
+        "health": "상태",
+        "compatibility": "호환성",
+        "security": "보안 및 컴플라이언스"
+      },
+      "items": {
+        "packageSize": {
+          "label": "패키지 크기",
+          "description": "패키지 자체의 크기(압축 해제)"
+        },
+        "installSize": {
+          "label": "설치 크기",
+          "description": "모든 의존성을 포함한 전체 설치 크기"
+        },
+        "dependencies": {
+          "label": "직접 의존성",
+          "description": "직접 의존성 수"
+        },
+        "totalDependencies": {
+          "label": "전체 의존성",
+          "description": "전이 의존성을 포함한 전체 의존성 수"
+        },
+        "downloads": {
+          "label": "다운로드/주",
+          "description": "주간 다운로드 수"
+        },
+        "totalLikes": {
+          "label": "좋아요",
+          "description": "좋아요 수"
+        },
+        "lastUpdated": {
+          "label": "게시됨",
+          "description": "이 버전이 게시된 시점"
+        },
+        "deprecated": {
+          "label": "사용 중단됨?",
+          "description": "패키지가 사용 중단되었는지 여부"
+        },
+        "engines": {
+          "label": "엔진",
+          "description": "Node.js 버전 요구사항"
+        },
+        "types": {
+          "label": "타입",
+          "description": "TypeScript 타입 정의"
+        },
+        "moduleFormat": {
+          "label": "모듈 형식",
+          "description": "ESM/CJS 지원"
+        },
+        "license": {
+          "label": "라이선스",
+          "description": "패키지 라이선스"
+        },
+        "vulnerabilities": {
+          "label": "취약점",
+          "description": "알려진 보안 취약점"
+        },
+        "githubStars": {
+          "label": "GitHub 스타",
+          "description": "GitHub 저장소의 스타 수"
+        },
+        "githubForks": {
+          "label": "GitHub 포크",
+          "description": "GitHub 저장소의 포크 수"
+        },
+        "githubIssues": {
+          "label": "GitHub 이슈",
+          "description": "GitHub 저장소의 이슈 수"
+        },
+        "createdAt": {
+          "label": "생성일",
+          "description": "패키지가 생성된 시점"
+        }
+      },
+      "values": {
+        "any": "전체",
+        "none": "없음",
+        "unknown": "알 수 없음",
+        "deprecated": "사용 중단됨",
+        "not_deprecated": "아니요",
+        "types_included": "포함됨",
+        "types_none": "없음",
+        "vulnerabilities_summary": "{count} ({critical}C/{high}H)",
+        "up_to_you": "선택은 자유입니다!"
+      },
+      "trends": {
+        "title": "트렌드 비교"
+      }
+    },
+    "file_changes": "파일 변경 사항",
+    "files_count": "파일 {count}개 | 파일 {count}개",
+    "lines_hidden": "숨겨진 줄 {count}개 | 숨겨진 줄 {count}개",
+    "compare_versions": "차이",
+    "compare_versions_title": "최신 버전과 비교",
+    "comparing_versions_label": "버전 비교 중...",
+    "version_back_to_package": "패키지로 돌아가기",
+    "version_error_message": "버전을 비교하지 못했습니다.",
+    "version_invalid_url_format": {
+      "hint": "잘못된 비교 URL입니다. 형식을 사용하세요: {0}",
+      "from_version": "이전 버전",
+      "to_version": "비교 버전"
+    },
+    "version_selector_title": "버전과 비교",
+    "summary": "요약",
+    "deps_count": "의존성 {count}개 | 의존성 {count}개",
+    "dependencies": "의존성",
+    "dev_dependencies": "개발 의존성",
+    "peer_dependencies": "피어 의존성",
+    "optional_dependencies": "선택 의존성",
+    "no_dependency_changes": "의존성 변경 없음",
+    "file_filter_option": {
+      "all": "전체({count})",
+      "added": "추가됨({count})",
+      "removed": "제거됨({count})",
+      "modified": "수정됨({count})"
+    },
+    "search_files_placeholder": "파일 검색...",
+    "no_files_all": "파일 없음",
+    "no_files_search": "\"{query}\"와 일치하는 파일이 없습니다",
+    "no_files_filtered": "{filter} 파일 없음",
+    "filter": {
+      "added": "추가된",
+      "removed": "제거된",
+      "modified": "수정된"
+    },
+    "files_button": "파일",
+    "select_file_prompt": "diff를 보려면 사이드바에서 파일을 선택하세요",
+    "close_files_panel": "파일 패널 닫기",
+    "filter_files_label": "변경 유형으로 파일 필터링",
+    "change_ratio": "변경 비율",
+    "char_edits": "문자 편집",
+    "diff_distance": "차이점(diff)",
+    "diff_truncated": "성능을 위해 diff가 잘렸습니다. 처음 변경된 줄만 표시합니다.",
+    "large_diff_mode": "성능을 위해 인라인 편집 병합을 비활성화한 상태로 큰 파일 diff를 표시합니다.",
+    "large_diff_options_disabled": "큰 파일 모드에서는 성능을 위해 인라인 편집 병합이 비활성화됩니다.",
+    "loading_diff": "diff 불러오는 중...",
+    "loading_diff_error": "diff를 불러오지 못했습니다",
+    "merge_modified_lines": "수정된 줄 병합",
+    "no_content_changes": "내용 변경이 감지되지 않았습니다",
+    "options": "옵션",
+    "view_file": "파일 보기",
+    "view_in_code_browser": "코드 브라우저에서 보기",
+    "word_wrap": "자동 줄바꿈"
+  },
+  "pds": {
+    "title": "npmx.social",
+    "meta_description": "npmx 커뮤니티를 위한 공식 AT Protocol Personal Data Server(PDS)입니다.",
+    "join": {
+      "title": "커뮤니티 참여",
+      "description": "atmosphere에서 첫 계정을 만들든 기존 계정을 이전하든, 이곳이 당신의 자리입니다. 핸들, 게시물, 팔로워를 잃지 않고 현재 계정을 이전할 수 있습니다.",
+      "migrate": "PDS MOOver로 이전"
+    },
+    "server": {
+      "title": "서버 세부 정보",
+      "location_label": "위치:",
+      "location_value": "독일 뉘른베르크",
+      "infrastructure_label": "인프라:",
+      "infrastructure_value": "Hetzner에서 호스팅",
+      "privacy_label": "개인정보:",
+      "privacy_value": "엄격한 EU 데이터 보호법 적용",
+      "learn_more": "npmx가 Atmosphere를 사용하는 방법 알아보기"
+    },
+    "community": {
+      "title": "누가 함께하나요",
+      "description": "이미 npmx.social을 집으로 삼고 있는 {count}개 계정 중 일부입니다:",
+      "loading": "PDS 커뮤니티를 불러오는 중...",
+      "error": "PDS 커뮤니티를 불러오지 못했습니다.",
+      "empty": "표시할 커뮤니티 멤버가 없습니다.",
+      "view_profile": "{handle}의 프로필 보기",
+      "new_accounts": "...그리고 atmosphere에 새로 합류한 {count}개 계정"
+    }
+  },
+  "privacy_policy": {
+    "title": "개인정보 처리방침",
+    "last_updated": "마지막 업데이트: {date}",
+    "welcome": "{app}에 오신 것을 환영합니다. 우리는 개인정보 보호를 중요하게 생각합니다. 이 정책은 수집하는 데이터, 사용 방식, 그리고 정보에 대한 권리를 설명합니다.",
+    "cookies": {
+      "what_are": {
+        "title": "쿠키란 무엇인가요?",
+        "p1": "쿠키는 웹사이트를 방문할 때 기기에 저장되는 작은 텍스트 파일입니다. 특정 환경설정과 설정을 기억해 브라우징 경험을 개선하는 데 사용됩니다."
+      },
+      "types": {
+        "title": "어떤 쿠키를 사용하나요?",
+        "p1": "사이트 기능에 반드시 필요한 목적을 위해서만 {bold}를 사용합니다. 서드파티 또는 광고 쿠키는 사용하지 않습니다.",
+        "bold": "필수 기술 쿠키",
+        "li1": "{li11}{separator} {li12}",
+        "li2": "{li21}{separator} {li22}",
+        "separator": ":",
+        "cookie_vdpl": "__vdpl",
+        "cookie_vdpl_desc": "이 쿠키는 호스팅 제공업체(Vercel)가 스큐 보호를 위해 사용합니다. 브라우징 중 새 업데이트가 배포되더라도 올바른 배포 버전의 에셋을 가져오도록 보장합니다. 사용자를 추적하지 않습니다.",
+        "cookie_h3": "h3",
+        "cookie_h3_desc": "보안 세션 쿠키입니다. Atmosphere 계정을 연결할 때 OAuth 액세스 토큰을 저장합니다. 인증된 세션을 유지하는 데 필수적입니다."
+      },
+      "local_storage": {
+        "title": "로컬 스토리지",
+        "p1": "세션 쿠키 외에도 브라우저의 {bold}를 사용해 표시 환경설정을 저장합니다. 이를 통해 선택한 테마(라이트/다크)와 일부 {settings}을 기억하므로 방문할 때마다 다시 설정할 필요가 없습니다.",
+        "bold": "Local Storage",
+        "p2": "이 정보는 기능 목적으로만 사용되며 기기에만 저장되고 {bold2}. 웹사이트 경험을 개선하는 데만 사용합니다.",
+        "bold2": "개인 데이터를 포함하지 않으며 사용자를 추적하는 데 사용되지 않습니다",
+        "settings": "설정"
+      },
+      "management": {
+        "title": "쿠키 관리",
+        "p1": "브라우저에서 원하는 대로 쿠키를 허용, 거부 또는 삭제하도록 설정할 수 있습니다. 다만 {bold}는 점에 유의하세요.",
+        "bold": "필수 쿠키를 거부하면 애플리케이션 전체 접근이 제한될 수 있습니다",
+        "p2": "아래는 일반적으로 많이 사용하는 브라우저의 쿠키 관리 안내 링크입니다:",
+        "chrome": "Google Chrome(새 창에서 열림)",
+        "firefox": "Mozilla Firefox(새 창에서 열림)",
+        "edge": "Microsoft Edge(새 창에서 열림)"
+      }
+    },
+    "analytics": {
+      "title": "분석",
+      "p1": "방문자가 웹사이트를 어떻게 사용하는지 이해하기 위해 {bold}를 사용합니다. 이는 사용자 경험을 개선하고 문제를 파악하는 데 도움이 됩니다.",
+      "bold": "Vercel Web Analytics",
+      "p2": "Vercel Analytics는 개인정보 보호를 고려해 설계되었습니다:",
+      "li1": "쿠키를 사용하지 않습니다",
+      "li2": "개인 식별자를 수집하지 않습니다",
+      "li3": "웹사이트 간 사용자를 추적하지 않습니다",
+      "li4": "모든 데이터는 집계 및 익명화됩니다",
+      "p3": "수집되는 정보는 페이지 URL, 리퍼러, 국가/지역, 기기 유형, 브라우저, 운영체제뿐입니다. 이 데이터로 개별 사용자를 식별할 수 없습니다."
+    },
+    "authenticated": {
+      "title": "인증된 사용자",
+      "p1": "{bold} 계정을 npmx에 연결하면 OAuth 액세스 토큰을 안전한 HTTP-only 세션 쿠키에 저장합니다. 이 토큰은 사용자를 대신한 요청을 인증하는 데만 사용됩니다.",
+      "bold": "Atmosphere",
+      "p2": "자격 증명은 저장하지 않으며, 사용하는 기능을 제공하는 데 필요한 범위를 넘어 어떤 데이터에도 접근하지 않습니다. 언제든지 {settings} 페이지에서 계정 연결을 해제할 수 있습니다.",
+      "settings": "설정"
+    },
+    "data_retention": {
+      "title": "데이터 보관",
+      "p1": "세션 쿠키는 브라우저를 닫거나 일정 시간 활동이 없으면 자동으로 삭제됩니다. 로컬 스토리지 환경설정은 브라우저 데이터를 삭제할 때까지 기기에 남아 있습니다. 분석 데이터는 집계 형태로 보관되며 개별 사용자와 연결할 수 없습니다."
+    },
+    "your_rights": {
+      "title": "사용자의 권리",
+      "p1": "사용자는 다음 권리를 가집니다:",
+      "li1": "수집하는 데이터에 대한 정보 열람",
+      "li2": "언제든지 로컬 스토리지와 쿠키 삭제",
+      "li3": "인증된 세션 연결 해제",
+      "li4": "데이터 처리 방식에 대한 정보 요청",
+      "p2": "우리는 개인 데이터를 수집하지 않으므로 일반적으로 삭제하거나 내보낼 개인 정보가 없습니다."
+    },
+    "contact": {
+      "title": "문의",
+      "p1": "이 개인정보 처리방침에 대한 질문이나 우려가 있다면 {link}에 이슈를 열어 문의할 수 있습니다.",
+      "link": "GitHub 저장소"
+    },
+    "changes": {
+      "title": "정책 변경",
+      "p1": "이 개인정보 처리방침은 때때로 업데이트될 수 있습니다. 변경 사항은 갱신된 개정일과 함께 이 페이지에 게시됩니다."
+    }
+  },
+  "a11y": {
+    "title": "접근성",
+    "footer_title": "a11y",
+    "welcome": "{app}을 가능한 한 많은 사람이 사용할 수 있기를 바랍니다.",
+    "approach": {
+      "title": "우리의 접근 방식",
+      "p1": "기능을 만들 때 웹 콘텐츠 접근성 지침(WCAG) 2.2를 따르고 참고하려고 합니다. WCAG의 특정 수준을 완전히 준수한다고 주장하지는 않습니다. 접근성은 지속적인 과정이며 언제나 더 할 일이 있습니다.",
+      "p2": "이 사이트는 {about}입니다. 접근성 개선은 정기 개발 과정의 일부로 점진적으로 이루어집니다.",
+      "about_link": "오픈소스 커뮤니티 주도 프로젝트"
+    },
+    "measures": {
+      "title": "우리가 하는 일",
+      "p1": "사이트 전반에서 다음을 지향합니다:",
+      "li1": "적절한 곳에 시맨틱 HTML과 ARIA 속성을 사용합니다.",
+      "li2": "브라우저에서 조정할 수 있도록 상대 텍스트 크기를 사용합니다.",
+      "li3": "인터페이스 전반에서 키보드 탐색을 지원합니다.",
+      "li4": "prefers-reduced-motion 및 prefers-color-scheme 미디어 쿼리를 존중합니다.",
+      "li5": "충분한 색상 대비를 고려해 디자인합니다.",
+      "li6": "일부 인터랙티브 기능은 JavaScript가 필요하지만, 필수 콘텐츠는 JavaScript 없이도 사용할 수 있도록 합니다."
+    },
+    "limitations": {
+      "title": "알려진 제한 사항",
+      "p1": "사이트의 일부 영역, 특히 패키지 README 같은 서드파티 콘텐츠는 접근성 기준을 충족하지 못할 수 있습니다. 시간이 지나며 이러한 영역을 개선하고 있습니다."
+    },
+    "contact": {
+      "title": "피드백",
+      "p1": "{app}에서 접근성 장벽을 발견하면 {link}에 이슈를 열어 알려주세요. 이러한 제보를 진지하게 받아들이고 해결하기 위해 최선을 다하겠습니다.",
+      "link": "GitHub 저장소"
+    }
+  },
+  "translation_status": {
+    "title": "번역 상태",
+    "generated_at": "생성일: {date}",
+    "welcome": "{npmx}를 아래 언어 중 하나로 번역하는 데 관심이 있다면 잘 찾아오셨습니다! 이 자동 업데이트 페이지에는 지금 도움이 필요한 모든 콘텐츠가 항상 표시됩니다.",
+    "p1": "기본 언어로 {lang}을 사용하며 총 {count}이 있습니다. 번역 추가를 돕고 싶다면 {bylang}에서 언어를 찾아 세부 정보를 펼치세요.",
+    "p1_lang": "미국 영어(en-US)",
+    "p1_count": "메시지 0개 | 메시지 1개 | 메시지 {count}개",
+    "p2": "시작하기 전에 번역 프로세스와 참여 방법을 알아보려면 {guide}를 읽어 주세요.",
+    "guide": "현지화(i18n) 가이드",
+    "by_locale": "로케일별 번역 진행률",
+    "by_file": "파일별 번역 진행률",
+    "complete_text": "이 번역은 완료되었습니다. 훌륭합니다!",
+    "missing_text": "누락",
+    "missing_keys": "누락된 번역이 없습니다 | 누락된 번역 | 누락된 번역",
+    "progress_label": "{locale} 진행 상태",
+    "table": {
+      "file": "파일",
+      "status": "상태",
+      "error": "파일 목록을 불러오는 중 에러가 발생했습니다.",
+      "empty": "파일을 찾을 수 없습니다",
+      "file_link": "GitHub에서 {file}({lang}) 편집"
+    }
+  },
+  "vacations": {
+    "title": "휴가 중",
+    "meta_description": "npmx 팀은 재충전 중이었습니다. Discord는 일주일 뒤 다시 열렸습니다.",
+    "heading": "재충전",
+    "subtitle": "우리는 {some} 사람들의 잠을 줄일 만큼 빠른 속도로 npmx를 만들고 있었습니다. 그 속도가 당연해지길 원하지 않았어요! 그래서 일주일을 쉬었습니다. 함께요.",
+    "illustration_alt": "아늑한 아이콘이 한 줄로 놓인 그림",
+    "poke_log": "모닥불 쑤시기",
+    "what": {
+      "title": "무슨 일이 있었나요",
+      "p1": "Discord는 {dates} 동안 닫혀 있었습니다.",
+      "dates": "2월 14일 - 21일",
+      "p2": "모든 초대 링크가 사라지고 채널이 잠겼습니다. 다만 계속 어울리고 싶은 사람들을 위해 {garden}만 열어 두었습니다.",
+      "garden": "#garden"
+    },
+    "meantime": {
+      "title": "그동안",
+      "p1": "{site}와 {repo}는 계속 열려 있었습니다. 사람들은 여전히 파고들며 이슈를 만들고 PR도 몇 개 열었지만, 대부분은 아늑한 벽난로 근처 어딘가에서 시간을 보냈습니다.",
+      "repo_link": "저장소"
+    },
+    "return": {
+      "title": "돌아왔습니다!",
+      "p1": "우리는 재충전을 마치고 3월 3일까지 마지막 스퍼트를 할 준비를 마쳤습니다. 업데이트를 받으려면 {social}.",
+      "social_link": "Bluesky에서 팔로우하세요"
+    },
+    "stats": {
+      "contributors": "기여자",
+      "commits": "커밋",
+      "pr": "병합된 PR",
+      "subtitle": {
+        "some": "일부",
+        "all": "모두"
+      }
+    }
+  },
+  "action_bar": {
+    "title": "작업 바",
+    "selection": "선택 0개 | 선택 1개 | 선택 {count}개",
+    "shortcut": "작업에 포커스하려면 \"{key}\"를 누르세요",
+    "button_close_aria_label": "작업 바 닫기"
+  },
+  "logo_menu": {
+    "copy_svg": "로고를 SVG로 복사",
+    "copied": "복사됨!",
+    "browse_brand": "브랜드 키트 둘러보기"
+  },
+  "brand": {
+    "title": "브랜드",
+    "heading": "브랜드",
+    "meta_description": "언론과 미디어에서 사용할 npmx 브랜드 가이드라인, 로고, 색상, 타이포그래피입니다.",
+    "intro": "프로젝트, 글, 미디어에서 npmx 브랜드를 사용할 때 필요한 리소스와 가이드라인입니다.",
+    "logos": {
+      "title": "로고",
+      "description": "npmx 로고를 SVG 및 PNG 형식으로 다운로드하세요. 배경에 맞는 변형을 사용하세요.",
+      "wordmark": "전체 워드마크",
+      "wordmark_alt": "어두운 배경에 파란 슬래시가 있는 npmx 전체 워드마크 로고",
+      "wordmark_light_alt": "밝은 배경에 강조 슬래시가 있는 npmx 전체 워드마크 로고",
+      "mark": "로고 마크",
+      "mark_alt": "어두운 배경에 점과 슬래시가 있는 npmx 로고 마크",
+      "mark_light_alt": "밝은 배경에 점과 슬래시가 있는 npmx 로고 마크",
+      "on_dark": "어두운 배경",
+      "on_light": "밝은 배경",
+      "download_svg": "SVG",
+      "download_png": "PNG",
+      "download_svg_aria": "{name}을(를) SVG로 다운로드",
+      "download_png_aria": "{name}을(를) PNG로 다운로드"
+    },
+    "customize": {
+      "title": "로고 맞춤 설정",
+      "description": "강조 색상과 배경을 적용한 npmx 로고를 미리보세요. 미리보기는 현재 설정을 반영합니다. 색상을 고르고 배경을 전환한 뒤 다운로드하세요.",
+      "accent_label": "강조",
+      "bg_label": "배경",
+      "download_svg_aria": "맞춤 로고를 SVG로 다운로드",
+      "download_png_aria": "맞춤 로고를 PNG로 다운로드"
+    },
+    "typography": {
+      "title": "타이포그래피",
+      "description": "npmx는 인터페이스 텍스트와 코드 모두에 Vercel의 Geist 글꼴 패밀리를 사용합니다.",
+      "sans": "Geist Sans",
+      "sans_desc": "본문 텍스트와 UI 요소에 사용됩니다.",
+      "mono": "Geist Mono",
+      "mono_desc": "코드, 제목, 기술 콘텐츠에 사용됩니다.",
+      "pangram": "재빠른 갈색 여우가 게으른 강아지를 뛰어넘다.",
+      "numbers": "0123456789"
+    },
+    "guidelines": {
+      "title": "작은 안내",
+      "message": "우리는 접근성을 중요하게 생각하며, 여러분도 이 비전에 함께해 주길 바랍니다. 언급된 미디어를 사용할 때는 배경과 충분한 대비가 있는지 확인하고 24px보다 작게 사용하지 마세요. 프로젝트에 대한 다른 리소스나 추가 정보가 필요하면 {link}로 편하게 연락해 주세요.",
+      "discord_link_text": "chat.npmx.dev"
+    }
+  },
+  "alt_logo_kawaii": "귀엽고 둥글며 다채로운 npmx 로고 버전입니다.",
+  "changelog": {
+    "pre_release": "사전 릴리스",
+    "draft": "초안",
+    "no_logs": "죄송합니다. 이 패키지는 변경 기록을 게시하지 않거나 변경 기록 형식이 지원되지 않습니다.",
+    "error": {
+      "p1": "죄송합니다. {package}의 변경 기록을 불러올 수 없습니다",
+      "p2": "나중에 다시 시도하거나 {viewon}"
+    },
+    "rate_limit_ungh": "죄송합니다. GitHub 요청 제한에 도달했습니다. 잠시 후 다시 시도하세요",
+    "version_unavailable": "요청한 버전을 사용할 수 없습니다."
+  }
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

Adds Korean (ko-KR) translations and registers the locale.

### 📚 Description

Added a new `ko-KR.json` locale and updated `config/i18n.ts` accordingly.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
