### PR TITLE
fix: detect implicit types in package timeline

### DIFF
--- a/server/api/registry/timeline/[...pkg].get.ts
+++ b/server/api/registry/timeline/[...pkg].get.ts
@@ -1,5 +1,6 @@
+import { enrichTimelineVersionTypes } from '#server/utils/package-timeline'
 import { normalizeLicense } from '#shared/utils/npm'
-import { analyzePackage, hasBuiltInTypes } from '~~/shared/utils/package-analysis'
+import { hasBuiltInTypes } from '~~/shared/utils/package-analysis'
 
 const DEFAULT_LIMIT = 25
 
@@ -84,40 +85,7 @@ export default defineCachedEventHandler(
         .sort((a, b) => Date.parse(b.time) - Date.parse(a.time))
       const visibleVersions = allVersions.slice(offset, offset + limit)
 
-      // File-aware detection is limited to potential removal events: metadata-untyped
-      // versions with an older typed release. Checking every untyped version would
-      // require additional registry and file-tree requests.
-      const possibleTypeRemovals = visibleVersions
-        .filter(version => {
-          if (version.hasTypes) return false
-
-          const versionIndex = allVersions.indexOf(version)
-          return allVersions
-            .slice(versionIndex + 1)
-            .some(previousVersion => previousVersion.hasTypes)
-        })
-        .map(async version => {
-          try {
-            const { pkg, typesPackage, files } = await fetchPackageWithTypesAndFiles(
-              packageName,
-              version.version,
-            )
-
-            const analysis = analyzePackage(pkg, {
-              typesPackage,
-              files,
-            })
-
-            if (analysis.types.kind === 'included') {
-              version.hasTypes = true
-            }
-          } catch {
-            // Preserve the metadata-only result when the file list is unavailable.
-          }
-        })
-
-      await Promise.all(possibleTypeRemovals)
-
+      await enrichTimelineVersionTypes(packageName, allVersions, visibleVersions)
       return {
         versions: visibleVersions,
         total: allVersions.length,

--- a/server/api/registry/timeline/[...pkg].get.ts
+++ b/server/api/registry/timeline/[...pkg].get.ts
@@ -85,10 +85,10 @@ export default defineCachedEventHandler(
       const visibleVersions = allVersions.slice(offset, offset + limit)
 
       const possibleTypeRemovals = visibleVersions.filter(version => {
-        const versionIndex = allVersions.indexOf(version)
-        const previousVersion = allVersions[versionIndex + 1]
+        if (version.hasTypes) return false
 
-        return !version.hasTypes && previousVersion?.hasTypes
+        const versionIndex = allVersions.indexOf(version)
+        return allVersions.slice(versionIndex + 1).some(previousVersion => previousVersion.hasTypes)
       })
 
       await Promise.all(

--- a/server/api/registry/timeline/[...pkg].get.ts
+++ b/server/api/registry/timeline/[...pkg].get.ts
@@ -82,17 +82,15 @@ export default defineCachedEventHandler(
           }
         })
         .sort((a, b) => Date.parse(b.time) - Date.parse(a.time))
+
       const visibleVersions = allVersions.slice(offset, offset + limit)
 
-      const possibleTypeRemovals = visibleVersions.filter(version => {
-        if (version.hasTypes) return false
-
-        const versionIndex = allVersions.indexOf(version)
-        return allVersions.slice(versionIndex + 1).some(previousVersion => previousVersion.hasTypes)
-      })
-
-      await Promise.all(
-        possibleTypeRemovals.map(async version => {
+      const possibleTypeRemovals = visibleVersions
+        .filter((version, index) => {
+          if (version.hasTypes) return false
+          return allVersions.slice(index + 1).some(previousVersion => previousVersion.hasTypes)
+        })
+        .map(async version => {
           try {
             const { pkg, typesPackage, files } = await fetchPackageWithTypesAndFiles(
               packageName,
@@ -110,8 +108,9 @@ export default defineCachedEventHandler(
           } catch {
             // Preserve the metadata-only result when the file list is unavailable.
           }
-        }),
-      )
+        })
+
+      await Promise.all(possibleTypeRemovals)
 
       return {
         versions: visibleVersions,

--- a/server/api/registry/timeline/[...pkg].get.ts
+++ b/server/api/registry/timeline/[...pkg].get.ts
@@ -1,5 +1,5 @@
 import { normalizeLicense } from '#shared/utils/npm'
-import { hasBuiltInTypes } from '~~/shared/utils/package-analysis'
+import { analyzePackage, hasBuiltInTypes } from '~~/shared/utils/package-analysis'
 
 const DEFAULT_LIMIT = 25
 
@@ -82,9 +82,39 @@ export default defineCachedEventHandler(
           }
         })
         .sort((a, b) => Date.parse(b.time) - Date.parse(a.time))
+      const visibleVersions = allVersions.slice(offset, offset + limit)
+
+      const possibleTypeRemovals = visibleVersions.filter(version => {
+        const versionIndex = allVersions.indexOf(version)
+        const previousVersion = allVersions[versionIndex + 1]
+
+        return !version.hasTypes && previousVersion?.hasTypes
+      })
+
+      await Promise.all(
+        possibleTypeRemovals.map(async version => {
+          try {
+            const { pkg, typesPackage, files } = await fetchPackageWithTypesAndFiles(
+              packageName,
+              version.version,
+            )
+
+            const analysis = analyzePackage(pkg, {
+              typesPackage,
+              files,
+            })
+
+            if (analysis.types.kind === 'included') {
+              version.hasTypes = true
+            }
+          } catch {
+            // Preserve the metadata-only result when the file list is unavailable.
+          }
+        }),
+      )
 
       return {
-        versions: allVersions.slice(offset, offset + limit),
+        versions: visibleVersions,
         total: allVersions.length,
       } satisfies TimelineResponse
     } catch (error: unknown) {

--- a/server/api/registry/timeline/[...pkg].get.ts
+++ b/server/api/registry/timeline/[...pkg].get.ts
@@ -82,13 +82,19 @@ export default defineCachedEventHandler(
           }
         })
         .sort((a, b) => Date.parse(b.time) - Date.parse(a.time))
-
       const visibleVersions = allVersions.slice(offset, offset + limit)
 
+      // File-aware detection is limited to potential removal events: metadata-untyped
+      // versions with an older typed release. Checking every untyped version would
+      // require additional registry and file-tree requests.
       const possibleTypeRemovals = visibleVersions
-        .filter((version, index) => {
+        .filter(version => {
           if (version.hasTypes) return false
-          return allVersions.slice(index + 1).some(previousVersion => previousVersion.hasTypes)
+
+          const versionIndex = allVersions.indexOf(version)
+          return allVersions
+            .slice(versionIndex + 1)
+            .some(previousVersion => previousVersion.hasTypes)
         })
         .map(async version => {
           try {

--- a/server/utils/package-timeline.ts
+++ b/server/utils/package-timeline.ts
@@ -1,0 +1,44 @@
+import { analyzePackage } from '#shared/utils/package-analysis'
+
+interface TimelineVersionWithTypes {
+  version: string
+  hasTypes?: boolean
+}
+
+export async function enrichTimelineVersionTypes(
+  packageName: string,
+  allVersions: TimelineVersionWithTypes[],
+  visibleVersions: TimelineVersionWithTypes[],
+): Promise<void> {
+  // File-aware detection is limited to potential removal events: metadata-untyped
+  // versions with an older typed release. Checking every untyped version would
+  // require additional registry and file-tree requests.
+  const possibleTypeRemovals = visibleVersions
+    .filter(version => {
+      if (version.hasTypes) return false
+
+      const versionIndex = allVersions.indexOf(version)
+      return allVersions.slice(versionIndex + 1).some(previousVersion => previousVersion.hasTypes)
+    })
+    .map(async version => {
+      try {
+        const { pkg, typesPackage, files } = await fetchPackageWithTypesAndFiles(
+          packageName,
+          version.version,
+        )
+
+        const analysis = analyzePackage(pkg, {
+          typesPackage,
+          files,
+        })
+
+        if (analysis.types.kind === 'included') {
+          version.hasTypes = true
+        }
+      } catch {
+        // Preserve the metadata-only result when the file list is unavailable.
+      }
+    })
+
+  await Promise.all(possibleTypeRemovals)
+}

--- a/test/unit/server/api/registry/timeline/pkg.get.spec.ts
+++ b/test/unit/server/api/registry/timeline/pkg.get.spec.ts
@@ -229,7 +229,8 @@ describe('timeline API', () => {
     const result = await handler(fakeEvent)
     expect(result.versions[0]!.hasTypes).toBe(true)
   })
-  it('sets hasTypes when declaration files exist beside an entry point', async () => {
+
+  it('sets hasTypes for consecutive versions with declaration files', async () => {
     routerParam = 'my-pkg'
 
     fetchNpmPackageMock.mockResolvedValue(
@@ -241,6 +242,47 @@ describe('timeline API', () => {
           '2.0.0': {
             main: './dist/index.mjs',
           },
+          '3.0.0': {
+            main: './dist/index.mjs',
+          },
+        },
+        time: {
+          '1.0.0': '2024-01-01T00:00:00Z',
+          '2.0.0': '2025-01-01T00:00:00Z',
+          '3.0.0': '2026-01-01T00:00:00Z',
+        },
+      }),
+    )
+
+    fetchPackageWithTypesAndFilesMock.mockImplementation(
+      async (packageName: string, version: string) => ({
+        pkg: {
+          name: packageName,
+          version,
+          main: './dist/index.mjs',
+        },
+        files: new Set(['dist/index.mjs', 'dist/index.d.mts']),
+      }),
+    )
+
+    const result = await handler(fakeEvent)
+
+    expect(fetchPackageWithTypesAndFilesMock).toHaveBeenCalledWith('my-pkg', '2.0.0')
+    expect(fetchPackageWithTypesAndFilesMock).toHaveBeenCalledWith('my-pkg', '3.0.0')
+    expect(result.versions).toHaveLength(3)
+    expect(result.versions[0]?.hasTypes).toBe(true)
+    expect(result.versions[1]?.hasTypes).toBe(true)
+    expect(result.versions[2]?.hasTypes).toBe(true)
+  })
+
+  it('keeps hasTypes unset when declarations are removed', async () => {
+    routerParam = 'my-pkg'
+
+    fetchNpmPackageMock.mockResolvedValue(
+      makePackument({
+        versions: {
+          '1.0.0': { types: './dist/index.d.ts' },
+          '2.0.0': { main: './dist/index.mjs' },
         },
         time: {
           '1.0.0': '2024-01-01T00:00:00Z',
@@ -255,14 +297,14 @@ describe('timeline API', () => {
         version: '2.0.0',
         main: './dist/index.mjs',
       },
-      files: new Set(['dist/index.mjs', 'dist/index.d.mts']),
+      files: new Set(['dist/index.mjs']),
     })
 
     const result = await handler(fakeEvent)
 
-    expect(fetchPackageWithTypesAndFilesMock).toHaveBeenCalledWith('my-pkg', '2.0.0')
-    expect(result.versions[0]!.hasTypes).toBe(true)
-    expect(result.versions[1]!.hasTypes).toBe(true)
+    expect(result.versions).toHaveLength(2)
+    expect(result.versions[0]?.hasTypes).toBeUndefined()
+    expect(result.versions[1]?.hasTypes).toBe(true)
   })
 
   it('sets hasTrustedPublisher when trustedPublisher is true', async () => {

--- a/test/unit/server/api/registry/timeline/pkg.get.spec.ts
+++ b/test/unit/server/api/registry/timeline/pkg.get.spec.ts
@@ -3,7 +3,9 @@ import { createError, type H3Event } from 'h3'
 import type { Packument, PackumentVersion } from '#shared/types/npm-registry'
 
 const fetchNpmPackageMock = vi.fn()
+const fetchPackageWithTypesAndFilesMock = vi.fn()
 vi.stubGlobal('fetchNpmPackage', fetchNpmPackageMock)
+vi.stubGlobal('fetchPackageWithTypesAndFiles', fetchPackageWithTypesAndFilesMock)
 vi.stubGlobal('defineCachedEventHandler', (fn: Function) => fn)
 vi.stubGlobal('CACHE_MAX_AGE_FIVE_MINUTES', 300)
 
@@ -226,6 +228,41 @@ describe('timeline API', () => {
 
     const result = await handler(fakeEvent)
     expect(result.versions[0]!.hasTypes).toBe(true)
+  })
+  it('sets hasTypes when declaration files exist beside an entry point', async () => {
+    routerParam = 'my-pkg'
+
+    fetchNpmPackageMock.mockResolvedValue(
+      makePackument({
+        versions: {
+          '1.0.0': {
+            types: './dist/index.d.ts',
+          },
+          '2.0.0': {
+            main: './dist/index.mjs',
+          },
+        },
+        time: {
+          '1.0.0': '2024-01-01T00:00:00Z',
+          '2.0.0': '2025-01-01T00:00:00Z',
+        },
+      }),
+    )
+
+    fetchPackageWithTypesAndFilesMock.mockResolvedValue({
+      pkg: {
+        name: 'my-pkg',
+        version: '2.0.0',
+        main: './dist/index.mjs',
+      },
+      files: new Set(['dist/index.mjs', 'dist/index.d.mts']),
+    })
+
+    const result = await handler(fakeEvent)
+
+    expect(fetchPackageWithTypesAndFilesMock).toHaveBeenCalledWith('my-pkg', '2.0.0')
+    expect(result.versions[0]!.hasTypes).toBe(true)
+    expect(result.versions[1]!.hasTypes).toBe(true)
   })
 
   it('sets hasTrustedPublisher when trustedPublisher is true', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Fixes #2791 

### 🧭 Context

<!-- Brief background and why this change is needed -->
The timeline incorrectly showed removed TypeScript types when declarations still existed as `.d.mts` files beside `.mjs` entry points.
<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
I updated the timeline to check the published package files when types appear to be removed. I also added a regression test for declarations stored beside the package entry points.
<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------

Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
