### PR TITLE
feat: add -y flag to allow for skipping warning message & prompt

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -46,8 +46,8 @@ const main = defineCommand({
     y: {
       type: 'boolean',
       description: 'Skip warning message and accept prompt',
-      default: false
-    }
+      default: false,
+    },
   },
   async run({ args }) {
     const port = Number.parseInt(args.port as string, 10) || DEFAULT_PORT
@@ -56,7 +56,7 @@ const main = defineCommand({
 
     initLogger()
 
-    if(!args.y) {
+    if (!args.y) {
       // Warning message and accept prompt
       logWarning(
         `This allows ${styleText('underline', 'npmx.dev')} to access your npm cli and any authenticated contexts.`,
@@ -65,7 +65,7 @@ const main = defineCommand({
         message: 'Do you accept?',
         initialValue: true,
       })
-  
+
       if (!accept || p.isCancel(accept)) {
         logError('Connector setup cancelled.')
         process.exit(0)

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -47,7 +47,7 @@ const main = defineCommand({
       type: 'boolean',
       description: 'Skip warning message and accept prompt',
       default: false,
-      alias: ["y"]
+      alias: ['y'],
     },
   },
   async run({ args }) {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -43,6 +43,11 @@ const main = defineCommand({
       description: 'Port to listen on',
       default: String(DEFAULT_PORT),
     },
+    y: {
+      type: 'boolean',
+      description: 'Skip warning message and accept prompt',
+      default: false
+    }
   },
   async run({ args }) {
     const port = Number.parseInt(args.port as string, 10) || DEFAULT_PORT
@@ -51,18 +56,20 @@ const main = defineCommand({
 
     initLogger()
 
-    // Warning message and accept prompt
-    logWarning(
-      `This allows ${styleText('underline', 'npmx.dev')} to access your npm cli and any authenticated contexts.`,
-    )
-    const accept = await p.confirm({
-      message: 'Do you accept?',
-      initialValue: true,
-    })
-
-    if (!accept || p.isCancel(accept)) {
-      logError('Connector setup cancelled.')
-      process.exit(0)
+    if(!args.y) {
+      // Warning message and accept prompt
+      logWarning(
+        `This allows ${styleText('underline', 'npmx.dev')} to access your npm cli and any authenticated contexts.`,
+      )
+      const accept = await p.confirm({
+        message: 'Do you accept?',
+        initialValue: true,
+      })
+  
+      if (!accept || p.isCancel(accept)) {
+        logError('Connector setup cancelled.')
+        process.exit(0)
+      }
     }
 
     // Check npm authentication before starting

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -43,10 +43,11 @@ const main = defineCommand({
       description: 'Port to listen on',
       default: String(DEFAULT_PORT),
     },
-    y: {
+    yes: {
       type: 'boolean',
       description: 'Skip warning message and accept prompt',
       default: false,
+      alias: ["y"]
     },
   },
   async run({ args }) {
@@ -56,7 +57,7 @@ const main = defineCommand({
 
     initLogger()
 
-    if (!args.y) {
+    if (!args.yes) {
       // Warning message and accept prompt
       logWarning(
         `This allows ${styleText('underline', 'npmx.dev')} to access your npm cli and any authenticated contexts.`,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

There's currently no way to run the connector non-interactively.

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

This PR adds a `-y` flag which skips the prompt.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
