### PR TITLE
feat(ui): add quick copy for package version

### DIFF
--- a/app/components/Package/Header.vue
+++ b/app/components/Package/Header.vue
@@ -61,6 +61,7 @@ const { y: scrollY } = useScroll(window)
 const showScrollToTop = computed(() => scrollY.value > SCROLL_TO_TOP_THRESHOLD)
 
 const packageName = computed(() => props.pkg?.name ?? '')
+const resolvedVersionText = computed(() => props.resolvedVersion ?? '')
 const fundingUrl = computed(() => {
   let funding = props.displayVersion?.funding
   if (Array.isArray(funding)) funding = funding[0]
@@ -72,6 +73,11 @@ const fundingUrl = computed(() => {
 
 const { copied: copiedPkgName, copy: copyPkgName } = useClipboard({
   source: packageName,
+  copiedDuring: 2000,
+})
+
+const { copied: copiedVersion, copy: copyVersion } = useClipboard({
+  source: resolvedVersionText,
   copiedDuring: 2000,
 })
 
@@ -99,6 +105,20 @@ useCommandPaletteContextCommands(
         },
       },
     ]
+
+    if (resolvedVersionText.value) {
+      commands.push({
+        id: 'package-copy-version',
+        group: 'package',
+        label: $t('package.copy_version'),
+        keywords: [resolvedVersionText.value],
+        iconClass: 'i-lucide:copy',
+        action: () => {
+          copyVersion()
+          announce($t('command_palette.announcements.copied_to_clipboard'))
+        },
+      })
+    }
 
     if (fundingUrl.value) {
       commands.push({
@@ -312,6 +332,16 @@ useShortcuts({
             :dist-tags="pkg['dist-tags']"
             :url-pattern="versionUrlPattern"
             position-class="max-md:inset-is-0 md:inset-ie-0"
+          />
+          <!-- Quick copy version -->
+          <ButtonBase
+            v-if="resolvedVersion"
+            size="sm"
+            variant="secondary"
+            :aria-label="copiedVersion ? $t('common.copied') : $t('package.copy_version')"
+            :classicon="copiedVersion ? 'i-lucide:check' : 'i-lucide:copy'"
+            :class="copiedVersion ? 'text-accent' : ''"
+            @click="copyVersion()"
           />
         </div>
       </div>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -411,6 +411,7 @@
     "verified_provenance": "Verified provenance",
     "navigation": "Package",
     "copy_name": "Copy package name",
+    "copy_version": "Copy version",
     "deprecation": {
       "package": "This package has been deprecated.",
       "version": "This version has been deprecated.",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -1237,6 +1237,9 @@
         "copy_name": {
           "type": "string"
         },
+        "copy_version": {
+          "type": "string"
+        },
         "deprecation": {
           "type": "object",
           "properties": {


### PR DESCRIPTION
Closes #2646

### What
Adds a quick way to copy the current package version, mirroring the existing `Copy package name` affordance.

### Changes
- **Visible copy button** next to the version selector in the package sub-header (icon-only `ButtonBase`, shows a check + accent color on success).
- **Command palette command** `package-copy-version` (grouped under `package`), mirroring `package-copy-name`, so it is keyboard-accessible and announces `Copied to clipboard`.
- New i18n key `package.copy_version` (`Copy version`) added to `en.json` (source of truth) and `i18n/schema.json`.

### Notes
- Uses the existing `useClipboard` pattern with `resolvedVersion` as the source.
- Only renders when a resolved version is available.
- Other locale files intentionally untouched; they fall back to English and are tracked via Lunaria, per the i18n contributing guide.