### PR TITLE
feat(ui): added support for Effect.ts playground links

### DIFF
--- a/app/components/Package/Playgrounds.vue
+++ b/app/components/Package/Playgrounds.vue
@@ -9,6 +9,7 @@ const props = defineProps<{
 const providerIcons: Record<string, string> = {
   'stackblitz': 'i-simple-icons:stackblitz',
   'codesandbox': 'i-simple-icons:codesandbox',
+  'effect-ts-playground': 'i-simple-icons:effect',
   'codepen': 'i-simple-icons:codepen',
   'replit': 'i-simple-icons:replit',
   'gitpod': 'i-simple-icons:gitpod',
@@ -28,6 +29,7 @@ const providerIcons: Record<string, string> = {
 const providerColors: Record<string, string> = {
   'stackblitz': 'text-provider-stackblitz',
   'codesandbox': 'text-provider-codesandbox',
+  'effect-ts-playground': 'text-provider-effect',
   'codepen': 'text-provider-codepen',
   'replit': 'text-provider-replit',
   'gitpod': 'text-provider-gitpod',

--- a/server/utils/readme.ts
+++ b/server/utils/readme.ts
@@ -100,6 +100,13 @@ const PLAYGROUND_PROVIDERS: PlaygroundProvider[] = [
     icon: 'typescript',
   },
   {
+    id: 'effect-ts-playground',
+    name: 'Effect.ts Playground',
+    domains: ['effect.website'],
+    paths: ['/play'],
+    icon: 'effect',
+  },
+  {
     id: 'solid-playground',
     name: 'Solid Playground',
     domains: ['playground.solidjs.com'],

--- a/test/unit/server/utils/readme.spec.ts
+++ b/test/unit/server/utils/readme.spec.ts
@@ -91,6 +91,18 @@ describe('Playground Link Extraction', () => {
       expect(result.playgroundLinks[0]!.provider).toBe('codepen')
     })
 
+    it('extracts Effect.ts playground links', async () => {
+      const markdown1 = `[Try it!](https://effect.website/play#3efe9f827b7d)`
+      const result1 = await renderReadmeHtml(markdown1, 'test-pkg')
+
+      expect(result1.playgroundLinks[0]!.provider).toBe('effect-ts-playground')
+
+      const markdown2 = `[Try it!](https://effect.website/play?code=Y29uc29sZS5sb2coKQ==)`
+      const result2 = await renderReadmeHtml(markdown2, 'test-pkg')
+
+      expect(result2.playgroundLinks[0]!.provider).toBe('effect-ts-playground')
+    })
+
     it('extracts Replit links', async () => {
       const markdown = `[Repl](https://replit.com/@user/project)`
       const result = await renderReadmeHtml(markdown, 'test-pkg')

--- a/uno.theme.ts
+++ b/uno.theme.ts
@@ -57,7 +57,7 @@ export const theme = {
     provider: {
       stackblitz: '#1389FD',
       codesandbox: '#FFCC00',
-      effect: '#000000',
+      effect: 'light-dark(#000000, #FFFFFF)',
       codepen: '#47CF73',
       replit: '#F26207',
       gitpod: '#FFAE33',

--- a/uno.theme.ts
+++ b/uno.theme.ts
@@ -57,6 +57,7 @@ export const theme = {
     provider: {
       stackblitz: '#1389FD',
       codesandbox: '#FFCC00',
+      effect: '#000000',
       codepen: '#47CF73',
       replit: '#F26207',
       gitpod: '#FFAE33',


### PR DESCRIPTION
### 🔗 Linked issue

Resolves: #3081

### 🧭 Context

[Effect.ts](https://effect.website) is an ecosystem of libraries that's gaining popularity (26 million downloads/week already for the main [`effect`](https://npmx.dev/package/effect) package). It has a playground page where people can share specific environments prepared for their libraries.

### 📚 Description

This PR makes packages with Effect.ts playground links in Readmes have them rendered in the right sidebar to encourage experimentation.