### PR TITLE
chore: upgrade to pnpm 11.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
   "engines": {
     "node": "24"
   },
-  "packageManager": "pnpm@11.10.0",
+  "packageManager": "pnpm@11.15.0+sha512.266f8957a30d2be6e9468e5e66bcdedd35a794175f71b067ba8504d686cce1d0c0f429b33c323c3c569ad4891e667574a49ff71d1b89a22cc66f13c65818c578",
   "storybook": {
     "url": "https://storybook.npmx.dev"
   }


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Renovate stopped working for us (runs out of memory) a couple weeks ago. There is a hypothesis that pnpm 11.11 introduced memory usage fixes that could resolve this.

### 📚 Description

Upgrade to latest pnpm (11.15.0).