### PR TITLE
fix: standard site sync

### DIFF
--- a/modules/standard-site-sync.ts
+++ b/modules/standard-site-sync.ts
@@ -4,7 +4,7 @@ import { glob } from 'node:fs/promises'
 import { join } from 'node:path'
 import { defineNuxtModule, useNuxt, createResolver } from 'nuxt/kit'
 import { safeParse } from 'valibot'
-import { BlogPostSchema, type BlogPostFrontmatter } from '#shared/schemas/blog'
+import { RawBlogPostSchema, type BlogPostFrontmatter } from '#shared/schemas/blog'
 import { NPMX_DEV_DID, NPMX_SITE } from '#shared/utils/constants'
 import { read } from 'gray-matter'
 import { PasswordSession } from '@atproto/lex-password-session'
@@ -18,6 +18,7 @@ import {
 import * as com from '../shared/types/lexicons/com'
 import * as site from '../shared/types/lexicons/site'
 import { generateBlogTID, npmxPublicationRkey } from '#shared/utils/atproto'
+import { setTimeout } from 'node:timers/promises'
 
 const syncedDocuments = new Map<string, string>()
 
@@ -89,7 +90,7 @@ export default defineNuxtModule({
               },
             )
             // Wait for the firehose and indexers to catch up if we create a publication
-            await new Promise(sleepResolve => setTimeout(sleepResolve, 2_000))
+            await setTimeout(2_000)
           }
           if (documentsToSync.length > 0) {
             await syncsiteStandardDocuments(authenticatedClient, documentsToSync)
@@ -169,7 +170,7 @@ function createContentHash(data: unknown): string {
     .digest('hex')
 }
 
-function buildATProtoDocument(siteUrl: string, data: BlogPostDocument) {
+function buildATProtoDocument(data: BlogPostDocument) {
   return site.standard.document.$build({
     site: `at://${NPMX_DEV_DID}/site.standard.publication/${npmxPublicationRkey()}`,
     path: data.path,
@@ -205,7 +206,7 @@ const syncFile = async (
     ).toISOString()
   }
 
-  const result = safeParse(BlogPostSchema, normalizedFrontmatter)
+  const result = safeParse(RawBlogPostSchema, normalizedFrontmatter)
   if (!result.success) {
     console.warn(`[standard-site-sync] Validation failed for ${filePath}`, result.issues)
     return
@@ -245,7 +246,7 @@ const syncFile = async (
   if (checkForBlogResult instanceof XrpcResponseError) {
     //Means it's not been uploaded and we can do that now
     if (checkForBlogResult.error === 'RecordNotFound') {
-      const document = buildATProtoDocument(siteUrl, data)
+      const document = buildATProtoDocument(data)
       return { tid, document }
     }
   }

--- a/shared/schemas/blog.ts
+++ b/shared/schemas/blog.ts
@@ -49,7 +49,7 @@ export const RawBlogPostSchema = object({
 })
 
 /** Schema for blog post frontmatter with resolved author data (avatars, profile URLs) */
-export const BlogPostSchema = object({
+const BlogPostSchema = object({
   authors: array(ResolvedAuthorSchema),
   title: string(),
   date: pipe(string(), isoTimestamp()),


### PR DESCRIPTION
Looks like after #1879 (probably) when the blog post avatars were done at build time, the schema that was being used in the standard site sync code for the blog post frontmatter validation wasn't updated, so it's been failing to sync. I ran this fix so the standard site is working in production, and this should keep it working for future posts.