### PR TITLE
fix: spacing on bluesky post embeds with a gallery on the blog

### DIFF
--- a/app/components/global/BlueskyPostEmbed.client.vue
+++ b/app/components/global/BlueskyPostEmbed.client.vue
@@ -238,7 +238,7 @@ const postUrl = computed(() => {
     </template>
 
     <!-- Timestamp + engagement -->
-    <div class="flex items-center gap-4 text-sm text-fg-subtle">
+    <div class="flex items-center gap-4 text-sm text-fg-subtle mt-3">
       <DateTime :datetime="post.record.createdAt" date-style="medium" />
       <span v-if="post.likeCount" class="flex items-center gap-1">
         <span class="i-lucide:heart w-3.5 h-3.5" aria-hidden="true" />


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

Rendering BlueSky posts.

### 📚 Description

After reading the [awesome recent blog post](https://npmx.dev/blog/release/rainbow-comet), I noticed some missing margin between the engagement section of a BlueSky post and images/videos.

This PR fixes the missing margin by adding `mt-3` to the engagement section, here is a visual comparison:

| Without margin  | With margin  |
|---|---|
| <img width="347" height="107" alt="image" src="https://github.com/user-attachments/assets/aa5671cf-c78e-4a23-9d82-56283e35c3dd" />  | <img width="279" height="82" alt="image" src="https://github.com/user-attachments/assets/044e007f-4cd6-4f62-899b-89f845604b4d" />  |
| [Production link](https://npmx.dev/blog/release/rainbow-comet#state-of-npmx)  | [Deployment preview](https://npmxdev-git-fork-trueberryless-fix-bluesky-post-eng-1ee600-npmx.vercel.app/blog/release/rainbow-comet#state-of-npmx)  |