### PR TITLE
fix: prioritize exact matches in Algolia search

### DIFF
--- a/app/composables/npm/useAlgoliaSearch.ts
+++ b/app/composables/npm/useAlgoliaSearch.ts
@@ -369,10 +369,12 @@ export function useAlgoliaSearch() {
     let packageExists: boolean | null = null
     if (packageQueryIndex >= 0) {
       const pkgResponse = results[packageQueryIndex] as SearchResponse<AlgoliaHit> | undefined
-      const exactHit = pkgResponse?.hits[0]
-      packageExists = exactHit ? exactHit.name === checks?.checkPackage : false
+      const [exactHit] = pkgResponse?.hits ?? []
+      const isExactHit = exactHit?.name === checks?.checkPackage
 
-      if (exactHit) {
+      packageExists = isExactHit
+
+      if (exactHit && isExactHit) {
         searchResult.objects = [
           hitToSearchResult(exactHit),
           ...searchResult.objects.filter(result => result.package.name !== exactHit.name),

--- a/app/composables/npm/useAlgoliaSearch.ts
+++ b/app/composables/npm/useAlgoliaSearch.ts
@@ -333,7 +333,7 @@ export function useAlgoliaSearch() {
         filters: `objectID:${checks.checkPackage}`,
         length: 1,
         analyticsTags: ['npmx.dev'],
-        attributesToRetrieve: EXISTENCE_CHECK_ATTRS,
+        attributesToRetrieve: ATTRIBUTES_TO_RETRIEVE,
         attributesToHighlight: [],
       })
     }
@@ -369,7 +369,15 @@ export function useAlgoliaSearch() {
     let packageExists: boolean | null = null
     if (packageQueryIndex >= 0) {
       const pkgResponse = results[packageQueryIndex] as SearchResponse<AlgoliaHit> | undefined
-      packageExists = (pkgResponse?.nbHits ?? 0) > 0
+      const exactHit = pkgResponse?.hits[0]
+      packageExists = exactHit ? exactHit.name === checks?.checkPackage : false
+
+      if (exactHit) {
+        searchResult.objects = [
+          hitToSearchResult(exactHit),
+          ...searchResult.objects.filter(result => result.package.name !== exactHit.name),
+        ]
+      }
     }
 
     return { search: searchResult, orgExists, userExists, packageExists }

--- a/test/nuxt/composables/use-algolia-search.spec.ts
+++ b/test/nuxt/composables/use-algolia-search.spec.ts
@@ -24,4 +24,33 @@ describe('useAlgoliaSearch', () => {
     const filtered = objects.filter(o => !o.package.isSecurityHeld).map(o => o.package.name)
     expect(filtered).toEqual(['npmx-connector'])
   })
+
+  it('places an exact package match before the regular search results', async () => {
+    const otherHit = fixture.find(hit => hit.name === 'vuln-npm')
+    const exactHit = fixture.find(hit => hit.name === 'npmx-connector')
+
+    if (!otherHit || !exactHit) {
+      throw new Error('Expected Algolia fixtures are missing')
+    }
+
+    mockSearch.mockResolvedValue({
+      results: [
+        { hits: [otherHit], nbHits: 2 },
+        { hits: [exactHit], nbHits: 1 },
+      ],
+    })
+
+    const { searchWithSuggestions } = useAlgoliaSearch()
+    const result = await searchWithSuggestions(
+      'npmx-connector',
+      {},
+      { checkPackage: 'npmx-connector' },
+    )
+
+    expect(result.packageExists).toBe(true)
+    expect(result.search.objects.map(item => item.package.name)).toEqual([
+      'npmx-connector',
+      'vuln-npm',
+    ])
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Fixes #2978

### 🧭 Context

<!-- Brief background and why this change is needed -->
The search page showed “Relevance” as the selected sort option, but an exact package-name match did not always appear first in the initial Algolia results.

<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
I fixed the search UI so that an exact package-name match is placed at the top of the Algolia results when sorting by relevance. The result is also filtered from its previous position to avoid duplicates.

I added a regression test to cover this behavior.

### Before
https://github.com/user-attachments/assets/7b90dc30-62b3-419a-9442-36a198edd8e3

### After

https://github.com/user-attachments/assets/e73ea88e-e74c-40c6-a1a6-462760619c4b




<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
