### PR TITLE
fix(ui): prevent facet label wrapping to fix info icon alignment

### DIFF
--- a/app/components/Compare/FacetRow.vue
+++ b/app/components/Compare/FacetRow.vue
@@ -91,7 +91,9 @@ function isCellLoading(index: number): boolean {
     <div
       class="comparison-label relative bg-bg flex items-center gap-1.5 px-4 py-3 border-b border-border"
     >
-      <span class="text-xs text-fg-muted uppercase tracking-wider">{{ label }}</span>
+      <span class="text-xs text-fg-muted uppercase tracking-wide whitespace-nowrap">{{
+        label
+      }}</span>
       <TooltipApp v-if="description" :text="description" position="top">
         <span class="i-lucide:info w-3 h-3 text-fg-subtle cursor-help" aria-hidden="true" />
       </TooltipApp>


### PR DESCRIPTION
### 🧭 Linked issue
resolves #3063

### 🧭 Context
On the compare packages page, the info icon next to each facet label (e.g. "GITHUB STARS", "GITHUB FORKS", "GITHUB ISSUES") only sat close to the text when the label fit on one line. Longer labels wrapped to two lines inside the fixed-width label column, and since the row used `items-center`, the icon centered itself between the two lines instead of next to the text — creating an inconsistent, jarring gap compared to single-line labels like "DEPRECATED?".

### 📚 Description
The wrapping was caused by `tracking-wider` (extra letter-spacing on the uppercase label) pushing labels like "GITHUB STARS" past the 140px label column width. Rather than trying to re-align the icon around variable wrapped text, I removed the wrapping at the source:

- Changed `tracking-wider` → `tracking-wide` to claw back a few px of width per label
- Added `whitespace-nowrap` so labels always render on a single line

Checked the longest label ("GITHUB ISSUES") against the label column width to confirm it doesn't overflow with the reduced tracking.

<!-- attach before/after screenshots here for desktop + mobile -->
BEFORE:
<img width="894" height="1095" alt="image" src="https://github.com/user-attachments/assets/d7e7d819-3b27-4a60-9821-112e88ef3166" />
AFTER:
<img width="505" height="527" alt="image" src="https://github.com/user-attachments/assets/27a1851a-bc2c-439c-bea2-ef97e4072c2c" />
