### PR TITLE
feat: add color-bridge data anomalies to download-anomalies.data.ts

### DIFF
--- a/app/utils/download-anomalies.data.ts
+++ b/app/utils/download-anomalies.data.ts
@@ -27,6 +27,12 @@ export const DOWNLOAD_ANOMALIES: DownloadAnomaly[] = [
     start: { date: '2024-12-22', weeklyDownloads: 21_395 },
     end: { date: '2024-12-24', weeklyDownloads: 28_308 },
   },
+  // color-bridge unexplained single spike of 935 downloads
+  {
+    packageName: 'color-bridge',
+    start: { date: '2026-07-09', weeklyDownloads: 2 },
+    end: { date: '2026-07-11', weeklyDownloads: 2 },
+  },
   /**
    * NOTE:
    *  - please add new entries above this comment.

--- a/app/utils/download-anomalies.data.ts
+++ b/app/utils/download-anomalies.data.ts
@@ -30,8 +30,8 @@ export const DOWNLOAD_ANOMALIES: DownloadAnomaly[] = [
   // color-bridge unexplained single spike of 935 downloads
   {
     packageName: 'color-bridge',
-    start: { date: '2026-07-09', weeklyDownloads: 2 },
-    end: { date: '2026-07-11', weeklyDownloads: 2 },
+    start: { date: '2026-07-09', weeklyDownloads: 10 },
+    end: { date: '2026-07-11', weeklyDownloads: 10 },
   },
   /**
    * NOTE:


### PR DESCRIPTION
### 🔗 Linked issue

NA

### 🧭 Context

This corrects a unusual punctual spike of downloads for the `color-bridge` package (which I own).
This package normally has very few downloads, and suddenly spiked by 2 orders of magnitude on a single day, skewing the whole downloads history.

### 📚 Description

Add an entry in known anomalies to correct the spike.

| Before correction | After correction |
| - | - |
|<img width="400" alt="before" src="https://github.com/user-attachments/assets/6b091223-4ef8-4e04-a04a-1d508657896d" />|<img width="400"  alt="after" src="https://github.com/user-attachments/assets/050876e7-f74d-472e-9f39-4d336865ce6f" />|
