### PR TITLE
chore: add 'code.haverbeke.berlin' to forgejo hosts list

### DIFF
--- a/shared/utils/git-providers.ts
+++ b/shared/utils/git-providers.ts
@@ -43,7 +43,7 @@ export const GITLAB_HOSTS = [
  * is effectively user-controlled input that can point at a malicious user-controlled server, this
  * would put us at risk of Server-Side Request Forgery (SSRF). Thus we only support allowlisted hosts.
  */
-export const FORGEJO_HOSTS = ['next.forgejo.org', 'try.next.forgejo.org']
+export const FORGEJO_HOSTS = ['next.forgejo.org', 'try.next.forgejo.org', 'code.haverbeke.berlin']
 
 /**
  * No open-ended Gitea host detection for the same reason as Forgejo above.


### PR DESCRIPTION
### 🧭 Context

Adding  'code.haverbeke.berlin' to `FORGEJO_HOSTS`

### 📚 Description

The maintainer of [Prosemirror](https://main.npmx.dev/package/prosemirror-model), [Codemirror](https://main.npmx.dev/package/codemirror) & [Lezer](https://main.npmx.dev/package/@lezer/common) has moved/is moving these packages to code.haverbeke.berlin as the new git host