### PR TITLE
fix: pluralization of dependencies change alert message

### DIFF
--- a/app/components/Package/SizeDecrease.vue
+++ b/app/components/Package/SizeDecrease.vue
@@ -41,9 +41,14 @@ const depDecreaseAbs = computed(() => Math.abs(props.diff.depDiff))
         >
       </i18n-t>
       <template v-if="diff.sizeThresholdExceeded && diff.depThresholdExceeded"> · </template>
-      <i18n-t v-if="diff.depThresholdExceeded" keypath="package.size_decrease.deps" scope="global">
+      <i18n-t
+        v-if="diff.depThresholdExceeded"
+        keypath="package.size_decrease.deps"
+        scope="global"
+        :plural="depDecreaseAbs"
+      >
         <template #count
-          ><strong>−{{ numberFormatter.format(depDecreaseAbs) }}</strong></template
+          ><strong>{{ numberFormatter.format(depDecreaseAbs) }}</strong></template
         >
       </i18n-t>
     </p>

--- a/app/components/Package/SizeIncrease.vue
+++ b/app/components/Package/SizeIncrease.vue
@@ -36,9 +36,14 @@ const sizePercent = computed(() => percentFormatter.value.format(Math.abs(props.
         >
       </i18n-t>
       <template v-if="diff.sizeThresholdExceeded && diff.depThresholdExceeded"> · </template>
-      <i18n-t v-if="diff.depThresholdExceeded" keypath="package.size_increase.deps" scope="global">
+      <i18n-t
+        v-if="diff.depThresholdExceeded"
+        keypath="package.size_increase.deps"
+        scope="global"
+        :plural="diff.depDiff"
+      >
         <template #count
-          ><strong>+{{ numberFormatter.format(diff.depDiff) }}</strong></template
+          ><strong>{{ numberFormatter.format(diff.depDiff) }}</strong></template
         >
       </i18n-t>
     </p>


### PR DESCRIPTION
### 🔗 Linked issue

Closes #3092

### 🧭 Context

There is an alert on package page when number of dependencies significantly changes. It shows `+` and `-` in front of number in message like "**-** 5 fewer dependency". Additionally the pluralization is broken too. This issue exists for both Increase and Decrease alert messages.
Example: https://npmx.dev/package/vite/v/8.2.0-beta.0

### 📚 Description

This PR fixes wrong pluralization inside `SizeDecrease.vue` and `SizeIncrease.vue` components:
- Adds `:plural` prop to `<i18n-t>`
- Removes unnecessary `-` and `+` in front of number

Alert before:
<img width="1128" height="97" alt="image" src="https://github.com/user-attachments/assets/78c7ce5c-d29f-43c9-bad6-17424b21ecaa" />
And after:
<img width="1128" height="97" alt="image" src="https://github.com/user-attachments/assets/41f83ee3-321a-4bad-aba3-01ae1f68b635" />
