### PR TITLE
chore: make autofix workflow steps parallel

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -32,16 +32,17 @@ jobs:
           cache: true
           sfw: true
 
-      - name: 🎨 Check for non-RTL/non-a11y CSS classes
-        run: vp run lint:css
+      - parallel:
+          - name: 🎨 Check for non-RTL/non-a11y CSS classes
+            run: vp run lint:css
 
-      - name: 🌐 Compare translations
-        run: vp run i18n:check
+          - name: 🌐 Compare translations
+            run: vp run i18n:check
 
-      - name: 🌍 Update lunaria data
-        run: vp run build:lunaria
+          - name: 🌍 Update lunaria data
+            run: vp run build:lunaria
 
-      - name: 🔠 Fix lint errors
-        run: vp run lint:fix
+          - name: 🔠 Fix lint errors
+            run: vp run lint:fix
 
       - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27 # v1.3.2


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

Using GitHub's new parallel feature for action steps: https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/

I went through all our GitHub actions and this was the only place where we can really safe some seconds and where parallelism is possible.

### 📚 Description

This PR wraps the four main steps in the `autofix.yml` action in a [parallel block](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsparallel), so they are executed simultaneously. This is only possible because they do not depend on each other:

- `lint:css` and `i18n:check` only read
- `build:lunaria` only generates files under `dist/lunaria`
- `lint:fix` does not touch build outputs