### PR TITLE
fix: differences in downloads embed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "0.1.20",
     "vue": "3.5.38",
-    "vue-data-ui": "3.21.5",
+    "vue-data-ui": "3.22.0",
     "vue-router": "5.0.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,8 +256,8 @@ importers:
         specifier: 3.5.38
         version: 3.5.38(typescript@6.0.2)
       vue-data-ui:
-        specifier: 3.21.5
-        version: 3.21.5(vue@3.5.38)
+        specifier: 3.22.0
+        version: 3.22.0(vue@3.5.38)
       vue-router:
         specifier: 5.0.4
         version: 5.0.4(@vue/compiler-sfc@3.5.38)(vue@3.5.38)
@@ -418,7 +418,7 @@ importers:
         version: 12.8.0
       docus:
         specifier: 5.9.0
-        version: 5.9.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@nuxt/schema@4.4.8)(@takumi-rs/wasm@1.0.9)(@tiptap/extensions@3.24.0)(@tiptap/y-tiptap@3.0.2)(@unhead/vue@2.1.15)(@upstash/redis@1.37.0)(@vue/compiler-dom@3.5.38)(better-sqlite3@12.8.0)(db0@0.3.4)(embla-carousel@8.6.0)(eslint@9.39.2)(focus-trap@8.0.0)(fontless@0.2.1)(h3@1.15.11)(ioredis@5.10.1)(magicast@0.5.3)(nitropack@2.13.4)(nuxt@4.4.8)(playwright-core@1.60.0)(react-dom@19.2.4)(react@19.2.4)(rollup@4.60.3)(sharp@0.34.5)(typescript@6.0.2)(unifont@0.7.4)(unstorage@1.17.5)(valibot@1.3.1)(vite@8.0.0)(vue-router@5.0.4)(vue@3.5.38)(yjs@13.6.29)
+        version: 5.9.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@nuxt/schema@4.4.8)(@takumi-rs/wasm@1.0.9)(@tiptap/extensions@3.24.0)(@tiptap/y-tiptap@3.0.2)(@unhead/vue@2.1.15)(@upstash/redis@1.37.0)(@vue/compiler-dom@3.5.38)(better-sqlite3@12.8.0)(db0@0.3.4)(embla-carousel@8.6.0)(eslint@9.39.2)(focus-trap@8.0.0)(fontless@0.2.1)(h3@2.0.1-rc.20)(ioredis@5.10.1)(magicast@0.5.3)(nitropack@2.13.4)(nuxt@4.4.8)(playwright-core@1.60.0)(react-dom@19.2.4)(react@19.2.4)(rollup@4.60.3)(sharp@0.34.5)(typescript@6.0.2)(unifont@0.7.4)(unstorage@1.17.5)(valibot@1.3.1)(vite@8.0.0)(vue-router@5.0.4)(vue@3.5.38)(yjs@13.6.29)
       nuxt:
         specifier: 4.4.8
         version: 4.4.8(@babel/plugin-syntax-jsx@7.28.6)(@babel/plugin-syntax-typescript@7.28.6)(@parcel/watcher@2.5.6)(@types/node@24.12.0)(@upstash/redis@1.37.0)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4)(esbuild@0.27.3)(eslint@9.39.2)(ioredis@5.10.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rollup-plugin-visualizer@7.0.1)(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.2)(vite@8.0.0)(vue-tsc@3.2.6)(yaml@2.9.0)
@@ -11252,8 +11252,8 @@ packages:
   vue-component-type-helpers@3.3.5:
     resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
 
