### PR TITLE
feat: show timeline chart with steps instead of spline

### DIFF
--- a/app/components/Package/TimelineChart.vue
+++ b/app/components/Package/TimelineChart.vue
@@ -187,7 +187,7 @@ const datasets = computed<{
       {
         name: $t('package.stats.install_size'),
         type: 'line',
-        smooth: true,
+        useStepper: true,
         series: seriesTotalSize.value.values,
         temperatureColors: areAllValuesEqual(seriesTotalSize.value.values)
           ? undefined
@@ -200,7 +200,7 @@ const datasets = computed<{
       {
         name: $t('compare.dependencies'),
         type: 'line',
-        smooth: true,
+        useStepper: true,
         series: seriesDependencies.value.values,
         temperatureColors: areAllValuesEqual(seriesDependencies.value.values)
           ? undefined


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2953

### 🧭 Context

The size / deps change isn't gradual but happens on release.

### 📚 Description

Show steps instead of a spline on the timeline chart:

| Dark mode | Light mode |
|------------|-------------|
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/d381b6a0-9510-48b2-8410-09cc82e7c973" />|<img width="400" alt="image" src="https://github.com/user-attachments/assets/108b8a3f-f270-401a-8f94-6ca1029d05ff" />|



