### PR TITLE
fix: use valid rule names in oxlint disable comments

### DIFF
--- a/app/components/Brand/Customize.vue
+++ b/app/components/Brand/Customize.vue
@@ -82,9 +82,9 @@ async function downloadCustomPng() {
 
     const img = new Image()
     const loaded = new Promise<void>((resolve, reject) => {
-      // oxlint-disable-next-line eslint-plugin-unicorn(prefer-add-event-listener)
+      // oxlint-disable-next-line unicorn/prefer-add-event-listener
       img.onload = () => resolve()
-      // oxlint-disable-next-line eslint-plugin-unicorn(prefer-add-event-listener)
+      // oxlint-disable-next-line unicorn/prefer-add-event-listener
       img.onerror = () => reject(new Error('Failed to load custom SVG'))
     })
     img.src = url

--- a/app/utils/svg.ts
+++ b/app/utils/svg.ts
@@ -21,9 +21,9 @@ export async function svgToPng(
   img.crossOrigin = 'anonymous'
 
   const loaded = new Promise<void>((resolve, reject) => {
-    // oxlint-disable-next-line eslint-plugin-unicorn(prefer-add-event-listener)
+    // oxlint-disable-next-line unicorn/prefer-add-event-listener
     img.onload = () => resolve()
-    // oxlint-disable-next-line eslint-plugin-unicorn(prefer-add-event-listener)
+    // oxlint-disable-next-line unicorn/prefer-add-event-listener
     img.onerror = () => reject(new Error(`Failed to load SVG: ${svgUrl}`))
   })
 


### PR DESCRIPTION
### 🔗 Linked issue
/ 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description
The disable comments used oxlint's diagnostic display format `eslint-plugin-unicorn(prefer-add-event-listener)`, which is not a valid rule name in `oxlint-disable-next-line` comments, so the warnings were not suppressed.                                                           
                                                                               
Use the plain rule name `unicorn/prefer-add-event-listener` instead. 
https://oxc.rs/docs/guide/usage/linter/ignore-comments.html
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
