### PR TITLE
refactor: make gif day noodle last 3 days

### DIFF
--- a/app/components/Noodle/index.ts
+++ b/app/components/Noodle/index.ts
@@ -77,7 +77,7 @@ export const ACTIVE_NOODLES: Noodle[] = [
     key: 'gif-day',
     logo: NoodleGifDayLogo,
     date: '2026-09-05',
-    dateTo: '2026-09-05',
+    dateTo: '2026-09-08',
     timezone: 'auto',
   },
 ]


### PR DESCRIPTION
### 📚 Description
As suggested by @trueberryless, I've bumped the GIF day noodles to 3 days.
3 days of GIFs is better than 1 day of GIFs.

![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExcm14Z3lqbGZ2aGN4czBsbXdhbW9ld2wzY3d3anl2ZXVzMmFqejRwYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xVbng0IWlktOi8M7oW/giphy.gif)