### PR TITLE
fix: remove bottom white space from PNG prints of xy charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "0.1.20",
     "vue": "3.5.39",
-    "vue-data-ui": "3.22.3",
+    "vue-data-ui": "3.22.6",
     "vue-router": "5.0.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,8 +256,8 @@ importers:
         specifier: 3.5.39
         version: 3.5.39(typescript@6.0.2)
       vue-data-ui:
-        specifier: 3.22.3
-        version: 3.22.3(vue@3.5.39)
+        specifier: 3.22.6
+        version: 3.22.6(vue@3.5.39)
       vue-router:
         specifier: 5.0.4
         version: 5.0.4(@vue/compiler-sfc@3.5.39)(vue@3.5.39)
@@ -11263,8 +11263,8 @@ packages:
   vue-component-type-helpers@3.3.6:
     resolution: {integrity: sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==}
 
-  vue-data-ui@3.22.3:
-    resolution: {integrity: sha512-CfH4X/fASIaeKJDUdLE19UstTbTXCB9mm6U2Ig95MGPekOLo4ZvC/9OfUcUEe7PwzGyu3a9861hL8EvM4IVqpA==}
+  vue-data-ui@3.22.6:
+    resolution: {integrity: sha512-E4vdfKCAWB3zAFiheMeRFbWEK491oZGfH1yv5ZiEodSidApizOgp+82FJLFQ0DgviBD7HDRseN6WT5ANcl+oUQ==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -24327,7 +24327,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.6: {}
 
-  vue-data-ui@3.22.3(vue@3.5.39):
+  vue-data-ui@3.22.6(vue@3.5.39):
     dependencies:
       vue: 3.5.39(typescript@6.0.2)
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #3002

### 🧭 Context

PNG prints of line charts (downloads, timeline) had excess bottom white space, due to the hidden zoom range slider.

### 📚 Description

Bump vue-data-ui to latest, which captures the print size without the zoom range component.

| Before | After |
|-|-|
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/d61a7f6c-b178-4d36-939a-d8f5a7cbb447" />|<img width="400" alt="image" src="https://github.com/user-attachments/assets/c0bd4588-b2d3-4447-8fe3-661d0908ae5c" />|