### PR TITLE
fix(i18n): use more explicit description in chart embed tooltip

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -762,7 +762,7 @@
         "chart": "Embed this chart",
         "copy_url": "Copy this URL to embed the chart into your website",
         "preview": "Preview",
-        "tip": "If startDate and endDate are not provided, the chart defaults to the last 12 months."
+        "tip": "If startDate and endDate are not provided in the URL, the graph will display the last 12 months by default."
       }
     },
     "downloads": {


### PR DESCRIPTION
### 🔗 Linked issue

See @userquin 's comment in #3040

### 🧭 Context

The description in the tooltip was not explicit enough.

### 📚 Description

The updated description makes it more explicit `endDate` and `startDate` are part of the embed URL