-  vue-data-ui@3.21.5:
-    resolution: {integrity: sha512-+aIsMphMdTdWpNncgflZlJO2ZsyAvzJbYkCTn9g89o8YYW4PpGS5DbO5aKwEo1Nho2DsBSTtKRp6vVY9PelYuw==}
+  vue-data-ui@3.22.0:
+    resolution: {integrity: sha512-FwEv+dtzrIny8jYR1qQ8Ye6IYMA7MDCy+86LQAldV5n/iWF1Ebfx6LI8LHfOBXL7mMZLZ0kggeukGo9y1Ssuyw==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -14587,11 +14587,11 @@ snapshots:
       - uploadthing
       - vue
 
-  '@nuxtjs/mcp-toolkit@0.13.4(h3@1.15.11)(magicast@0.5.3)(zod@4.3.6)':
+  '@nuxtjs/mcp-toolkit@0.13.4(h3@2.0.1-rc.20)(magicast@0.5.3)(zod@4.3.6)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
-      h3: 1.15.11
+      h3: 2.0.1-rc.20
       tinyglobby: 0.2.17
       zod: 4.3.6
     transitivePeerDependencies:
@@ -18272,7 +18272,7 @@ snapshots:
 
   doctypes@1.1.0: {}
 
-  docus@5.9.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@nuxt/schema@4.4.8)(@takumi-rs/wasm@1.0.9)(@tiptap/extensions@3.24.0)(@tiptap/y-tiptap@3.0.2)(@unhead/vue@2.1.15)(@upstash/redis@1.37.0)(@vue/compiler-dom@3.5.38)(better-sqlite3@12.8.0)(db0@0.3.4)(embla-carousel@8.6.0)(eslint@9.39.2)(focus-trap@8.0.0)(fontless@0.2.1)(h3@1.15.11)(ioredis@5.10.1)(magicast@0.5.3)(nitropack@2.13.4)(nuxt@4.4.8)(playwright-core@1.60.0)(react-dom@19.2.4)(react@19.2.4)(rollup@4.60.3)(sharp@0.34.5)(typescript@6.0.2)(unifont@0.7.4)(unstorage@1.17.5)(valibot@1.3.1)(vite@8.0.0)(vue-router@5.0.4)(vue@3.5.38)(yjs@13.6.29):
+  docus@5.9.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@nuxt/schema@4.4.8)(@takumi-rs/wasm@1.0.9)(@tiptap/extensions@3.24.0)(@tiptap/y-tiptap@3.0.2)(@unhead/vue@2.1.15)(@upstash/redis@1.37.0)(@vue/compiler-dom@3.5.38)(better-sqlite3@12.8.0)(db0@0.3.4)(embla-carousel@8.6.0)(eslint@9.39.2)(focus-trap@8.0.0)(fontless@0.2.1)(h3@2.0.1-rc.20)(ioredis@5.10.1)(magicast@0.5.3)(nitropack@2.13.4)(nuxt@4.4.8)(playwright-core@1.60.0)(react-dom@19.2.4)(react@19.2.4)(rollup@4.60.3)(sharp@0.34.5)(typescript@6.0.2)(unifont@0.7.4)(unstorage@1.17.5)(valibot@1.3.1)(vite@8.0.0)(vue-router@5.0.4)(vue@3.5.38)(yjs@13.6.29):
     dependencies:
       '@ai-sdk/gateway': 3.0.101(zod@4.3.6)
       '@ai-sdk/mcp': 1.0.36(zod@4.3.6)
@@ -18285,7 +18285,7 @@ snapshots:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       '@nuxt/ui': 4.6.1(@nuxt/content@3.12.0)(@tiptap/extensions@3.24.0)(@tiptap/y-tiptap@3.0.2)(@upstash/redis@1.37.0)(db0@0.3.4)(embla-carousel@8.6.0)(focus-trap@8.0.0)(ioredis@5.10.1)(magicast@0.5.3)(react-dom@19.2.4)(react@19.2.4)(tailwindcss@4.2.2)(typescript@6.0.2)(valibot@1.3.1)(vite@8.0.0)(vue-router@5.0.4)(vue@3.5.38)(yjs@13.6.29)(zod@4.3.6)
       '@nuxtjs/i18n': 10.2.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@upstash/redis@1.37.0)(@vue/compiler-dom@3.5.38)(db0@0.3.4)(eslint@9.39.2)(ioredis@5.10.1)(magicast@0.5.3)(rollup@4.60.3)(typescript@6.0.2)(vue@3.5.38)
-      '@nuxtjs/mcp-toolkit': 0.13.4(h3@1.15.11)(magicast@0.5.3)(zod@4.3.6)
+      '@nuxtjs/mcp-toolkit': 0.13.4(h3@2.0.1-rc.20)(magicast@0.5.3)(zod@4.3.6)
       '@nuxtjs/mdc': 0.21.1(magicast@0.5.3)
       '@nuxtjs/robots': 6.0.9(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.8)(vite@8.0.0)(vue@3.5.38)(zod@4.3.6)
       '@shikijs/core': 4.1.0
@@ -24306,7 +24306,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.5: {}
 
-  vue-data-ui@3.21.5(vue@3.5.38):
+  vue-data-ui@3.22.0(vue@3.5.38):
     dependencies:
       vue: 3.5.38(typescript@6.0.2)
 

--- a/server/utils/embed-downloads-svg.ts
+++ b/server/utils/embed-downloads-svg.ts
@@ -120,6 +120,10 @@ export function parseMetric(value: unknown): Metric {
   return 'downloads'
 }
 
+function dateIsoToUtcMs(dateIso: string): number {
+  return new Date(`${dateIso}T00:00:00.000Z`).getTime()
+}
+
 export async function createDownloadsSvgResponse(query: QueryParameters): Promise<string> {
   const packageNames = parsePackageNames(query.packages ?? query.package)
 
@@ -172,7 +176,7 @@ export async function createDownloadsSvgResponse(query: QueryParameters): Promis
   })
 
   const chartFilter = {
-    averageWindow: 1,
+    averageWindow: 0,
     smoothingTau: 0,
     predictionPoints: 0,
   }
@@ -195,13 +199,16 @@ export async function createDownloadsSvgResponse(query: QueryParameters): Promis
     accent,
   })
 
+  const effectiveEndDateIso = getEffectiveEndDateIso(evolutionOptions.endDate)
+  const effectiveEndDateMs = dateIsoToUtcMs(effectiveEndDateIso)
+
   const dataset = buildNormalisedTrendsDataset({
     dataset: chartData.dataset,
     dates: chartData.dates,
     granularity: chartGranularity,
     selectedMetric: metric,
     chartFilter,
-    nowMs: Date.now(),
+    endDateMs: effectiveEndDateMs,
   })
 
   if (!chartData.dataset?.length) {
@@ -284,8 +291,6 @@ export async function createDownloadsSvgResponse(query: QueryParameters): Promis
       },
     },
   })
