### PR TITLE
fix: use `arg_<index>` for anonymous doc parameters

### DIFF
--- a/server/utils/docs/format.ts
+++ b/server/utils/docs/format.ts
@@ -19,7 +19,7 @@ export function getNodeSignature(node: DenoDocNode): string | null {
     case 'function': {
       const typeParams = node.functionDef?.typeParams?.map(t => t.name).join(', ')
       const typeParamsStr = typeParams ? `<${typeParams}>` : ''
-      const params = node.functionDef?.params?.map(p => formatParam(p)).join(', ') || ''
+      const params = formatParams(node.functionDef?.params)
       const ret = formatType(node.functionDef?.returnType) || 'void'
       const asyncStr = node.functionDef?.isAsync ? 'async ' : ''
       return `${asyncStr}function ${name}${typeParamsStr}(${params}): ${ret}`
@@ -60,10 +60,18 @@ export function getNodeSignature(node: DenoDocNode): string | null {
 /**
  * Format a function parameter.
  */
-export function formatParam(param: FunctionParam): string {
+export function formatParam(param: FunctionParam, index = 0): string {
+  const name = param.name || `arg_${index}`
   const optional = param.optional ? '?' : ''
   const type = formatType(param.tsType)
-  return type ? `${param.name}${optional}: ${type}` : `${param.name}${optional}`
+  return type ? `${name}${optional}: ${type}` : `${name}${optional}`
+}
+
+/**
+ * Format a function parameter list.
+ */
+export function formatParams(params?: FunctionParam[]): string {
+  return params?.map((param, index) => formatParam(param, index)).join(', ') || ''
 }
 
 /**
@@ -116,7 +124,7 @@ const TYPE_FORMATTERS: Partial<Record<TsType['kind'], (type: TsType) => string>>
 function formatFnOrConstructorType(fn: NonNullable<TsType['fnOrConstructor']>): string {
   const typeParams = fn.typeParams?.map(t => t.name).join(', ')
   const typeParamsStr = typeParams ? `<${typeParams}>` : ''
-  const params = fn.params.map(p => formatParam(p)).join(', ')
+  const params = formatParams(fn.params)
   const ret = formatType(fn.tsType) || 'void'
   return `${typeParamsStr}(${params}) => ${ret}`
 }
@@ -129,7 +137,7 @@ function formatTypeLiteralType(lit: NonNullable<TsType['typeLiteral']>): string 
     parts.push(`${ro}${prop.name}${opt}: ${formatType(prop.tsType) || 'unknown'}`)
   }
   for (const method of lit.methods) {
-    const params = method.params?.map(p => formatParam(p)).join(', ') || ''
+    const params = formatParams(method.params)
     const ret = formatType(method.returnType) || 'void'
     parts.push(`${method.name}(${params}): ${ret}`)
   }

--- a/server/utils/docs/render.ts
+++ b/server/utils/docs/render.ts
@@ -8,7 +8,7 @@
 
 import type { DenoDocNode, JsDocTag } from '#shared/types/deno-doc'
 import { highlightCodeBlock } from '../shiki'
-import { formatParam, formatType, getNodeSignature } from './format'
+import { formatParams, formatType, getNodeSignature } from './format'
 import { groupMergedByKind } from './processing'
 import { escapeHtml, createSymbolId, parseJsDocLinks, renderMarkdown } from './text'
 import type { MergedSymbol, SymbolLookup } from './types'
@@ -306,7 +306,7 @@ function renderClassMembers(def: NonNullable<DenoDocNode['classDef']>): string {
     lines.push(`<div class="docs-members">`)
     lines.push(`<h4>Constructor</h4>`)
     for (const ctor of constructors) {
-      const params = ctor.params?.map(p => formatParam(p)).join(', ') || ''
+      const params = formatParams(ctor.params)
       lines.push(`<pre><code>constructor(${escapeHtml(params)})</code></pre>`)
     }
     lines.push(`</div>`)
@@ -350,7 +350,7 @@ function renderClassMembers(def: NonNullable<DenoDocNode['classDef']>): string {
 
   if (regularMethods.length > 0) {
     const methodItems: DefinitionListItem[] = regularMethods.map(method => {
-      const params = method.functionDef?.params?.map(p => formatParam(p)).join(', ') || ''
+      const params = formatParams(method.functionDef?.params)
       const ret = formatType(method.functionDef?.returnType) || 'void'
       const staticStr = method.isStatic ? 'static ' : ''
 
@@ -397,7 +397,7 @@ function renderInterfaceMembers(def: NonNullable<DenoDocNode['interfaceDef']>): 
     lines.push(`<h4>Methods</h4>`)
     lines.push(`<dl>`)
     for (const method of methods) {
-      const params = method.params?.map(p => formatParam(p)).join(', ') || ''
+      const params = formatParams(method.params)
       const ret = formatType(method.returnType) || 'void'
       lines.push(
         `<dt><code>${escapeHtml(method.name)}(${escapeHtml(params)}): ${escapeHtml(ret)}</code></dt>`,

--- a/shared/types/deno-doc.ts
+++ b/shared/types/deno-doc.ts
@@ -61,7 +61,7 @@ export interface TsType {
 /** Function parameter from deno doc */
 export interface FunctionParam {
   kind: string
-  name: string
+  name?: string
   optional?: boolean
   tsType?: TsType
 }

--- a/test/fixtures/esm-sh/doc-nodes/tanstack-highlight@0.0.9-create-highlighter.json
+++ b/test/fixtures/esm-sh/doc-nodes/tanstack-highlight@0.0.9-create-highlighter.json
@@ -1,0 +1,73 @@
+{
+  "name": "createHighlighter",
+  "isDefault": false,
+  "kind": "function",
+  "functionDef": {
+    "params": [
+      {
+        "kind": "object",
+        "props": [
+          {
+            "kind": "assign",
+            "key": "fallbackLanguage"
+          },
+          {
+            "kind": "assign",
+            "key": "languages"
+          }
+        ],
+        "optional": false,
+        "tsType": {
+          "repr": "",
+          "kind": "typeLiteral",
+          "typeLiteral": {
+            "properties": [
+              {
+                "name": "fallbackLanguage",
+                "optional": true,
+                "tsType": {
+                  "repr": "string",
+                  "kind": "keyword",
+                  "keyword": "string"
+                }
+              },
+              {
+                "name": "languages",
+                "optional": false,
+                "tsType": {
+                  "repr": "ReadonlyArray",
+                  "kind": "typeRef",
+                  "typeRef": {
+                    "typeParams": [
+                      {
+                        "repr": "LanguageDefinition",
+                        "kind": "typeRef",
+                        "typeRef": {
+                          "typeName": "LanguageDefinition"
+                        }
+                      }
+                    ],
+                    "typeName": "ReadonlyArray"
+                  }
+                }
+              }
+            ],
+            "methods": [],
+            "callSignatures": [],
+            "indexSignatures": []
+          }
+        }
+      }
+    ],
+    "returnType": {
+      "repr": "Highlighter",
+      "kind": "typeRef",
+      "typeRef": {
+        "typeName": "Highlighter"
+      }
+    },
+    "isAsync": false,
+    "isGenerator": false,
+    "typeParams": []
+  }
+}

--- a/test/unit/server/utils/docs/format.spec.ts
+++ b/test/unit/server/utils/docs/format.spec.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { formatType, getNodeSignature } from '#server/utils/docs/format'
+import { formatParams, formatType, getNodeSignature } from '#server/utils/docs/format'
 import type { DenoDocNode } from '#shared/types/deno-doc'
 
 function loadFixture(name: string): DenoDocNode {
@@ -82,5 +82,31 @@ describe('issue #1411 - linkdave@0.0.2 unknown types', () => {
     const pickSig = getNodeSignature(pickType as DenoDocNode)
     expect(pickSig).toContain('type RawVoiceServerUpdate =')
     expect(pickSig).not.toContain('= unknown')
+  })
+})
+
+describe('anonymous function parameters', () => {
+  it('uses a positional fallback for a destructured parameter', () => {
+    const node = loadFixture('tanstack-highlight@0.0.9-create-highlighter.json')
+
+    expect(getNodeSignature(node)).toBe(
+      'function createHighlighter(arg_0: { fallbackLanguage?: string; languages: ReadonlyArray<LanguageDefinition> }): Highlighter',
+    )
+  })
+
+  it('uses the zero-based parameter index in fallback names', () => {
+    expect(
+      formatParams([
+        {
+          kind: 'identifier',
+          name: 'value',
+          tsType: { repr: 'string', kind: 'keyword', keyword: 'string' },
+        },
+        {
+          kind: 'object',
+          tsType: { repr: 'object', kind: 'keyword', keyword: 'object' },
+        },
+      ]),
+    ).toBe('value: string, arg_1: object')
   })
 })


### PR DESCRIPTION
`@deno/doc` omits `name` for parameters destructured directly in parameter lists, causing package docs to render `undefined` as the parameter name. This adds positional fallback names and regression coverage.

The fallback uses `arg_<index>` because [TypeScript uses the same form for unlabeled tuple elements](https://github.com/microsoft/TypeScript/blob/v5.9.3/src/compiler/checker.ts#L38299), while the zero-based index keeps multiple anonymous parameters distinct.

---

*This pull request was created with assistance from a code agent.*