### PR TITLE
fix: repo stars button should take you to repo homepage for now

### DIFF
--- a/app/components/Package/ExternalLinks.vue
+++ b/app/components/Package/ExternalLinks.vue
@@ -8,7 +8,15 @@ const props = defineProps<{
 
 const displayVersion = computed(() => props.pkg?.requestedVersion ?? null)
 const { repositoryUrl } = useRepositoryUrl(displayVersion)
-const { meta: repoMeta, repoRef, stars, starsLink, forks, forksLink } = useRepoMeta(repositoryUrl)
+const {
+  meta: repoMeta,
+  repoRef,
+  stars,
+  starsLink,
+  forks,
+  forksLink,
+  repoLink,
+} = useRepoMeta(repositoryUrl)
 const compactNumberFormatter = useCompactNumberFormatter()
 
 const homepageUrl = computed(() => {
@@ -143,8 +151,8 @@ useCommandPaletteContextCommands(
         <span v-else>{{ $t('package.links.repo') }}</span>
       </LinkBase>
     </li>
-    <li v-if="repositoryUrl && repoMeta && starsLink">
-      <LinkBase :to="starsLink" classicon="i-lucide:star">
+    <li v-if="repositoryUrl && repoMeta && repoLink">
+      <LinkBase :to="repoLink" classicon="i-lucide:star">
         {{ compactNumberFormatter.format(stars) }}
       </LinkBase>
     </li>

--- a/app/components/Package/ExternalLinks.vue
+++ b/app/components/Package/ExternalLinks.vue
@@ -8,15 +8,7 @@ const props = defineProps<{
 
 const displayVersion = computed(() => props.pkg?.requestedVersion ?? null)
 const { repositoryUrl } = useRepositoryUrl(displayVersion)
-const {
-  meta: repoMeta,
-  repoRef,
-  stars,
-  starsLink,
-  forks,
-  forksLink,
-  repoLink,
-} = useRepoMeta(repositoryUrl)
+const { meta: repoMeta, repoRef, stars, forks, forksLink, repoLink } = useRepoMeta(repositoryUrl)
 const compactNumberFormatter = useCompactNumberFormatter()
 
 const homepageUrl = computed(() => {
@@ -63,14 +55,14 @@ useCommandPaletteContextCommands(
       })
     }
 
-    if (repositoryUrl.value && starsLink.value) {
+    if (repositoryUrl.value && repoLink.value) {
       commands.push({
         id: 'package-link-stars',
         group: 'links',
         label: $t('command_palette.package_links.stars'),
         keywords: [...packageKeywords, $t('command_palette.package_links.stars')],
         iconClass: 'i-lucide:star',
-        href: starsLink.value,
+        href: repoLink.value,
       })
     }
 

--- a/app/composables/useRepoMeta.ts
+++ b/app/composables/useRepoMeta.ts
@@ -36,7 +36,6 @@ export function useRepoMeta(repositoryUrl: MaybeRefOrGetter<string | null | unde
     forks: computed(() => meta.value?.forks ?? 0),
     watchers: computed(() => meta.value?.watchers ?? 0),
 
-    starsLink: computed(() => meta.value?.links.stars ?? null),
     forksLink: computed(() => meta.value?.links.forks ?? null),
     watchersLink: computed(() => meta.value?.links.watchers ?? null),
     repoLink: computed(() => meta.value?.links.repo ?? null),

--- a/test/nuxt/components/OgImagePackage.spec.ts
+++ b/test/nuxt/components/OgImagePackage.spec.ts
@@ -84,7 +84,6 @@ describe('OgImagePackage', () => {
     mockUseRepoMeta.mockReturnValue({
       meta: computed(() => null),
       repoRef: computed(() => ({ owner: 'test', repo: 'repo' })),
-      starsLink: computed(() => ''),
       forks: computed(() => 0),
       forksLink: computed(() => ''),
       stars: computed(() => stars),


### PR DESCRIPTION
### 🔗 Linked issue

Closes #3069

### 🧭 Context

The link to GitHub stars on the package pages pointed to a URL that returned a 404 error.

The reason was that GitHub recently introduced changes affecting some public UI endpoints.

<!-- High-level summary of what changed -->

### 📚 Description

Now, the user is redirected straight to the repository's main page.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
