### PR TITLE
fix: prevent code ligatures from being applied when disabled in diff viewer

### DIFF
--- a/app/components/Diff/Line.vue
+++ b/app/components/Diff/Line.vue
@@ -91,7 +91,7 @@ const renderedSegments = computed(() =>
     <!-- Line content -->
     <td :class="contentClasses">
       <component :is="line.type === 'insert' ? 'ins' : line.type === 'delete' ? 'del' : 'span'">
-        <span
+        <code
           v-for="(seg, i) in renderedSegments"
           :key="i"
           :class="{


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
fix #2754 

### 🧭 Context

<!-- Brief background and why this change is needed -->
While the normal code viewer respects the ligature setting, the diff viewer ignores the same setting.
<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Ligatures style is applied here:
https://github.com/npmx-dev/npmx.dev/blob/636d8adbf46690a81d6818ba0baf8d678d3b06c0/app/assets/main.css#L290-L293

But the diff viewer has no `<code>` block in the code line. This change ensures to have `<code>` for each line and apply the ligatures setting.


#### Example result

In https://main.npmx.dev/diff/nitro/v/2.2.28...3.0.260610-beta?file=lib/class-file.js, this line `if( this.__.src === undefined ) this.load();` will be rendered as follows:

**Before**

```html
<td data-v-f41da3b8="" class="pe-6 text-nowrap">
  <del data-v-f41da3b8="">
    <span data-v-f41da3b8="" class="">
      <span class="line">
        <span style="color:#F97583;--shiki-light:#CD3443">    if</span><span style="color:#E1E4E8;--shiki-light:#24292E">( </span><span style="color:#79B8FF;--shiki-light:#005CC5">this</span><span style="color:#E1E4E8;--shiki-light:#24292E">.__.src </span><span style="color:#F97583;--shiki-light:#CD3443">===</span><span style="color:#79B8FF;--shiki-light:#005CC5"> undefined</span><span style="color:#E1E4E8;--shiki-light:#24292E"> ) </span><span style="color:#79B8FF;--shiki-light:#005CC5">this</span><span style="color:#E1E4E8;--shiki-light:#24292E">.</span><span style="color:#B392F0;--shiki-light:#6F42C1">load</span><span style="color:#E1E4E8;--shiki-light:#24292E">();
        </span>
      </span>
    </code>
  </del>
</td>
```

**After**

https://npmxdev-git-shuuji3-fixligature-in-diff-viewer-npmx.vercel.app/diff/nitro/v/2.2.28...3.0.260610-beta?file=lib/class-file.js

```html
<td data-v-f41da3b8="" class="pe-6 text-nowrap">
  <del data-v-f41da3b8="">
    <code data-v-f41da3b8="" class="">
      <span class="line">
        <span style="color:#F97583;--shiki-light:#CD3443">    if</span><span style="color:#E1E4E8;--shiki-light:#24292E">( </span><span style="color:#79B8FF;--shiki-light:#005CC5">this</span><span style="color:#E1E4E8;--shiki-light:#24292E">.__.src </span><span style="color:#F97583;--shiki-light:#CD3443">===</span><span style="color:#79B8FF;--shiki-light:#005CC5"> undefined</span><span style="color:#E1E4E8;--shiki-light:#24292E"> ) </span><span style="color:#79B8FF;--shiki-light:#005CC5">this</span><span style="color:#E1E4E8;--shiki-light:#24292E">.</span><span style="color:#B392F0;--shiki-light:#6F42C1">load</span><span style="color:#E1E4E8;--shiki-light:#24292E">();
        </span>
      </span>
    </code>
  </del>
</td>
```


<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
