### PR TITLE
fix(ui): consistent terminal box height across package managers

### DIFF
--- a/app/components/Terminal/Execute.vue
+++ b/app/components/Terminal/Execute.vue
@@ -51,7 +51,8 @@ const copyExecuteCommand = () => copyExecute(getFullExecuteCommand())
         <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
         <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
       </div>
-      <div class="px-3 pt-2 pb-3 sm:px-4 sm:pt-3 sm:pb-4 space-y-1">
+      <!-- flex gap (not space-y) so hidden PM variants never affect spacing -->
+      <div class="px-3 pt-2 pb-3 sm:px-4 sm:pt-3 sm:pb-4 flex flex-col gap-1">
         <!-- Execute command - render all PM variants, CSS controls visibility -->
         <div
           v-for="pm in packageManagers"

--- a/app/components/Terminal/Install.vue
+++ b/app/components/Terminal/Install.vue
@@ -218,7 +218,11 @@ useCommandPaletteContextCommands(
         <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
         <span class="w-2.5 h-2.5 rounded-full bg-fg-subtle" />
       </div>
-      <div class="px-3 pt-2 pb-3 sm:px-4 sm:pt-3 sm:pb-4 space-y-1 overflow-x-auto" dir="ltr">
+      <!-- flex gap (not space-y) so hidden PM variants never affect spacing -->
+      <div
+        class="px-3 pt-2 pb-3 sm:px-4 sm:pt-3 sm:pb-4 flex flex-col gap-1 overflow-x-auto"
+        dir="ltr"
+      >
         <!-- Install command - render all PM variants, CSS controls visibility -->
         <div
           v-for="pm in packageManagers"


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #3016

### 🧭 Context

Every package manager's command variant stays in the DOM and is shown/hidden with CSS. The container used `space-y-1`, which only adds spacing to items that aren't the last child. The last PM in the list (`nub`) is always the structurally-last child, so when you select it, it loses its bottom margin and its command box renders ~4px shorter than the others.

### 📚 Description

Swapped `space-y-1` for `flex flex-col gap-1` on the command containers in `Terminal/Install.vue` and `Terminal/Execute.vue`. `gap` only spaces items that are actually rendered, so the hidden variants no longer affect the height and every PM's box is the same size. Visible spacing is unchanged.

Checked with `pnpm lint`, `pnpm test:types` and `pnpm test` (all passing). No new test — the bug lives in the generated CSS layout, which Vitest doesn't render.

### 📸 Screenshots

Before: non-last package managers rendered slightly taller than the last package manager (`nub`).

| npm | nub |
| --- | --- |
| <img width="775" height="129" alt="Before npm terminal height" src="https://github.com/user-attachments/assets/9818df3a-ccdf-4d6d-9732-8996b6c0d083" /> | <img width="775" height="129" alt="Before nub terminal height" src="https://github.com/user-attachments/assets/943563bf-c35b-41a5-87b5-af44379a601e" /> |

After: `npm` and `nub` render with the same terminal box height.

| npm | nub |
| --- | --- |
| <img width="775" height="129" alt="After npm terminal height" src="https://github.com/user-attachments/assets/75b2c2ae-25a6-4924-bdd6-b8e913d93a8d" /> | <img width="775" height="129" alt="After nub terminal height" src="https://github.com/user-attachments/assets/c6653cd5-0ae2-42a9-bfd3-dd236b95ba39" /> |
