### PR TITLE
perf: lazy load Bluesky video player

### DIFF
--- a/app/components/global/BlueskyPostEmbed.client.vue
+++ b/app/components/global/BlueskyPostEmbed.client.vue
@@ -10,7 +10,13 @@ const props = defineProps<{
   uri?: string
   /** Bluesky URL of the post, e.g. https://bsky.app/profile/handle/post/rkey */
   url?: string
+  /** Optional preload hint. Rendering still depends on the fetched embed metadata. */
+  mediaHint?: 'video'
 }>()
+
+if (props.mediaHint === 'video') {
+  void import('~/components/VideoPlayer.vue')
+}
 
 interface PostAuthor {
   did: string
@@ -199,7 +205,7 @@ const postUrl = computed(() => {
     <!-- Embedded video -->
     <template v-if="post.embed?.playlist">
       <div class="relative block mb-3 p-0.5 bg-bg-muted rounded-lg">
-        <VideoPlayer
+        <LazyVideoPlayer
           :poster="post.embed.thumbnail"
           playsInline
           controls

--- a/app/pages/blog/release/crystal-chronicle.md
+++ b/app/pages/blog/release/crystal-chronicle.md
@@ -36,7 +36,7 @@ To keep a high-quality and predictable user experience, we’ve switched to plan
 
 When it comes to growth, one of the most important metrics is change rather than absolute values. It shows how the project or package is evolving and in what direction. To make this analysis easier, we added a Timeline tab that shows not only versions, but also the key changes that happened in each of them.
 
-<BlueskyPostEmbed url="https://bsky.app/profile/graphieros.npmx.social/post/3mllmom2zfk2v" />
+<BlueskyPostEmbed url="https://bsky.app/profile/graphieros.npmx.social/post/3mllmom2zfk2v" media-hint="video" />
 
 ### Module replacements v3
 
@@ -66,7 +66,7 @@ And now, for example, when you follow links from pnpm, you’ll immediately get 
 
 The community has always been a key part of npmx. And we’re incredibly excited to work together to create the perfect experience. In the last release, we added a package comparison chart with the scoring system. This chart, given the specific nature of any comparison, received a lot of feedback from the community. To make the experience more comprehensive and convenient, we’ve made it so you can now choose what and how you want to compare.
 
-<BlueskyPostEmbed url="https://bsky.app/profile/graphieros.npmx.social/post/3mjzlmesrts2f" />
+<BlueskyPostEmbed url="https://bsky.app/profile/graphieros.npmx.social/post/3mjzlmesrts2f" media-hint="video" />
 
 ### And much more
 


### PR DESCRIPTION
### 🔗 Linked issue

None (but perf is always good!)

### 📚 Description

This PR lazy-loads the Bluesky video player so non-video Bluesky embeds no longer pull in the full HLS player chunk if they dont need it.

Optionally, a `media-hint="video"` preload hint for known video posts can be set, which starts loading the video player earlier while still rendering only when post.embed?.playlist is present. This is optional but recommended when we know the content.

During tests, HLS split into its own (now optional) chunk at about 152.2 KB gzip, with the Bluesky embed chunk staying small at about 2.1 KB gzip.