### PR TITLE
docs: align contributer guide

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,20 @@
   "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.patterns": {
     "*.vue": "${capture}.stories.ts"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[vue]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,6 @@ This focus helps guide our project decisions as a community and what we choose t
   - [Test fixtures (mocking external APIs)](#test-fixtures-mocking-external-apis)
 - [Storybook](#storybook)
   - [Component categories](#component-categories)
-  - [Coverage guidelines](#coverage-guidelines)
   - [Project conventions](#project-conventions)
   - [Configuration](#configuration)
   - [Global app settings](#global-app-settings)
@@ -73,7 +72,6 @@ This focus helps guide our project decisions as a community and what we choose t
   - [Before submitting](#before-submitting)
   - [Pull request process](#pull-request-process)
   - [Commit messages and PR titles](#commit-messages-and-pr-titles)
-- [Pre-commit hooks](#pre-commit-hooks)
 - [Using AI](#using-ai)
 - [Questions](#questions)
 - [License](#license)
@@ -82,8 +80,10 @@ This focus helps guide our project decisions as a community and what we choose t
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) (LTS version recommended)
-- [pnpm](https://pnpm.io/) v10.28.1 or later
+- [Node.js](https://nodejs.org/)
+- [pnpm](https://pnpm.io/)
+
+Please use the version pinned in the `engines.node` and `packageManager` field of [package.json](./package.json).
 
 ### Setup
 
@@ -100,7 +100,13 @@ This focus helps guide our project decisions as a community and what we choose t
    pnpm dev
    ```
 
-4. (optional) if you want to test the admin UI/flow, you can run the local connector:
+4. start the connector with mock data:
+
+   ```bash
+   pnpm mock-connector
+   ```
+
+   or with real data (requires npm login):
 
    ```bash
    pnpm npmx-connector
@@ -169,7 +175,7 @@ rm -rf .nuxt/cache/nitro/handlers/
 rm -rf .nuxt/cache/nitro/handlers/npmx-picks/
 ```
 
-Alternatively, you can bypass the cache entirely in development by adding `shouldBypassCache: () => import.meta.dev` to your `defineCachedEventHandler` options:
+Alternatively, you can bypass the cache for a specific API entirely in development by adding `shouldBypassCache: () => import.meta.dev` to your `defineCachedEventHandler` options:
 
 ```ts
 export default defineCachedEventHandler(
@@ -227,7 +233,7 @@ The connector will check your npm authentication, generate a connection token, a
 
 ### Mock connector (for local development)
 
-If you're working on admin features (org management, package access controls, operations queue) and don't want to use your real npm account, you can run the mock connector instead:
+If you don't want to use your real npm account, you can run the mock connector instead:
 
 ```bash
 pnpm mock-connector
@@ -257,11 +263,7 @@ pnpm mock-connector --empty        # start with no prepopulated data
 
 ## Code style
 
-When committing changes, try to keep an eye out for unintended formatting updates. These can make a pull request look noisier than it really is and slow down the review process. Sometimes IDEs automatically reformat files on save, which can unintentionally introduce extra changes.
-
-To help with this, the project uses `oxfmt` to handle formatting via a pre-commit hook. The hook will automatically reformat files when needed. If something can’t be fixed automatically, it will let you know what needs to be updated before you can commit.
-
-If you want to get ahead of any formatting issues, you can also run `pnpm lint:fix` before committing to fix formatting across the whole project.
+When committing changes, try to keep an eye out for unintended formatting updates. These can make a pull request look noisier than it really is and slow down the review process. Sometimes IDEs automatically reformat files on save, which can unintentionally introduce extra changes. To prevent this, you can configure your IDE to use `oxc` as the formatter, which is aligned with the linter used inside the workflows for this project. Alternatively, you can manually run `pnpm lint:fix` before committing to fix formatting across the whole project.
 
 ### npmx name
 
@@ -796,7 +798,7 @@ docker run --rm \
   -e NODE_OPTIONS="--max-old-space-size=4096" \
   -v $(pwd):/work \
   -w /work \
-  mcr.microsoft.com/playwright:v1.58.2-noble \
+  mcr.microsoft.com/playwright:v1.62.1-noble \
   sh -c "npm install -g pnpm && pnpm install && pnpm vp run build:test && pnpm vp run test:browser:prebuilt --update-snapshots"
 ```
 
@@ -827,6 +829,16 @@ Fixtures are stored in `test/fixtures/` with this structure:
 
 ```
 test/fixtures/
+├── algolia/
+│   └── search/           # Algolia search results
+├── esm-sh/
+│   ├── doc-nodes/        # Parsed documentation nodes (exports, types, functions)
+│   ├── headers/          # esm.sh response headers (used to resolve type declarations)
+│   └── types/            # TypeScript type declaration files
+├── github/               # GitHub API responses (contributor stats)
+├── jsdelivr/             # jsDelivr Data API responses (package file lists)
+├── jsdelivr-cdn/         # jsDelivr CDN responses (raw package file content)
+├── microlink/            # Microlink API responses (homepage link previews)
 ├── npm-registry/
 │   ├── packuments/       # Package metadata (vue.json, @nuxt/kit.json)
 │   ├── search/           # Search results (vue.json, nuxt.json)
@@ -883,7 +895,6 @@ cli/src/
 ├── mock-app.ts        # H3 mock app + MockConnectorServer class
 └── mock-server.ts     # CLI entry point (pnpm mock-connector)
 
-test/test-utils/       # Re-exports from cli/src/ for test convenience
 test/e2e/helpers/      # E2E-specific wrappers (fixtures, global setup)
 ```
 
@@ -972,13 +983,9 @@ Single-use components that encapsulate one feature.
 - **Testing focus:** Layout, responsive behavior, integration testing
 - **Coverage:** Critical user flows and breakpoints
 
-### Coverage guidelines
-
-#### Which Components Need Stories?
-
-TBD
-
 ### Project conventions
+
+Stories should follow the [Component Story Format (CSF)](https://storybook.js.org/docs/api/csf).
 
 #### Place `.stories.ts` files next to the component
 
@@ -1223,10 +1230,6 @@ This provides the following benefits:
 
 - it links the pull request to the issue (the merge icon will appear in the issue), so everybody can see there is an open PR
 - when the pull request is merged, the linked issue is automatically closed
-
-## Pre-commit hooks
-
-The project uses `lint-staged` with `simple-git-hooks` to automatically lint files on commit.
 
 ## Using AI
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,9 +264,9 @@ pnpm mock-connector --empty        # start with no prepopulated data
 
 ## Code style
 
-When committing changes, try to keep an eye out for unintended formatting updates. These can make a pull request look noisier than it really is and slow down the review process. Sometimes IDEs automatically reformat files on save, which can unintentionally introduce extra changes. To prevent this, you can configure your IDE to use `oxc` as the formatter, which is aligned with the linter used inside the workflows for this project. Alternatively, you can manually run `pnpm lint:fix` before committing to fix formatting across the whole project.
+When committing changes, try to keep an eye out for unintended formatting updates. These can make a pull request look noisier than it really is and slow down the review process. Sometimes IDEs automatically reformat files on save, which can unintentionally introduce extra changes if your formatter is not configured correctly. To prevent this, you can configure your IDE to use `oxc` as the formatter, which is aligned with the linter used inside the workflows for this project.
 
-Before you commit, staged files will automatically be linted and formatted using a [pre-commit hook](#pre-commit-hooks).
+Before you commit, staged files will automatically be linted and formatted using a [pre-commit hook](#pre-commit-hooks). Alternatively, you can manually run `pnpm lint:fix` before committing to fix formatting across the whole project.
 
 ### npmx name
 
@@ -1238,10 +1238,10 @@ This provides the following benefits:
 
 Before committing, the following things will run against staged files:
 
-- **`*.{js,ts,mjs,cjs,vue}`** — `vp lint --fix` (auto-fix lint errors)
-- **`*.vue`** — UnoCSS class checker
-- **`*.{js,ts,mjs,cjs,vue,json,yml,md,html,css}`** — `vp fmt` (auto-format)
-- **`i18n/locales/*`** — regenerate Lunaria tracking data and `i18n/schema.json`
+- **`*.{js,ts,mjs,cjs,vue}`** - `vp lint --fix` (auto-fix lint errors)
+- **`*.vue`** - UnoCSS class checker
+- **`*.{js,ts,mjs,cjs,vue,json,yml,md,html,css}`** - `vp fmt` (auto-format)
+- **`i18n/locales/*`** - regenerate Lunaria tracking data and `i18n/schema.json`
 
 If something can't be fixed automatically, the commit will be blocked. Run `pnpm lint:fix` beforehand to resolve any issues proactively.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,7 @@ This focus helps guide our project decisions as a community and what we choose t
   - [Before submitting](#before-submitting)
   - [Pull request process](#pull-request-process)
   - [Commit messages and PR titles](#commit-messages-and-pr-titles)
+- [Pre-commit hooks](#pre-commit-hooks)
 - [Using AI](#using-ai)
 - [Questions](#questions)
 - [License](#license)
@@ -264,6 +265,8 @@ pnpm mock-connector --empty        # start with no prepopulated data
 ## Code style
 
 When committing changes, try to keep an eye out for unintended formatting updates. These can make a pull request look noisier than it really is and slow down the review process. Sometimes IDEs automatically reformat files on save, which can unintentionally introduce extra changes. To prevent this, you can configure your IDE to use `oxc` as the formatter, which is aligned with the linter used inside the workflows for this project. Alternatively, you can manually run `pnpm lint:fix` before committing to fix formatting across the whole project.
+
+Before you commit, staged files will automatically be linted and formatted using a [pre-commit hook](#pre-commit-hooks).
 
 ### npmx name
 
@@ -1230,6 +1233,19 @@ This provides the following benefits:
 
 - it links the pull request to the issue (the merge icon will appear in the issue), so everybody can see there is an open PR
 - when the pull request is merged, the linked issue is automatically closed
+
+## Pre-commit hooks
+
+Before commiting, the following things will run against staged files:
+
+- **`*.{js,ts,mjs,cjs,vue}`** — `vp lint --fix` (auto-fix lint errors)
+- **`*.vue`** — UnoCSS class checker
+- **`*.{js,ts,mjs,cjs,vue,json,yml,md,html,css}`** — `vp fmt` (auto-format)
+- **`i18n/locales/*`** — regenerate Lunaria tracking data and `i18n/schema.json`
+
+If something can't be fixed automatically, the commit will be blocked. Run `pnpm lint:fix` beforehand to resolve any issues proactively.
+
+The configuration for the pre-commit hook is defined in the [`staged` block of vite.config.ts](vite.config.ts#L168-L174) and is automatically installed by running `vp config`, which will run any time you run `pnpm install`.
 
 ## Using AI
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1236,7 +1236,7 @@ This provides the following benefits:
 
 ## Pre-commit hooks
 
-Before commiting, the following things will run against staged files:
+Before committing, the following things will run against staged files:
 
 - **`*.{js,ts,mjs,cjs,vue}`** — `vp lint --fix` (auto-fix lint errors)
 - **`*.vue`** — UnoCSS class checker


### PR DESCRIPTION
### 🔗 Linked issue

resolve #2523

### 🧭 Context

- update git hooks info
- update vscode settings to reduce formatting issues
- starting a connector is no longer an optional step
- update text fixture list

### 📚 Description

This is my first contribution, and I tried to take some time to enhance some things that stood out. At the same time, I'm new to this project, so let me know if something seems off.

The issue mentions that git hooks were removed, after looking into it they are actually still here, the config just moved to vite plus. 

I removed the code coverage part of storybook, it was not defined and in my opinion this should be self-explanatory: if the component is defined in the UI library it should be in storybook (I see [there is a ticket ](https://github.com/npmx-dev/npmx.dev/issues/1841) to add the missing ones). If some components are more reusable than others, it might be better to organize the components a bit to reflect that.

I also noticed the list of dev commands and project structure was not complete, but I figured you might only want to highlight the most relevant entries. For example, I’m not sure if you want to mention storybook or i18n commands, at least not initially.

Finally, I noticed on my first run that I could not really do much without running a connector. The document mentions only needing it for admin tasks, but I had to add it to be able to search for packages and view package info. Therefore no longer optional. If I did something wrong, lmk.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
