### PR TITLE
feat(ui): add Deno icon to engine compatibility table

### DIFF
--- a/app/components/Package/Compatibility.vue
+++ b/app/components/Package/Compatibility.vue
@@ -5,6 +5,7 @@ const props = defineProps<{
 
 const engineNames: Record<string, string> = {
   bun: 'Bun',
+  deno: 'Deno',
   node: 'Node.js',
   npm: 'npm',
 }
@@ -12,6 +13,7 @@ const engineNames: Record<string, string> = {
 // Map engine name to icon class
 const engineIcons: Record<string, string> = {
   bun: 'i-simple-icons:bun',
+  deno: 'i-simple-icons:deno',
   node: 'i-simple-icons:nodedotjs',
   npm: 'i-simple-icons:npm',
   pnpm: 'i-simple-icons:pnpm',


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

The "Compatibility" table in the right sidebar on the package page shows what runtimes/tools the package supports. The data comes from `package.json#engines`. There are pretty icons for Node, npm, bun, but not for Deno.

This PR adds the icon and the proper capitalization for `deno`.

### 📚 Description

For example, [`@fedify/fedify`](https://npmx.dev/package/@fedify/fedify):

| Before | After |
| ------ | ----- |
| <img width="310" height="138" alt="image" src="https://github.com/user-attachments/assets/bdaf562a-d209-4d29-bf1f-1ea8ea50b1ae" /> | <img width="311" height="139" alt="image" src="https://github.com/user-attachments/assets/baf05da3-b748-4279-bccf-216cbb463f67" /> |



<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
