### PR TITLE
fix(i18n): add missing translation key for noodles 404

### DIFF
--- a/app/pages/noodles/[slug].vue
+++ b/app/pages/noodles/[slug].vue
@@ -168,7 +168,7 @@ if (import.meta.server && !noodle.value) {
 
           <template v-else>
             <p class="font-mono text-xs tracking-widest uppercase text-fg-subtle mb-3">
-              404 — empty bowl
+              404 — {{ $t('noodles.missing.empty_bowl') }}
             </p>
             <h1 class="font-mono text-3xl sm:text-4xl font-medium tracking-tight mb-4">
               {{ $t('noodles.missing.title') }}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -261,7 +261,8 @@
     "back_to_archive": "Back to all noodles",
     "missing": {
       "title": "This noodle never made it out of the bowl.",
-      "body": "We don't have a “{slug}” noodle on the menu. Either it's still being plated, or it was never written. Either way — back to the archive."
+      "body": "We don't have a “{slug}” noodle on the menu. Either it's still being plated, or it was never written. Either way — back to the archive.",
+      "empty_bowl": "empty bowl"
     }
   },
   "settings": {

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -789,6 +789,9 @@
             },
             "body": {
               "type": "string"
+            },
+            "empty_bowl": {
+              "type": "string"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
### 🔗 Linked issue

#3064 

### 🧭 Context

When a Noodle is missing, a non-translated (English) string is shown for all languages (tested on locales: ES, RU), i.e.

```html
<p class="font-mono text-xs tracking-widest uppercase text-fg-subtle mb-3">
  404 — empty bowl
</p>
```

### 📚 Description

This PR:
- makes the string for a missing noodle translatable in the source code (`app/pages/noodles/[slug].vue`)
- adds the key to the `i18n/locales/en.json`
- updates the `i18n/schema.json`

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->

<br>

There *might* be more strings, I'll keep checking.