### PR TITLE
fix: outdated dependencies icon not shown

### DIFF
--- a/app/composables/npm/useOutdatedDependencies.ts
+++ b/app/composables/npm/useOutdatedDependencies.ts
@@ -26,7 +26,7 @@ function resolveOutdated(
 
   let filteredVersions = versions
   if (!constraintIncludesPrerelease(constraint)) {
-    filteredVersions = versions.filter(v => !getPrerelease(v))
+    filteredVersions = versions.filter(v => !getPrerelease(v)?.length)
   }
 
   const resolved = findMaxSatisfying(filteredVersions, constraint)

--- a/server/utils/npm.ts
+++ b/server/utils/npm.ts
@@ -62,7 +62,7 @@ export async function resolveVersionConstraint(
 
     // Filter out prerelease versions unless constraint explicitly includes one
     if (!constraintIncludesPrerelease(constraint)) {
-      versions = versions.filter(v => !getPrerelease(v))
+      versions = versions.filter(v => !getPrerelease(v)?.length)
     }
 
     return findMaxSatisfying(versions, constraint)


### PR DESCRIPTION
### 🔗 Linked issue

Closes #3098

### 🧭 Context

This is related to breaking changes in `verkit@0.2.0`

Missed it when doing #3093

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

Fixes outdated dependencies icon not being shown

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
