### PR TITLE
perf: use lightning css transformer

### DIFF
--- a/app/components/Package/TimelineChart.vue
+++ b/app/components/Package/TimelineChart.vue
@@ -919,7 +919,7 @@ const indexSelection = computed(() => {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  ::deep(.vue-data-ui-component .serie_line_0 path),
+  :deep(.vue-data-ui-component .serie_line_0 path),
   .svg-element-transition,
   :deep(.vdui-shape-circle) {
     transition: none !important;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -409,6 +409,9 @@ export default defineNuxtConfig({
   },
 
   vite: {
+    css: {
+      transformer: 'lightningcss',
+    },
     optimizeDeps: {
       include: [
         '@vueuse/core',

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
     // keep this preset last
     ...(process.env.CI ? [] : [presetRtl(), presetA11y()]),
   ].filter(Boolean),
-  transformers: [transformerDirectives(), transformerVariantGroup()],
+  transformers: [transformerDirectives({ enforce: 'pre' }), transformerVariantGroup()],
   theme,
   shortcuts: [
     // Layout


### PR DESCRIPTION
### 🧭 Context

Faster builds with what Vite 8 will use as the default.

### 📚 Description

This branch enables Vite’s Lightning CSS transformer and makes UnoCSS directive transforms run in `pre` to expand directives before Lightning CSS. It also fixes one invalid `::deep(...)` -> `:deep(...)` reference.

On my machine, this reduces build time from 9.16s to 8.57s (~6.4% faster).