-
-  const effectiveEndDateIso = getEffectiveEndDateIso(evolutionOptions.endDate)
 
   const shouldDashLastPoint =
     (chartGranularity === 'monthly' && !isLastDayOfMonth(effectiveEndDateIso)) ||

--- a/shared/utils/trends-chart.ts
+++ b/shared/utils/trends-chart.ts
@@ -298,7 +298,7 @@ export function buildNormalisedTrendsDataset(options: {
   endDateMs?: number | null
   nowMs?: number
 }): TrendsNormalisedDatasetItem[] {
-  const referenceMs = options.endDateMs ?? options.nowMs ?? Date.now()
+  const referenceMs = options.endDateMs ?? Date.now()
   const lastDateMs = options.dates.at(-1) ?? 0
   const isAbsoluteMetric = options.selectedMetric === 'contributors'
 

--- a/shared/utils/trends-chart.ts
+++ b/shared/utils/trends-chart.ts
@@ -296,7 +296,6 @@ export function buildNormalisedTrendsDataset(options: {
     predictionPoints?: number
   }
   endDateMs?: number | null
-  nowMs?: number
 }): TrendsNormalisedDatasetItem[] {
   const referenceMs = options.endDateMs ?? Date.now()
   const lastDateMs = options.dates.at(-1) ?? 0

--- a/test/unit/shared/utils/trends-chart.spec.ts
+++ b/test/unit/shared/utils/trends-chart.spec.ts
@@ -546,7 +546,6 @@ describe('buildNormalisedTrendsDataset', () => {
       selectedMetric: 'downloads',
       chartFilter: { averageWindow: 2, smoothingTau: 3 },
       endDateMs: 500,
-      nowMs: 100,
     })
 
     expect(applyDataPipelineMock).toHaveBeenCalledWith(
@@ -572,7 +571,7 @@ describe('buildNormalisedTrendsDataset', () => {
     ])
   })
 
-  it('uses Date.now when endDateMs and nowMs are missing', () => {
+  it('uses Date.now when endDateMs is missing', () => {
     const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(999)
 
     buildNormalisedTrendsDataset({

--- a/test/unit/shared/utils/trends-chart.spec.ts
+++ b/test/unit/shared/utils/trends-chart.spec.ts
@@ -526,7 +526,6 @@ describe('buildNormalisedTrendsDataset', () => {
         granularity: 'daily',
         selectedMetric: 'downloads',
         chartFilter: { averageWindow: 1, smoothingTau: 0 },
-        nowMs: 100,
       }),
     ).toEqual([])
   })
@@ -573,26 +572,6 @@ describe('buildNormalisedTrendsDataset', () => {
     ])
   })
 
-  it('uses nowMs when endDateMs is null', () => {
-    buildNormalisedTrendsDataset({
-      dataset: [{ name: 'vue', type: 'line', series: [1] }],
-      dates: [10],
-      granularity: 'daily',
-      selectedMetric: 'downloads',
-      chartFilter: { averageWindow: 1, smoothingTau: 0 },
-      endDateMs: null,
-      nowMs: 123,
-    })
-
-    expect(applyDataPipelineMock).toHaveBeenCalledWith(
-      [1],
-      expect.any(Object),
-      expect.objectContaining({
-        referenceMs: 123,
-      }),
-    )
-  })
-
   it('uses Date.now when endDateMs and nowMs are missing', () => {
     const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(999)
 
@@ -624,19 +603,23 @@ describe('buildNormalisedTrendsDataset', () => {
       dates: [10],
       granularity: 'weekly',
       selectedMetric: 'contributors',
-      chartFilter: { averageWindow: 1, smoothingTau: 0, predictionPoints: 5 },
-      nowMs: 100,
+      chartFilter: { averageWindow: 0, smoothingTau: 0, predictionPoints: 5 },
+      endDateMs: 100,
     })
 
     expect(applyDataPipelineMock).toHaveBeenCalledWith(
       [1],
-      expect.objectContaining({
+      {
+        averageWindow: 0,
+        smoothingTau: 0,
         predictionPoints: 0,
-      }),
-      expect.objectContaining({
-        isAbsoluteMetric: true,
+      },
+      {
+        granularity: 'weekly',
+        lastDateMs: 10,
         referenceMs: 100,
-      }),
+        isAbsoluteMetric: true,
+      },
     )
   })
 })


### PR DESCRIPTION
Follow up to #2833 

This fixes 2 imprecisions in the embed-chart:

1. `averageWindow` data correction was set to 1, instead of 0 (no data correction is to be applied on the embed version).
2. the end date was forced to date.now instead of the same date as the one used in TrendsChart.vue, resulting in a different last value.

To test:
- go to the stats page and open the 'Embed this chart' details under the downloads chart
- the preview chart should have the same shape and last value as the main chart (make sure you have unset any data correction settings)

Other:
- Bump vue-data-ui to latest