### PR TITLE
chore(deps): bump vue-data-ui from 3.22.14 to 3.23.0

### DIFF
--- a/app/components/Package/TimelineChart.vue
+++ b/app/components/Package/TimelineChart.vue
@@ -480,6 +480,9 @@ const commonConfig = computed<CommonUserOptions>(() => ({
 const config = computed<VueUiXyConfig>(() => {
   return {
     theme: isDarkMode.value ? 'dark' : '',
+    transitions: {
+      pauseOnDatasetChange: true, // prevents transitions on axis labels when switching from install size to dependencies
+    },
     downsample: {
       threshold: 5000,
     },

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "catalog:vite-plus",
     "vue": "3.5.39",
-    "vue-data-ui": "3.22.14",
+    "vue-data-ui": "3.23.0",
     "vue-router": "5.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,8 +269,8 @@ importers:
         specifier: 3.5.39
         version: 3.5.39(typescript-native-bridge@6.0.3-bridge.9.tsgo.7.0.2)
       vue-data-ui:
-        specifier: 3.22.14
-        version: 3.22.14(vue@3.5.39)
+        specifier: 3.23.0
+        version: 3.23.0(vue@3.5.39)
       vue-router:
         specifier: 5.2.0
         version: 5.2.0(@voidzero-dev/vite-plus-core@0.2.7)(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.2)(vue@3.5.39)(webpack@5.108.4)
@@ -10839,8 +10839,8 @@ packages:
   vue-component-type-helpers@3.3.9:
     resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
 
-  vue-data-ui@3.22.14:
-    resolution: {integrity: sha512-90NtOSzc5sGvKn2MW6BN/eb+L4A2gAH1f8R+boa6tS0/amCgs2eHCO89SShTinaempqnnbAp00bQ5X7Bm0ZKuw==}
+  vue-data-ui@3.23.0:
+    resolution: {integrity: sha512-Drgg76fb+eOn5yLFsUX7Kvfs3Fcyfpv0QKXL8EVfprklTeyWseeqeiP2yJWWSFD79JfB/4Ap6Dwtp2/w1RiwMw==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -23451,7 +23451,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.9: {}
 
-  vue-data-ui@3.22.14(vue@3.5.39):
+  vue-data-ui@3.23.0(vue@3.5.39):
     dependencies:
       vue: 3.5.39(typescript-native-bridge@6.0.3-bridge.9.tsgo.7.0.2)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,6 +43,7 @@ ignoreWorkspaceRootCheck: true
 
 minimumReleaseAgeExclude:
   - '@iconify-json/simple-icons@1.2.93'
+  - vue-data-ui@3.23.0
 
 overrides:
   '@types/node': 24.13.3


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

- Upgrade vue-data-ui to latest minor (see [release notes](https://github.com/graphieros/vue-data-ui/releases/tag/v3.23.0), related to css transitions)
- use new config attribute in the timeline chart to prevent y-axis transitions when switching views from install size to dependencies