### PR TITLE
fix(ui): add pointer cursors to interactive controls

### DIFF
--- a/app/components/Code/Header.vue
+++ b/app/components/Code/Header.vue
@@ -211,7 +211,7 @@ useEventListener('keydown', (event: KeyboardEvent) => {
               v-for="mode in markdownViewModes"
               :key="mode.key"
               role="tab"
-              class="px-2 py-1.5 font-mono text-xs rounded transition-colors duration-150 inline-flex items-center gap-1.5"
+              class="cursor-pointer px-2 py-1.5 font-mono text-xs rounded transition-colors duration-150 inline-flex items-center gap-1.5"
               :class="
                 markdownViewMode === mode.key
                   ? 'bg-bg-muted shadow text-fg'

--- a/app/components/CollapsibleSection.vue
+++ b/app/components/CollapsibleSection.vue
@@ -95,7 +95,7 @@ useHead({
         <button
           :id="buttonId"
           type="button"
-          class="size-5 -me-1 flex items-center justify-center text-fg-subtle hover:text-fg-muted transition-colors duration-200 shrink-0 focus-visible:outline-accent/70 rounded"
+          class="cursor-pointer size-5 -me-1 flex items-center justify-center text-fg-subtle hover:text-fg-muted transition-colors duration-200 shrink-0 focus-visible:outline-accent/70 rounded"
           :aria-expanded="isOpen"
           :aria-controls="contentId"
           :aria-label="ariaLabel"

--- a/app/components/PaginationControls.vue
+++ b/app/components/PaginationControls.vue
@@ -127,7 +127,7 @@ function handlePageSizeChange(event: Event) {
       >
         <button
           type="button"
-          class="px-2.5 py-1 text-xs font-mono rounded-sm transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-fg focus-visible:ring-offset-1"
+          class="cursor-pointer px-2.5 py-1 text-xs font-mono rounded-sm transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-fg focus-visible:ring-offset-1"
           :class="mode === 'infinite' ? 'bg-bg-muted text-fg' : 'text-fg-muted hover:text-fg'"
           :aria-pressed="mode === 'infinite'"
           @click="mode = 'infinite'"
@@ -136,7 +136,7 @@ function handlePageSizeChange(event: Event) {
         </button>
         <button
           type="button"
-          class="px-2.5 py-1 text-xs font-mono rounded-sm transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-fg focus-visible:ring-offset-1"
+          class="cursor-pointer px-2.5 py-1 text-xs font-mono rounded-sm transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-fg focus-visible:ring-offset-1"
           :class="mode === 'paginated' ? 'bg-bg-muted text-fg' : 'text-fg-muted hover:text-fg'"
           :aria-pressed="mode === 'paginated'"
           @click="mode = 'paginated'"
@@ -184,7 +184,7 @@ function handlePageSizeChange(event: Event) {
         <!-- Previous button -->
         <button
           type="button"
-          class="p-1.5 rounded hover:bg-bg-muted text-fg-muted hover:text-fg disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-fg focus-visible:ring-offset-1"
+          class="cursor-pointer p-1.5 rounded hover:bg-bg-muted text-fg-muted hover:text-fg disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-fg focus-visible:ring-offset-1"
           :disabled="!canGoPrev"
           :aria-label="$t('filters.pagination.previous')"
           @click="goPrev"
@@ -198,7 +198,7 @@ function handlePageSizeChange(event: Event) {
           <button
             v-else
             type="button"
-            class="min-w-[32px] h-8 px-2 font-mono text-sm rounded transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-fg focus-visible:ring-offset-1"
+            class="cursor-pointer min-w-[32px] h-8 px-2 font-mono text-sm rounded transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-fg focus-visible:ring-offset-1"
             :class="
               page === currentPage
                 ? 'bg-fg text-bg'
@@ -214,7 +214,7 @@ function handlePageSizeChange(event: Event) {
         <!-- Next button -->
         <button
           type="button"
-          class="p-1.5 rounded hover:bg-bg-muted text-fg-muted hover:text-fg disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-fg focus-visible:ring-offset-1"
+          class="cursor-pointer p-1.5 rounded hover:bg-bg-muted text-fg-muted hover:text-fg disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-fg focus-visible:ring-offset-1"
           :disabled="!canGoNext"
           :aria-label="$t('filters.pagination.next')"
           @click="goNext"

--- a/app/components/SearchProviderToggle.client.vue
+++ b/app/components/SearchProviderToggle.client.vue
@@ -53,7 +53,7 @@ useEventListener('keydown', event => {
           <button
             type="button"
             role="menuitem"
-            class="w-full flex items-start gap-3 px-3 py-2.5 rounded-md text-start transition-colors hover:bg-bg-muted"
+            class="cursor-pointer w-full flex items-start gap-3 px-3 py-2.5 rounded-md text-start transition-colors hover:bg-bg-muted"
             :class="[searchProviderValue !== 'algolia' ? 'bg-bg-muted' : '']"
             @click="
               () => {
@@ -85,7 +85,7 @@ useEventListener('keydown', event => {
           <button
             type="button"
             role="menuitem"
-            class="w-full flex items-start gap-3 px-3 py-2.5 rounded-md text-start transition-colors hover:bg-bg-muted mt-1"
+            class="cursor-pointer w-full flex items-start gap-3 px-3 py-2.5 rounded-md text-start transition-colors hover:bg-bg-muted mt-1"
             :class="[searchProviderValue === 'algolia' ? 'bg-bg-muted' : '']"
             @click="
               () => {

--- a/app/components/ViewModeToggle.vue
+++ b/app/components/ViewModeToggle.vue
@@ -12,7 +12,7 @@ const viewMode = defineModel<ViewMode>({ default: 'cards' })
   >
     <button
       type="button"
-      class="flex items-center px-2.5 py-2 text-sm font-medium rounded-sm border transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-fg focus-visible:ring-offset-1"
+      class="flex cursor-pointer items-center px-2.5 py-2 text-sm font-medium rounded-sm border transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-fg focus-visible:ring-offset-1"
       :class="
         viewMode === 'cards'
           ? 'bg-bg-subtle text-fg border-fg-subtle'
@@ -27,7 +27,7 @@ const viewMode = defineModel<ViewMode>({ default: 'cards' })
     </button>
     <button
       type="button"
-      class="flex items-center px-2.5 py-2 text-sm font-medium rounded-sm border transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-fg focus-visible:ring-offset-1"
+      class="flex cursor-pointer items-center px-2.5 py-2 text-sm font-medium rounded-sm border transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-fg focus-visible:ring-offset-1"
       :class="
         viewMode === 'table'
           ? 'bg-bg-subtle  text-fg border-fg-subtle'


### PR DESCRIPTION
### Linked issue

Fixes #3025

### Context

The Card view and Table view toggle buttons were interactive but kept the default cursor, which made them feel inconsistent with other interactive controls.

### Description

Adds `cursor-pointer` to the two view mode toggle buttons next to the sort select.

### Verification

- `npm exec pnpm@11.10.0 -- lint:fix`