### PR TITLE
fix(ui): prevent peer dependency layout overlap

### DIFF
--- a/app/components/Package/Dependencies.vue
+++ b/app/components/Package/Dependencies.vue
@@ -238,11 +238,7 @@ const numberFormatter = useNumberFormatter()
           class="flex items-center justify-between py-1 text-sm gap-1 min-w-0"
         >
           <div class="flex items-center gap-2 min-w-0 flex-1">
-            <LinkBase
-              :to="packageRoute(peer.name)"
-              class="block flex-1 min-w-0 break-all"
-              dir="ltr"
-            >
+            <LinkBase :to="packageRoute(peer.name)" class="block min-w-0 break-all" dir="ltr">
               {{ peer.name }}
             </LinkBase>
             <TagStatic
@@ -255,7 +251,7 @@ const numberFormatter = useNumberFormatter()
           </div>
           <LinkBase
             :to="packageRoute(peer.name, peer.version)"
-            class="block truncate shrink-0 max-w-32"
+            class="block truncate shrink-0 max-w-20"
             :title="peer.version"
             dir="ltr"
           >

--- a/app/components/Package/Dependencies.vue
+++ b/app/components/Package/Dependencies.vue
@@ -238,16 +238,24 @@ const numberFormatter = useNumberFormatter()
           class="flex items-center justify-between py-1 text-sm gap-1 min-w-0"
         >
           <div class="flex items-center gap-2 min-w-0 flex-1">
-            <LinkBase :to="packageRoute(peer.name)" class="block max-w-[70%] break-words" dir="ltr">
+            <LinkBase
+              :to="packageRoute(peer.name)"
+              class="block flex-1 min-w-0 break-all"
+              dir="ltr"
+            >
               {{ peer.name }}
             </LinkBase>
-            <TagStatic v-if="peer.optional" :title="$t('package.dependencies.optional')">
+            <TagStatic
+              v-if="peer.optional"
+              :title="$t('package.dependencies.optional')"
+              class="shrink-0"
+            >
               {{ $t('package.dependencies.optional') }}
             </TagStatic>
           </div>
           <LinkBase
             :to="packageRoute(peer.name, peer.version)"
-            class="block truncate max-w-[30%]"
+            class="block truncate shrink-0 max-w-32"
             :title="peer.version"
             dir="ltr"
           >


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2886 

### 🧭 Context

This PR addresses the layout issue where long peer dependency package names could overlap with the Optional badge and the version constraint, making the list difficult to read.

### 📚 Description

This change improves the peer dependency layout by:

- Allowing long package names to wrap instead of overlapping adjacent elements.
- Preventing the Optional badge from shrinking.
- Preventing the version constraint from shrinking while keeping it truncated when necessary.
- Preserving the existing one-row layout with minimal changes to the component structure.

### 📸  Screenshots
<img width="354" height="552" alt="Screenshot 2026-07-12 at 10 19 41" src="https://github.com/user-attachments/assets/2b0662bb-bac9-480c-9081-ef59b82f536a" />

<img width="354" height="552" alt="Screenshot 2026-07-12 at 10 29 47" src="https://github.com/user-attachments/assets/6c50743f-8451-4db7-ad1d-f57cc9e79f25" />