### PR TITLE
fix: show fallback for oversized package files

### DIFF
--- a/app/pages/package-code/[[org]]/[packageName]/v/[version]/[...filePath].vue
+++ b/app/pages/package-code/[[org]]/[packageName]/v/[version]/[...filePath].vue
@@ -184,6 +184,8 @@ const isLoading = computed<boolean>(() => {
     return treeStatus.value !== 'success' && treeStatus.value !== 'error'
   }
 
+  if (isFileTooLarge.value) return false
+
   return !fileStatus.value || fileStatus.value === 'pending' || fileStatus.value === 'idle'
 })
 

--- a/test/nuxt/pages/PackageCodePage.spec.ts
+++ b/test/nuxt/pages/PackageCodePage.spec.ts
@@ -1,0 +1,74 @@
+import type { Component } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mountSuspended, mockNuxtImport, registerEndpoint } from '@nuxt/test-utils/runtime'
+
+const fetchFileContent = vi.fn()
+
+const pages = import.meta.glob('/app/pages/package-code/**/*.vue', {
+  eager: true,
+  import: 'default',
+})
+
+const PackageCodePage = pages[
+  '/app/pages/package-code/[[org]]/[packageName]/v/[version]/[...filePath].vue'
+] as Component
+
+mockNuxtImport('usePackage', () => {
+  return () => ({
+    data: ref({
+      'name': '@types/vscode',
+      'dist-tags': { latest: '1.118.0' },
+      'versions': { '1.118.0': { version: '1.118.0' } },
+      'requestedVersion': { version: '1.118.0' },
+    }),
+  })
+})
+
+mockNuxtImport('useCommandPalettePackageVersions', () => {
+  return () => ({
+    versions: ref(['1.118.0']),
+    ensureLoaded: vi.fn(),
+  })
+})
+
+describe('package code page', () => {
+  beforeEach(() => {
+    clearNuxtData()
+    fetchFileContent.mockClear()
+  })
+
+  it('shows the raw-file fallback instead of loading forever for large files', async () => {
+    registerEndpoint('/api/registry/files/@types/vscode/v/1.118.0', () => ({
+      package: '@types/vscode',
+      version: '1.118.0',
+      tree: [{ name: 'index.d.ts', path: 'index.d.ts', type: 'file', size: 720 * 1024 }],
+    }))
+
+    registerEndpoint('/api/registry/file/@types/vscode/v/1.118.0/index.d.ts', () => {
+      fetchFileContent()
+      return {
+        content: '',
+        html: '',
+        lines: 0,
+        contentType: 'text/plain',
+      }
+    })
+
+    const component = await mountSuspended(PackageCodePage, {
+      route: '/package-code/@types/vscode/v/1.118.0/index.d.ts',
+      shallow: true,
+    })
+
+    await vi.waitFor(() => {
+      expect(component.text()).toContain('File too large')
+    })
+
+    expect(component.text()).not.toContain('Loading file')
+    expect(fetchFileContent).not.toHaveBeenCalled()
+
+    const rawFileLink = component.findComponent({ name: 'LinkBase' })
+    expect(rawFileLink.props('to')).toBe(
+      'https://cdn.jsdelivr.net/npm/@types/vscode@1.118.0/index.d.ts',
+    )
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Fixes #2732

### 🧭 Context

<!-- Brief background and why this change is needed -->
The package code browser remained in a loading state when the selected file exceeded the supported size limit. The page already had a fallback for oversized files, but it was never rendered because the skipped content request remained in the idle state and was still treated as loading.

<!-- High-level summary of what changed -->
The issue can be reproduced on the current production site:

https://npmx.dev/package-code/@types/vscode/v/1.118.0/index.d.ts

The updated behaviour can be verified on the PR preview:

https://npmx-h3s403v0g-npmx.vercel.app/package-code/@types/vscode/v/1.118.0/index.d.ts

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
I updated the loading-state logic so an oversized file no longer leaves the page waiting for a request that will not run. The existing large-file warning and “Open raw file” action are now displayed as intended.

I also added a regression test that covers the oversized-file path, verifies that the fallback is rendered, and confirms that the application does not request the file content.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
