### PR TITLE
fix: passthrough of query

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -190,7 +190,11 @@ export default defineNuxtConfig({
     },
     // pages
     '/leaderboard/likes': getISRConfig(900),
-    '/package/**': getISRConfig(300, { fallback: 'html' }),
+    '/package/**': getISRConfig(300, {
+      fallback: 'html',
+      passQuery: true,
+      allowQuery: ['activeTab'],
+    }),
     '/package/:name/_payload.json': getISRConfig(300, { fallback: 'json' }),
     '/package/:name/v/:version/_payload.json': getISRConfig(300, { fallback: 'json' }),
     '/package/:org/:name/_payload.json': getISRConfig(300, { fallback: 'json' }),
@@ -449,8 +453,14 @@ export default defineNuxtConfig({
 
 interface ISRConfigOptions {
   fallback?: 'html' | 'json'
+  allowQuery?: string[]
+  passQuery?: boolean
 }
 function getISRConfig(expirationSeconds: number, options: ISRConfigOptions = {}) {
+  const extraISR = {
+    ...(options.passQuery ? { passQuery: true } : {}),
+    ...(options.allowQuery ? { allowQuery: options.allowQuery } : {}),
+  }
   if (options.fallback) {
     return {
       isr: {
@@ -458,12 +468,14 @@ function getISRConfig(expirationSeconds: number, options: ISRConfigOptions = {})
         fallback:
           options.fallback === 'html' ? 'spa.prerender-fallback.html' : 'payload-fallback.json',
         initialHeaders: options.fallback === 'json' ? { 'content-type': 'application/json' } : {},
+        ...extraISR,
       } as { expiration: number },
     }
   }
   return {
     isr: {
       expiration: expirationSeconds,
+      ...extraISR,
     },
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

The hope is that this fix will make the change implemented in https://github.com/npmx-dev/npmx.dev/pull/2800 work when npmx is deployed. That fix worked locally, but not when live.

### 🧭 Context

For reasons that I don't fully understand (still a nuxt noob) the query options were not being passed through.

### 📚 Description

This PR changes the nuxt config in a way that I *think* will mean it passes through what we need and things should start to work. I hope.  I don't know how to test this though.  Working locally isn't enough I know; is there a way to push this to a preview environment or similar?  Dunno.  cc @gameroman 