### PR TITLE
fix: preserve search results during preference hydration

### DIFF
--- a/app/composables/npm/useSearch.ts
+++ b/app/composables/npm/useSearch.ts
@@ -228,6 +228,10 @@ export function useSearch(
       return
     }
 
+    if (asyncData.status.value === 'pending') {
+      await asyncData.refresh()
+    }
+
     if (cache.value && (cache.value.query !== q || cache.value.provider !== provider)) {
       cache.value = null
       await asyncData.refresh()

--- a/app/composables/npm/useSearch.ts
+++ b/app/composables/npm/useSearch.ts
@@ -229,7 +229,7 @@ export function useSearch(
     }
 
     if (asyncData.status.value === 'pending') {
-      await asyncData.refresh()
+      await asyncData.refresh({ dedupe: 'defer' })
     }
 
     if (cache.value && (cache.value.query !== q || cache.value.provider !== provider)) {

--- a/test/nuxt/composables/use-search.spec.ts
+++ b/test/nuxt/composables/use-search.spec.ts
@@ -1,0 +1,89 @@
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import type { NpmSearchResponse } from '#shared/types'
+import { useSearch } from '~/composables/npm/useSearch'
+
+const { mockAlgoliaSearch, mockAlgoliaMultiSearch, mockUseAlgoliaSearch, mockUseNpmSearch } =
+  vi.hoisted(() => ({
+    mockAlgoliaSearch: vi.fn(),
+    mockAlgoliaMultiSearch: vi.fn(),
+    mockUseAlgoliaSearch: vi.fn(),
+    mockUseNpmSearch: vi.fn(),
+  }))
+
+mockNuxtImport('useAlgoliaSearch', () => mockUseAlgoliaSearch)
+mockNuxtImport('useNpmSearch', () => mockUseNpmSearch)
+
+describe('useSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockUseAlgoliaSearch.mockReturnValue({
+      search: mockAlgoliaSearch,
+      searchWithSuggestions: mockAlgoliaMultiSearch,
+    })
+
+    mockUseNpmSearch.mockReturnValue({
+      search: vi.fn(),
+      checkOrgExists: vi.fn(),
+      checkUserExists: vi.fn(),
+    })
+  })
+
+  it('waits for a pending initial search before loading more results', async () => {
+    const response: NpmSearchResponse = {
+      isStale: false,
+      objects: [
+        {
+          package: {
+            name: 'nuxt',
+            version: '4.0.0',
+            date: '2026-01-01T00:00:00.000Z',
+            links: {},
+          },
+        },
+      ],
+      total: 1,
+      time: '2026-01-01T00:00:00.000Z',
+    }
+
+    const searchResult = {
+      search: response,
+      orgExists: false,
+      userExists: false,
+      packageExists: true,
+    }
+
+    let resolveInitialSearch!: (value: typeof searchResult) => void
+
+    mockAlgoliaMultiSearch
+      .mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveInitialSearch = resolve
+          }),
+      )
+      .mockResolvedValue(searchResult)
+
+    mockAlgoliaSearch.mockResolvedValue(response)
+
+    const size = ref(25)
+    const result = useSearch(ref('nuxt'), ref('algolia'), () => ({ size: size.value }), {
+      suggestions: true,
+    })
+
+    await vi.waitFor(() => {
+      expect(mockAlgoliaMultiSearch).toHaveBeenCalled()
+    })
+
+    size.value = 50
+    await nextTick()
+
+    resolveInitialSearch(searchResult)
+
+    await vi.waitFor(() => {
+      expect(result.data.value?.objects.map(item => item.package.name)).toEqual(['nuxt'])
+    })
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Fixes #2617

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->
When the page size was set to 50 or more, the first search could show no package results. Reloading the same search page made the results appear.

This happened because the saved page-size preference was loaded while the initial search was still running.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
I changed fetchMore to wait for the initial search to finish before using its results. This prevents an empty response from being cached while the saved preference is loading.

I also added a regression test that reproduces this timing issue and checks that the package results are preserved.
<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
