### PR TITLE
fix: world Emoji Day logo styles & annotations

### DIFF
--- a/app/components/Noodle/EmojiDay/Logo.vue
+++ b/app/components/Noodle/EmojiDay/Logo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative flex w-full">
+  <div class="relative flex w-full" role="img" :aria-label="$t('alt_logo')">
     <ThemedLogo v-if="colorMode.value === 'dark'" :emojiSets="darkTheme" />
     <ThemedLogo v-else :emojiSets="lightTheme" />
   </div>

--- a/app/components/Noodle/EmojiDay/ThemedLogo.vue
+++ b/app/components/Noodle/EmojiDay/ThemedLogo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="sizer" class="sizer w-full sm:w-[540px] md:w-[640px] lg:w-[900px]"></div>
+  <div ref="sizer" class="sizer w-full sm:w-[540px] md:w-[640px] lg:w-[900px]" aria-hidden="true" />
 </template>
 
 <style>

--- a/app/components/Noodle/EmojiDay/emoji-thing.js
+++ b/app/components/Noodle/EmojiDay/emoji-thing.js
@@ -139,11 +139,15 @@ export function init(sizer, emojiSetImages) {
       y: ((event.clientY - rect.top) / rect.height) * VIEW_HEIGHT,
     }
   }
-  area.addEventListener('pointerenter', onPointerMove)
-  area.addEventListener('pointermove', onPointerMove)
-  area.addEventListener('pointerout', () => {
-    pointer = undefined
-  })
+  area.addEventListener('pointerenter', onPointerMove, { passive: true })
+  area.addEventListener('pointermove', onPointerMove, { passive: true })
+  area.addEventListener(
+    'pointerout',
+    () => {
+      pointer = undefined
+    },
+    { passive: true },
+  )
 
   const emojiSets = new Map(
     Object.entries(emojiSetImages).map(([name, image]) => {
@@ -170,6 +174,8 @@ export function init(sizer, emojiSetImages) {
               top: `-${size / 2}px`,
               width: `${size}px`,
               height: `${size}px`,
+              pointerEvents: 'none',
+              userSelect: 'none',
             })
 
             const ctx = sprite.getContext('2d')

--- a/app/components/Noodle/EmojiDay/emoji-thing.js
+++ b/app/components/Noodle/EmojiDay/emoji-thing.js
@@ -117,6 +117,7 @@ export function init(sizer, emojiSetImages) {
     'width': `${VIEW_WIDTH}px`,
     'height': `${VIEW_HEIGHT}px`,
     'transform-origin': '0 0',
+    'touch-action': 'pinch-zoom',
   })
   sizer.appendChild(area)
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

Interacting with the World Emoji Day logo is a difficult on mobile platforms, due to pointer movement getting interpreted as panning, and the emoji particles getting selected.

The logo is also missing accessibility roles and labeling.

### 📚 Description

This pull request sets `touch-action: pinch-zoom` for the emoji particle container element, which allows pointer movement that would otherwise get interpreted as panning to interact with the logo instead.

The emoji particles also get `user-select: none` and `pointer-events: none` styles.

The pointer event handlers are marked as passive, as they'll never call `event.preventDefault()`.

Additionally, this pull request adds `role="img"` and an `aria-label` to the logo's root element, and `aria-hidden="true"` to its immediate children.