### PR TITLE
feat: persist timeline chart metric in URL

### DIFF
--- a/app/components/Package/TimelineChart.vue
+++ b/app/components/Package/TimelineChart.vue
@@ -49,7 +49,6 @@ const props = defineProps<{
   timelineEntries: TimelineVersion[]
   selectedVersion: string | null
   loading: boolean
-  permalink?: boolean
 }>()
 
 const { settings } = useSettings()
@@ -187,7 +186,26 @@ const seriesDependencies = computed(() => {
   }
 })
 
-const activeTab = usePermalink<TimelineChartMetric>('metric', 'totalSize')
+const timelineChartMetrics = new Set<TimelineChartMetric>([
+  'totalSize',
+  'dependencyCount',
+  'dependencySize',
+])
+
+const activeTab = usePermalink<TimelineChartMetric>('metric', 'totalSize', {
+  permanent: true,
+})
+
+watch(
+  activeTab,
+  value => {
+    if (!timelineChartMetrics.has(value)) {
+      activeTab.value = 'totalSize'
+    }
+  },
+  { immediate: true },
+)
+
 const shouldPauseChartAnimations = shallowRef(true)
 
 const { start: startChartAnimationPauseTimer } = useTimeoutFn(
@@ -859,7 +877,7 @@ const timelineMetricTabs = computed(() => [
   <div
     style="width: 100%"
     class="font-mono border-b border-border"
-    :class="{ loading: shouldPauseChartAnimations }"
+    :class="{ loading: shouldPauseChartAnimations || loading }"
     id="timeline-chart"
   >
     <div class="mt-4 flex flex-row flex-wrap items-center justify-between gap-4">
@@ -967,7 +985,7 @@ const timelineMetricTabs = computed(() => [
             :markersNegative="getNegativeDatapointPlots(svg.data[0], svg.slicer.start)"
             :colors
             :gradientColors="E18E_GRADIENT_COLORS"
-            :pauseAnimations="shouldPauseChartAnimations"
+            :pauseAnimations="shouldPauseChartAnimations || loading"
           />
         </template>
 
@@ -1040,7 +1058,10 @@ const timelineMetricTabs = computed(() => [
         :dataset="datasets.dependencySize"
         :config="stackbarConfig"
         :selected-x-index="indexSelection"
-        :style="{ opacity: shouldPauseChartAnimations ? 0 : 1, transition: 'opacity 0.15s' }"
+        :style="{
+          opacity: shouldPauseChartAnimations || loading ? 0 : 1,
+          transition: 'opacity 0.15s',
+        }"
         ref="chartRef"
       >
         <!-- Injecting custom svg elements -->
@@ -1059,7 +1080,7 @@ const timelineMetricTabs = computed(() => [
             "
             :activeVersionPlot="getActiveVersionDatapointBar(svg.data, svg.barWidth)"
             :colors
-            :pauseAnimations="shouldPauseChartAnimations"
+            :pauseAnimations="shouldPauseChartAnimations || loading"
           />
         </template>
 

--- a/app/components/Package/TimelineChart.vue
+++ b/app/components/Package/TimelineChart.vue
@@ -49,6 +49,7 @@ const props = defineProps<{
   timelineEntries: TimelineVersion[]
   selectedVersion: string | null
   loading: boolean
+  permalink?: boolean
 }>()
 
 const { settings } = useSettings()
@@ -186,16 +187,15 @@ const seriesDependencies = computed(() => {
   }
 })
 
-const activeTab = shallowRef<TimelineChartMetric>('totalSize')
-
+const activeTab = usePermalink<TimelineChartMetric>('metric', 'totalSize')
 const shouldPauseChartAnimations = shallowRef(true)
 
 const { start: startChartAnimationPauseTimer } = useTimeoutFn(
   () => {
     shouldPauseChartAnimations.value = false
   },
-  1000,
-  { immediate: false },
+  300,
+  { immediate: true },
 )
 
 function pauseChartAnimations() {
@@ -859,7 +859,7 @@ const timelineMetricTabs = computed(() => [
   <div
     style="width: 100%"
     class="font-mono border-b border-border"
-    :class="{ loaded: shouldPauseChartAnimations }"
+    :class="{ loading: shouldPauseChartAnimations }"
     id="timeline-chart"
   >
     <div class="mt-4 flex flex-row flex-wrap items-center justify-between gap-4">
@@ -1040,6 +1040,7 @@ const timelineMetricTabs = computed(() => [
         :dataset="datasets.dependencySize"
         :config="stackbarConfig"
         :selected-x-index="indexSelection"
+        :style="{ opacity: shouldPauseChartAnimations ? 0 : 1, transition: 'opacity 0.15s' }"
         ref="chartRef"
       >
         <!-- Injecting custom svg elements -->
@@ -1112,7 +1113,10 @@ const timelineMetricTabs = computed(() => [
       </VueUiStackbar>
 
       <template #fallback>
-        <SkeletonBlock class="flex place-items-center justify-center aspect-[1152/254.59]">
+        <SkeletonBlock
+          class="flex place-items-center justify-center"
+          :class="[activeTab === 'dependencySize' ? 'aspect-[1152/466.4]' : 'aspect-[1152/254.59]']"
+        >
           <span class="i-lucide:chart-line w-10 h-10 text-fg-muted" aria-hidden="true" />
         </SkeletonBlock>
       </template>
@@ -1198,9 +1202,9 @@ const timelineMetricTabs = computed(() => [
   animation: indeterminate 1.5s ease-in-out infinite;
 }
 
-.loaded :deep(.vue-data-ui-component .serie_line_0 path),
-.loaded :deep(.vdui-shape-circle),
-.loaded :deep(.vue-ui-stackbar rect) {
+.loading :deep(.vue-data-ui-component .serie_line_0 path),
+.loading :deep(.vdui-shape-circle),
+.loading :deep(.vue-ui-stackbar rect) {
   transition: none !important;
   animation: none !important;
 }

--- a/app/pages/package-timeline/[[org]]/[packageName].vue
+++ b/app/pages/package-timeline/[[org]]/[packageName].vue
@@ -360,7 +360,6 @@ useSeoMeta({
             :timelineEntries
             :selectedVersion
             :loading="sizesLoading"
-            permalink
           />
         </div>
       </div>

--- a/app/pages/package-timeline/[[org]]/[packageName].vue
+++ b/app/pages/package-timeline/[[org]]/[packageName].vue
@@ -12,6 +12,7 @@ import type { TimelineSizeCacheValue } from '~/utils/charts'
 definePageMeta({
   name: 'timeline',
   path: '/package-timeline/:org?/:packageName/v/:version',
+  preserveScrollOnQuery: true,
 })
 
 const { t } = useI18n()
@@ -359,6 +360,7 @@ useSeoMeta({
             :timelineEntries
             :selectedVersion
             :loading="sizesLoading"
+            permalink
           />
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "catalog:vite-plus",
     "vue": "3.5.39",
-    "vue-data-ui": "3.22.6",
+    "vue-data-ui": "3.22.12",
     "vue-router": "5.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "catalog:vite-plus",
     "vue": "3.5.39",
-    "vue-data-ui": "3.22.12",
+    "vue-data-ui": "3.22.13",
     "vue-router": "5.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,8 +268,8 @@ importers:
         specifier: 3.5.39
         version: 3.5.39(typescript@6.0.3)
       vue-data-ui:
-        specifier: 3.22.6
-        version: 3.22.6(vue@3.5.39)
+        specifier: 3.22.12
+        version: 3.22.12(vue@3.5.39)
       vue-router:
         specifier: 5.1.0
         version: 5.1.0(@voidzero-dev/vite-plus-core@0.2.2)(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(rolldown@1.1.4)(rollup@4.62.2)(vue@3.5.39)(webpack@5.108.4)
@@ -10660,8 +10660,8 @@ packages:
   vue-component-type-helpers@3.3.6:
     resolution: {integrity: sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==}
 
-  vue-data-ui@3.22.6:
-    resolution: {integrity: sha512-E4vdfKCAWB3zAFiheMeRFbWEK491oZGfH1yv5ZiEodSidApizOgp+82FJLFQ0DgviBD7HDRseN6WT5ANcl+oUQ==}
+  vue-data-ui@3.22.12:
+    resolution: {integrity: sha512-kt8PpMx07xIHWkmi6wOeYEOA6VHEfpn10UzJnek2EOCbr41GrFEMK6405uyRgFe5b6cvBnNwMdlfB0UI2soRgQ==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -22869,7 +22869,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.6: {}
 
-  vue-data-ui@3.22.6(vue@3.5.39):
+  vue-data-ui@3.22.12(vue@3.5.39):
     dependencies:
       vue: 3.5.39(typescript@6.0.3)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,8 +268,8 @@ importers:
         specifier: 3.5.39
         version: 3.5.39(typescript@6.0.3)
       vue-data-ui:
-        specifier: 3.22.12
-        version: 3.22.12(vue@3.5.39)
+        specifier: 3.22.13
+        version: 3.22.13(vue@3.5.39)
       vue-router:
         specifier: 5.1.0
         version: 5.1.0(@voidzero-dev/vite-plus-core@0.2.2)(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(rolldown@1.1.4)(rollup@4.62.2)(vue@3.5.39)(webpack@5.108.4)
@@ -10660,8 +10660,8 @@ packages:
   vue-component-type-helpers@3.3.6:
     resolution: {integrity: sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==}
 
-  vue-data-ui@3.22.12:
-    resolution: {integrity: sha512-kt8PpMx07xIHWkmi6wOeYEOA6VHEfpn10UzJnek2EOCbr41GrFEMK6405uyRgFe5b6cvBnNwMdlfB0UI2soRgQ==}
+  vue-data-ui@3.22.13:
+    resolution: {integrity: sha512-NQeLKNUZQWw9DGQUEQPQo2kIcKV+Uap685DTUzydK6b+N4E6CByy/VepaNIScRbyUV1wFWe5aG3pnyyg32aN7g==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -22869,7 +22869,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.6: {}
 
-  vue-data-ui@3.22.12(vue@3.5.39):
+  vue-data-ui@3.22.13(vue@3.5.39):
     dependencies:
       vue: 3.5.39(typescript@6.0.3)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,7 +42,7 @@ ignoreDepScripts: true
 ignoreWorkspaceRootCheck: true
 
 minimumReleaseAgeExclude:
-  - vue-data-ui@3.22.6
+  - vue-data-ui@3.22.6 || 3.22.12
 
 overrides:
   '@types/node': 24.13.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,7 +42,7 @@ ignoreDepScripts: true
 ignoreWorkspaceRootCheck: true
 
 minimumReleaseAgeExclude:
-  - vue-data-ui@3.22.6 || 3.22.12
+  - vue-data-ui@3.22.13
 
 overrides:
   '@types/node': 24.13.2


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #3049

### 🧭 Context

Timeline page: the selected timeline metric should be persisted in the URL.

### 📚 Description

- Set the active tab from the permalink
- Some issues related to the fact that the stackbar chart (dependency size chart) was previously never loaded as the first chart, are fixed:

  - the chart internally has an autosize feature that adapts the chart area depending on the axis labels: on load, this auto-sizing  was visible
  - the chart showed its built-in skeleton loader, which was also visible until the chart computed the data set. The ideal solution in general is to set the skeleton to the same types of params as the final chart, but not in this case, since the params are unpredictable (package version names have various lengths, number of data points can vary a lot, making CLS unavoidable during the skeleton -> final render transition).
  
Both of these issues are fixed by setting the opacity of the chart to 0 while waiting for its internals to stabilize before bumping its opacity back to 1. It's not perfect, a proper solution might be required in the chart library itself, to signal when a chart is stable, but it seems to do the job for now.

The aspect ratio of the ClientOnly's fallback is now also adapted based on the metric, since both chart components have different aspect ratios.

## Other: 
Bump vue-data-ui to latest, with css transition improvements on scale labels
- [3.22.12](https://github.com/graphieros/vue-data-ui/releases/tag/v3.22.12)
- [3.22.13](https://github.com/graphieros/vue-data-ui/releases/tag/v3.22.13)