### PR TITLE
perf: import module replacements util directly

### DIFF
--- a/app/components/Compare/ReplacementSuggestion.vue
+++ b/app/components/Compare/ReplacementSuggestion.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ModuleReplacement } from 'module-replacements'
-import { resolveDocUrl } from 'module-replacements'
+import { resolveDocUrl } from 'module-replacements/dist/util.js'
 import { getReplacementDescription, getReplacementNodeVersion } from '~/utils/module-replacements'
 
 const props = defineProps<{

--- a/app/components/Package/Replacement.vue
+++ b/app/components/Package/Replacement.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ModuleReplacement, ModuleReplacementMapping } from 'module-replacements'
-import { resolveDocUrl } from 'module-replacements'
+import { resolveDocUrl } from 'module-replacements/dist/util.js'
 import { getReplacementDescription, getReplacementNodeVersion } from '~/utils/module-replacements'
 
 const props = defineProps<{


### PR DESCRIPTION
### 📚  Description

We don't use the module replacements manifest, only the util.
As @gameroman pointed out in https://github.com/e18e/module-replacements/pull/751, we can already use the dist alias to avoid pulling in the manifest and saving 21 kB.

This PR does exactly that.

Note: If https://github.com/e18e/module-replacements/pull/751 lands I suggest to use the "official alias".