### PR TITLE
fix: deduplicate `id="provenance"`

### DIFF
--- a/app/components/PackageProvenanceSection.vue
+++ b/app/components/PackageProvenanceSection.vue
@@ -5,7 +5,7 @@ defineProps<{
 </script>
 
 <template>
-  <section id="provenance" aria-labelledby="provenance-heading" class="scroll-mt-20">
+  <section aria-labelledby="provenance-heading" class="scroll-mt-20">
     <h2 id="provenance-heading" class="group text-xs text-fg-subtle uppercase tracking-wider mb-3">
       <LinkBase to="#provenance">
         {{ $t('package.provenance_section.title') }}


### PR DESCRIPTION
### 🔗 Linked issue

Hi!

Small fix, no related issue

### 🧭 Context

`id="provenance"` may appear twice in the page if `provenanceData` is defined

<img width="1310" height="556" alt="image" src="https://github.com/user-attachments/assets/b5f11d6e-af21-4601-82e3-53d8dc0f4737" />

https://github.com/search?q=repo%3Anpmx-dev%2Fnpmx.dev+%22id%3D%5C%22provenance%22&type=code

### 📚 Description

Issue discovered with Pa11y

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
