### PR TITLE
fix: clear modal input and error state on close

### DIFF
--- a/app/components/Header/AuthModal.client.vue
+++ b/app/components/Header/AuthModal.client.vue
@@ -42,6 +42,12 @@ async function handleLogin() {
   }
 }
 
+/** Reset the login form so a stale handle/error isn't shown when reopening. */
+function handleModalClose() {
+  handleInput.value = ''
+  errorMessage.value = ''
+}
+
 watch(handleInput, newHandleInput => {
   errorMessage.value = ''
   if (!newHandleInput) return
@@ -64,7 +70,12 @@ watch(user, async newUser => {
 
 <template>
   <!-- Modal -->
-  <Modal :modalTitle="$t('auth.modal.title')" class="max-w-lg" id="auth-modal">
+  <Modal
+    :modalTitle="$t('auth.modal.title')"
+    class="max-w-lg"
+    id="auth-modal"
+    @close="handleModalClose"
+  >
     <div v-if="user?.handle" class="space-y-4">
       <div class="flex items-center gap-3 p-4 bg-bg-subtle border border-border rounded-lg">
         <span class="w-3 h-3 rounded-full bg-green-500" aria-hidden="true" />

--- a/app/components/Header/ConnectorModal.vue
+++ b/app/components/Header/ConnectorModal.vue
@@ -1,6 +1,14 @@
 <script setup lang="ts">
-const { isConnected, isConnecting, npmUser, error, hasOperations, connect, disconnect } =
-  useConnector()
+const {
+  isConnected,
+  isConnecting,
+  npmUser,
+  error,
+  hasOperations,
+  connect,
+  disconnect,
+  clearError,
+} = useConnector()
 
 const { settings } = useSettings()
 
@@ -10,12 +18,23 @@ const { copied, copy } = useClipboard({ copiedDuring: 2000 })
 
 const hasAttemptedConnect = shallowRef(false)
 
+function resetForm() {
+  tokenInput.value = ''
+  hasAttemptedConnect.value = false
+  clearError()
+}
+
 watch(isConnected, connected => {
   if (!connected) {
-    tokenInput.value = ''
-    hasAttemptedConnect.value = false
+    resetForm()
   }
 })
+
+/** Reset the connection form so a stale token/error isn't shown when reopening. */
+function handleModalClose() {
+  if (isConnected.value) return
+  resetForm()
+}
 
 async function handleConnect() {
   hasAttemptedConnect.value = true
@@ -51,6 +70,7 @@ const executeNpmxConnectorCommand = computed(() => {
     :modalTitle="$t('connector.modal.title')"
     :class="isConnected && hasOperations ? 'max-w-2xl' : 'max-w-md'"
     id="connector-modal"
+    @close="handleModalClose"
   >
     <!-- Connected state -->
     <div v-if="isConnected" class="space-y-4">

--- a/app/composables/useConnector.ts
+++ b/app/composables/useConnector.ts
@@ -173,6 +173,10 @@ export const useConnector = createSharedComposable(function useConnector() {
     }
   }
 
+  function clearError() {
+    state.value.error = null
+  }
+
   async function refreshState(): Promise<void> {
     if (!config.value) return
 
@@ -433,6 +437,7 @@ export const useConnector = createSharedComposable(function useConnector() {
     connect,
     reconnect,
     disconnect,
+    clearError,
     refreshState,
     connectorFetch,
 

--- a/test/nuxt/components/HeaderConnectorModal.spec.ts
+++ b/test/nuxt/components/HeaderConnectorModal.spec.ts
@@ -73,6 +73,9 @@ function createMockUseConnector() {
     connect: vi.fn().mockResolvedValue(true),
     reconnect: vi.fn().mockResolvedValue(true),
     disconnect: vi.fn(),
+    clearError: vi.fn(() => {
+      mockState.value.error = null
+    }),
     refreshState: vi.fn().mockResolvedValue(undefined),
     addOperation: vi.fn().mockResolvedValue(null),
     addOperations: vi.fn().mockResolvedValue([]),


### PR DESCRIPTION
Both the Local Connector and Atmosphere modals kept their form state after being dismissed. If a connection attempt failed, closing the modal and reopening it showed the previously entered token/handle still populated, along with the stale error message from the last attempt. Now, both modals now reset their form state when the dialog closes.


Before: 
when we write on input fieldn closes it and opens it again, we can still see the input and error message. 

<img width="1551" height="980" alt="before" src="https://github.com/user-attachments/assets/cbb5ebc4-bf35-4163-b4d5-bf7f7eefbd68" />


After: 
Now we cannot see. 

<img width="1551" height="980" alt="after" src="https://github.com/user-attachments/assets/5624ceff-7cdf-4d48-9116-533ec695dca8" />
