### PR TITLE
chore(ui): add some storybook entries

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -67,10 +67,15 @@ const preview: Preview = {
       attributeName: 'data-theme',
     }),
     (story, context) => {
-      const { accentColor, locale } = context.globals as {
+      const { accentColor, locale, theme } = context.globals as {
         accentColor?: string
         locale?: string
+        theme?: string
       }
+
+      const themeClass = theme === 'Light' ? 'light' : 'dark'
+      document.documentElement.classList.remove('light', 'dark')
+      document.documentElement.classList.add(themeClass)
 
       // Set accent color from globals
       if (accentColor) {

--- a/app/components/About/GovernanceList.stories.ts
+++ b/app/components/About/GovernanceList.stories.ts
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import type { GitHubContributor } from '~~/server/api/contributors.get'
+import GovernanceList from './GovernanceList.vue'
+
+const members: GitHubContributor[] = [
+  {
+    login: 'mock-steward-a',
+    id: 1001,
+    avatar_url: 'https://api.dicebear.com/9.x/initials/svg?seed=steward-a',
+    html_url: 'https://github.com/mock-steward-a',
+    contributions: 2800,
+    role: 'steward',
+    sponsors_url: 'https://github.com/sponsors/',
+  },
+  {
+    login: 'mock-core-a',
+    id: 1003,
+    avatar_url: 'https://api.dicebear.com/9.x/initials/svg?seed=core-a',
+    html_url: 'https://github.com/mock-core-a',
+    contributions: 9000,
+    role: 'core',
+    sponsors_url: null,
+  },
+  {
+    login: 'mock-maintainer-a',
+    id: 1004,
+    avatar_url: 'https://api.dicebear.com/9.x/initials/svg?seed=maintainer-a',
+    html_url: 'https://github.com/mock-maintainer-a',
+    contributions: 210,
+    role: 'maintainer',
+    sponsors_url: null,
+  },
+]
+
+const meta = {
+  component: GovernanceList,
+  tags: ['autodocs'],
+  args: {
+    members,
+  },
+} satisfies Meta<typeof GovernanceList>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+/** A single member with a sponsor link. */
+export const SingleMember: Story = {
+  args: {
+    members: [members[0]!],
+  },
+}
+
+/** No members returned — renders an empty grid. */
+export const Empty: Story = {
+  args: {
+    members: [],
+  },
+}

--- a/app/components/About/LogoImg.stories.ts
+++ b/app/components/About/LogoImg.stories.ts
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import LogoImg from './LogoImg.vue'
+import LogoVercel from '~/assets/logos/sponsors/vercel.svg'
+import LogoVercelLight from '~/assets/logos/sponsors/vercel-light.svg'
+import LogoNuxt from '~/assets/logos/oss-partners/nuxt.svg'
+
+const meta = {
+  component: LogoImg,
+  tags: ['autodocs'],
+  decorators: [() => ({ template: '<div style="height: 36px; width: 160px;"><story /></div>' })],
+} satisfies Meta<typeof LogoImg>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** A single logo used regardless of theme. */
+export const SingleSource: Story = {
+  args: {
+    src: LogoNuxt,
+    alt: 'Nuxt',
+  },
+}
+
+/** Separate assets swapped between dark and light themes. */
+export const DarkAndLight: Story = {
+  args: {
+    src: {
+      dark: LogoVercel,
+      light: LogoVercelLight,
+    },
+    alt: 'Vercel',
+  },
+}
+
+/**
+ * A dark-only asset with `light: 'auto'` — grayscaled and inverted in light
+ * mode so a single logo works on both backgrounds.
+ */
+export const AutoInvert: Story = {
+  args: {
+    src: {
+      dark: LogoNuxt,
+      light: 'auto',
+    },
+    alt: 'Nuxt',
+  },
+}

--- a/app/components/About/LogoList.stories.ts
+++ b/app/components/About/LogoList.stories.ts
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import LogoList from './LogoList.vue'
+import { SPONSORS } from '~/assets/logos/sponsors'
+import { OSS_PARTNERS } from '~/assets/logos/oss-partners'
+
+const meta = {
+  component: LogoList,
+  tags: ['autodocs'],
+} satisfies Meta<typeof LogoList>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Sponsor logos laid out in the wide grid used on the about page. */
+export const Sponsors: Story = {
+  args: {
+    list: SPONSORS.gold,
+  },
+  render: args => ({
+    components: { LogoList },
+    setup() {
+      return { args }
+    },
+    template: `<LogoList v-bind="args" class="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-4 grid-flow-row-dense" />`,
+  }),
+}
+
+/**
+ * OSS partners use a denser grid and include a grouped entry, which renders
+ * with the bracketed container spanning multiple columns.
+ */
+export const OssPartners: Story = {
+  args: {
+    list: OSS_PARTNERS,
+  },
+  render: args => ({
+    components: { LogoList },
+    setup() {
+      return { args }
+    },
+    template: `<LogoList v-bind="args" class="grid grid-cols-[repeat(auto-fill,minmax(64px,1fr))] gap-4 grid-flow-row-dense" />`,
+  }),
+}

--- a/app/components/Alert.stories.ts
+++ b/app/components/Alert.stories.ts
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import Alert from './Alert.vue'
+
+const meta = {
+  component: Alert,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['warning', 'error'],
+    },
+  },
+  args: {
+    variant: 'warning',
+    title: 'Heads up',
+    default: 'Something you might want to know about this package.',
+  },
+} satisfies Meta<typeof Alert>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Non-critical notice, announced politely via `role="status"`. */
+export const Warning: Story = {}
+
+/** Critical notice, announced assertively via `role="alert"`. */
+export const Error: Story = {
+  args: {
+    variant: 'error',
+    title: 'Something went wrong',
+    default: 'We could not load this data. Please try again.',
+  },
+}
+
+/** The title is optional — the body slot renders on its own. */
+export const WithoutTitle: Story = {
+  args: {
+    title: undefined,
+    default: 'A short message with no heading.',
+  },
+}

--- a/app/components/BaseCard.stories.ts
+++ b/app/components/BaseCard.stories.ts
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import BaseCard from './BaseCard.vue'
+
+const meta = {
+  component: BaseCard,
+  tags: ['autodocs'],
+  render: args => ({
+    components: { BaseCard },
+    setup() {
+      return { args }
+    },
+    template: `
+      <div class="max-w-md">
+        <BaseCard v-bind="args">
+          <h3 class="font-semibold text-fg">example-package</h3>
+          <p class="text-sm text-fg-muted mt-1">A short description of what this package does.</p>
+        </BaseCard>
+      </div>
+    `,
+  }),
+} satisfies Meta<typeof BaseCard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Default card used across search results and listings. */
+export const Default: Story = {}
+
+/** Highlighted state for the result that exactly matches the query. */
+export const ExactMatch: Story = {
+  args: {
+    isExactMatch: true,
+  },
+}
+
+/** Keyboard/pointer selection state. */
+export const Selected: Story = {
+  args: {
+    selected: true,
+  },
+}

--- a/app/components/Brand/Customize.stories.ts
+++ b/app/components/Brand/Customize.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import Customize from './Customize.vue'
+
+const meta = {
+  component: Customize,
+  tags: ['autodocs'],
+  decorators: [() => ({ template: '<div class="max-w-3xl p-4"><story /></div>' })],
+} satisfies Meta<typeof Customize>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Interactive brand logo customizer: pick an accent color and background, then
+ * download the result as SVG or PNG.
+ */
+export const Default: Story = {}

--- a/app/components/Code/DirectoryListing.stories.ts
+++ b/app/components/Code/DirectoryListing.stories.ts
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import type { PackageFileTree } from '#shared/types/npm-registry'
+import DirectoryListing from './DirectoryListing.vue'
+
+const tree: PackageFileTree[] = [
+  {
+    name: 'src',
+    path: 'src',
+    type: 'directory',
+    size: 5120,
+    children: [
+      { name: 'index.ts', path: 'src/index.ts', type: 'file', size: 1024 },
+      {
+        name: 'utils',
+        path: 'src/utils',
+        type: 'directory',
+        size: 2048,
+        children: [{ name: 'format.ts', path: 'src/utils/format.ts', type: 'file', size: 512 }],
+      },
+    ],
+  },
+  {
+    name: 'dist',
+    path: 'dist',
+    type: 'directory',
+    size: 8192,
+    children: [{ name: 'index.js', path: 'dist/index.js', type: 'file', size: 4096 }],
+  },
+  { name: 'package.json', path: 'package.json', type: 'file', size: 640 },
+  { name: 'README.md', path: 'README.md', type: 'file', size: 2200 },
+]
+
+const baseRoute = {
+  params: { org: undefined, packageName: 'mock-package', version: '1.0.0' },
+}
+
+const meta = {
+  component: DirectoryListing,
+  tags: ['autodocs'],
+  args: {
+    tree,
+    currentPath: '',
+    baseUrl: 'mock-package@1.0.0',
+    baseRoute,
+  },
+} satisfies Meta<typeof DirectoryListing>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Package root. `dist` is flagged as possibly-unnecessary content. */
+export const Root: Story = {}
+
+/** A nested directory, showing the `..` parent link at the top. */
+export const Nested: Story = {
+  args: {
+    currentPath: 'src',
+  },
+}
+
+/** A path with no contents renders the empty state. */
+export const Empty: Story = {
+  args: {
+    currentPath: 'does-not-exist',
+  },
+}

--- a/app/components/Code/FileTree.stories.ts
+++ b/app/components/Code/FileTree.stories.ts
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import type { PackageFileTree } from '#shared/types/npm-registry'
+import FileTree from './FileTree.vue'
+
+const tree: PackageFileTree[] = [
+  {
+    name: 'src',
+    path: 'src',
+    type: 'directory',
+    size: 5120,
+    children: [
+      { name: 'index.ts', path: 'src/index.ts', type: 'file', size: 1024 },
+      {
+        name: 'utils',
+        path: 'src/utils',
+        type: 'directory',
+        size: 2048,
+        children: [{ name: 'format.ts', path: 'src/utils/format.ts', type: 'file', size: 512 }],
+      },
+    ],
+  },
+  {
+    name: 'dist',
+    path: 'dist',
+    type: 'directory',
+    size: 8192,
+    children: [{ name: 'index.js', path: 'dist/index.js', type: 'file', size: 4096 }],
+  },
+  { name: 'package.json', path: 'package.json', type: 'file', size: 640 },
+  { name: 'README.md', path: 'README.md', type: 'file', size: 2200 },
+]
+
+const baseRoute = {
+  params: { org: undefined, packageName: 'mock-package', version: '1.0.0' },
+}
+
+const meta = {
+  component: FileTree,
+  tags: ['autodocs'],
+  args: {
+    tree,
+    currentPath: '',
+    baseUrl: 'mock-package@1.0.0',
+    baseRoute,
+  },
+  decorators: [
+    () => ({ template: '<div class="w-72 border border-border bg-bg-subtle"><story /></div>' }),
+  ],
+} satisfies Meta<typeof FileTree>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Collapsed tree with nothing selected. */
+export const Default: Story = {}
+
+/**
+ * With a file selected, its ancestor directories auto-expand and the active
+ * file is highlighted.
+ */
+export const WithSelectedFile: Story = {
+  args: {
+    baseUrl: 'mock-package-selected@1.0.0',
+    currentPath: 'src/utils/format.ts',
+  },
+}

--- a/app/components/Code/Header.stories.ts
+++ b/app/components/Code/Header.stories.ts
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import type { PackageFileContentResponse } from '#shared/types/npm-registry'
+import Header from './Header.vue'
+
+const getCodeUrlWithPath = (path?: string) => (path ? `/${path}` : '/')
+
+const fileContent: PackageFileContentResponse = {
+  package: 'mock-package',
+  version: '1.0.0',
+  path: 'src/utils/format.ts',
+  language: 'typescript',
+  contentType: 'text/plain',
+  content: 'export const format = (value: number) => value.toLocaleString()\n',
+  html: '',
+  lines: 1,
+}
+
+const readmeContent: PackageFileContentResponse = {
+  ...fileContent,
+  path: 'README.md',
+  language: 'markdown',
+  content: '# mock-package\n\nA mock package.\n',
+  markdownHtml: {
+    html: '<h1>mock-package</h1><p>A mock package.</p>',
+    playgroundLinks: [],
+    toc: [],
+  },
+}
+
+const meta = {
+  component: Header,
+  tags: ['autodocs'],
+  args: {
+    loading: false,
+    isViewingFile: true,
+    isBinaryFile: false,
+    fileContent,
+    filePath: 'src/utils/format.ts',
+    markdownViewMode: 'preview',
+    selectedLines: null,
+    getCodeUrlWithPath,
+    packageName: 'mock-package',
+    version: '1.0.0',
+  },
+} satisfies Meta<typeof Header>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Viewing a source file: breadcrumbs plus copy and raw-file actions. */
+export const FileView: Story = {}
+
+/** Browsing a directory rather than a file — only the layout controls show. */
+export const DirectoryView: Story = {
+  args: {
+    isViewingFile: false,
+    filePath: null,
+    fileContent: null,
+  },
+}
+
+/** A markdown file adds the preview / code view-mode toggle. */
+export const MarkdownFile: Story = {
+  args: {
+    filePath: 'README.md',
+    fileContent: readmeContent,
+  },
+}
+
+/** With lines selected, the copy-permalink button appears. */
+export const WithSelectedLines: Story = {
+  args: {
+    selectedLines: { start: 1, end: 1 },
+  },
+}
+
+/** A binary file hides the text-specific actions. */
+export const BinaryFile: Story = {
+  args: {
+    isBinaryFile: true,
+    filePath: 'assets/logo.png',
+    fileContent: { ...fileContent, path: 'assets/logo.png', content: '' },
+  },
+}
+
+/** While loading, the layout toggle is disabled. */
+export const Loading: Story = {
+  args: {
+    loading: true,
+    isViewingFile: false,
+    filePath: null,
+    fileContent: null,
+  },
+}

--- a/app/components/Code/MobileTreeDrawer.stories.ts
+++ b/app/components/Code/MobileTreeDrawer.stories.ts
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import type { PackageFileTree } from '#shared/types/npm-registry'
+import MobileTreeDrawer from './MobileTreeDrawer.vue'
+
+const tree: PackageFileTree[] = [
+  {
+    name: 'src',
+    path: 'src',
+    type: 'directory',
+    size: 5120,
+    children: [
+      { name: 'index.ts', path: 'src/index.ts', type: 'file', size: 1024 },
+      {
+        name: 'utils',
+        path: 'src/utils',
+        type: 'directory',
+        size: 2048,
+        children: [{ name: 'format.ts', path: 'src/utils/format.ts', type: 'file', size: 512 }],
+      },
+    ],
+  },
+  { name: 'package.json', path: 'package.json', type: 'file', size: 640 },
+  { name: 'README.md', path: 'README.md', type: 'file', size: 2200 },
+]
+
+const baseRoute = {
+  params: { org: undefined, packageName: 'mock-package', version: '1.0.0' },
+}
+
+const meta = {
+  component: MobileTreeDrawer,
+  tags: ['autodocs'],
+  args: {
+    tree,
+    currentPath: 'src/index.ts',
+    baseUrl: 'mock-package@1.0.0',
+    baseRoute,
+  },
+} satisfies Meta<typeof MobileTreeDrawer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Slide-in file tree for small screens. The drawer is hidden at `md` and wider,
+ * so view this story in a narrow viewport. Use the button to toggle it open.
+ */
+export const Default: Story = {
+  render: args => ({
+    components: { MobileTreeDrawer },
+    setup() {
+      return { args }
+    },
+    template: `
+      <div>
+        <button
+          class="md:hidden px-3 py-1.5 bg-bg-muted border border-border rounded-md text-sm"
+          @click="$refs.drawer.toggle()"
+        >
+          Toggle drawer
+        </button>
+        <p class="hidden md:block text-sm text-fg-muted">
+          This drawer only renders below the <code>md</code> breakpoint. Switch to a narrow viewport to see it.
+        </p>
+        <MobileTreeDrawer ref="drawer" v-bind="args" />
+      </div>
+    `,
+  }),
+}

--- a/app/components/Code/SkeletonLoader.stories.ts
+++ b/app/components/Code/SkeletonLoader.stories.ts
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import SkeletonLoader from './SkeletonLoader.vue'
+
+const meta = {
+  component: SkeletonLoader,
+  tags: ['autodocs'],
+  decorators: [
+    () => ({ template: '<div class="h-125 border border-border bg-bg-subtle"><story /></div>' }),
+  ],
+} satisfies Meta<typeof SkeletonLoader>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Loading placeholder shown while a file's contents are being fetched. */
+export const Default: Story = {}

--- a/app/components/Code/Viewer.stories.ts
+++ b/app/components/Code/Viewer.stories.ts
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import Viewer from './Viewer.vue'
+
+// Mimics the markup Shiki emits server-side: a <pre><code> with one
+// `.line` span per line. Inline color styles keep the sample self-contained.
+const lines = [
+  `<span style="color:#F97583">export</span> <span style="color:#F97583">function</span> <span style="color:#B392F0">greet</span><span style="color:#E1E4E8">(</span><span style="color:#FFAB70">name</span><span style="color:#F97583">:</span> <span style="color:#79B8FF">string</span><span style="color:#E1E4E8">) {</span>`,
+  `<span style="color:#E1E4E8">  </span><span style="color:#F97583">return</span> <span style="color:#9ECBFF">\`Hello, \${name}!\`</span></span>`,
+  `<span style="color:#E1E4E8">}</span>`,
+]
+
+const html = `<pre class="shiki"><code>${lines
+  .map(line => `<span class="line">${line}</span>`)
+  .join('\n')}</code></pre>`
+
+const meta = {
+  component: Viewer,
+  tags: ['autodocs'],
+  args: {
+    html,
+    lines: lines.length,
+    selectedLines: null,
+  },
+  decorators: [
+    () => ({
+      template: '<div class="border border-border bg-bg-subtle"><story /></div>',
+    }),
+  ],
+} satisfies Meta<typeof Viewer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Syntax-highlighted file with line numbers. */
+export const Default: Story = {}
+
+/** A range of lines highlighted, as when linking to a permalink. */
+export const WithSelectedLines: Story = {
+  args: {
+    selectedLines: { start: 2, end: 2 },
+  },
+}

--- a/app/components/CollapsibleSection.stories.ts
+++ b/app/components/CollapsibleSection.stories.ts
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import CollapsibleSection from './CollapsibleSection.vue'
+
+const meta = {
+  component: CollapsibleSection,
+  tags: ['autodocs'],
+  args: {
+    id: 'demo-section',
+    title: 'Dependencies',
+  },
+  render: args => ({
+    components: { CollapsibleSection },
+    setup() {
+      return { args }
+    },
+    template: `
+      <CollapsibleSection v-bind="args">
+        <ul class="text-sm text-fg-muted list-disc ps-4 space-y-1">
+          <li>vue@3.4.0</li>
+          <li>vue-router@4.2.0</li>
+          <li>pinia@2.1.0</li>
+        </ul>
+      </CollapsibleSection>
+    `,
+  }),
+} satisfies Meta<typeof CollapsibleSection>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Expanded section with a heading, anchor link and collapse toggle. */
+export const Default: Story = {}
+
+/** A secondary line of context beneath the title. */
+export const WithSubtitle: Story = {
+  args: {
+    id: 'demo-section-subtitle',
+    subtitle: '3 direct dependencies',
+  },
+}
+
+/** Spinner in place of the chevron while content is being fetched. */
+export const Loading: Story = {
+  args: {
+    id: 'demo-section-loading',
+    isLoading: true,
+  },
+}
+
+/** The `actions` slot renders controls on the right of the header. */
+export const WithActions: Story = {
+  render: args => ({
+    components: { CollapsibleSection },
+    setup() {
+      return { args }
+    },
+    template: `
+      <CollapsibleSection v-bind="args">
+        <template #actions>
+          <button class="text-xs font-mono text-fg-muted hover:text-fg">Expand all</button>
+        </template>
+        <p class="text-sm text-fg-muted">Section body content.</p>
+      </CollapsibleSection>
+    `,
+  }),
+  args: {
+    id: 'demo-section-actions',
+  },
+}

--- a/app/components/CopyToClipboardButton.stories.ts
+++ b/app/components/CopyToClipboardButton.stories.ts
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import { fn } from 'storybook/test'
+import CopyToClipboardButton from './CopyToClipboardButton.vue'
+
+const meta = {
+  component: CopyToClipboardButton,
+  tags: ['autodocs'],
+  args: {
+    copied: false,
+    onClick: fn(),
+  },
+  render: args => ({
+    components: { CopyToClipboardButton },
+    setup() {
+      return { args }
+    },
+    template: `
+      <CopyToClipboardButton v-bind="args">
+        <code class="font-mono text-sm px-2 py-1 rounded bg-bg-subtle border border-border">npm install example-package</code>
+      </CopyToClipboardButton>
+    `,
+  }),
+} satisfies Meta<typeof CopyToClipboardButton>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * The copy button is visually hidden until you hover (or focus) the wrapped
+ * content, then slides in beneath it. Hover the code below to reveal it.
+ */
+export const Default: Story = {}
+
+/** The "copied" confirmation state, shown after a successful copy. */
+export const Copied: Story = {
+  args: {
+    copied: true,
+  },
+}
+
+/** Custom labels for both the idle and copied states. */
+export const CustomLabels: Story = {
+  args: {
+    copyText: 'Copy command',
+    copiedText: 'Copied!',
+  },
+}

--- a/app/components/Input/Base.stories.ts
+++ b/app/components/Input/Base.stories.ts
@@ -4,6 +4,7 @@ import Component from './Base.vue'
 
 const meta = {
   component: Component,
+  tags: ['autodocs'],
   argTypes: {
     disabled: { control: 'boolean' },
     size: {

--- a/app/components/Link/Link.stories.ts
+++ b/app/components/Link/Link.stories.ts
@@ -3,6 +3,7 @@ import LinkBase from './Base.vue'
 
 const meta = {
   component: LinkBase,
+  tags: ['autodocs'],
   args: {
     to: '/',
   },

--- a/app/components/LoadingSpinner.stories.ts
+++ b/app/components/LoadingSpinner.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import LoadingSpinner from './LoadingSpinner.vue'
+
+const meta = {
+  component: LoadingSpinner,
+  tags: ['autodocs'],
+} satisfies Meta<typeof LoadingSpinner>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Falls back to the localised "Loading…" label when no text is given. */
+export const Default: Story = {}
+
+/** Custom label alongside the spinner. */
+export const WithText: Story = {
+  args: {
+    text: 'Fetching package metadata…',
+  },
+}

--- a/app/components/PaginationControls.stories.ts
+++ b/app/components/PaginationControls.stories.ts
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import { ref } from 'vue'
+import PaginationControls from './PaginationControls.vue'
+
+const meta = {
+  component: PaginationControls,
+  tags: ['autodocs'],
+  args: {
+    totalItems: 1240,
+    mode: 'paginated',
+    pageSize: 25,
+    currentPage: 3,
+  },
+  // The component is driven by v-model, so seed local state from the args and
+  // bind the remaining props explicitly.
+  render: args => ({
+    components: { PaginationControls },
+    setup() {
+      const mode = ref(args.mode)
+      const pageSize = ref(args.pageSize)
+      const currentPage = ref(args.currentPage)
+      return { args, mode, pageSize, currentPage }
+    },
+    template: `
+      <PaginationControls
+        :total-items="args.totalItems"
+        :view-mode="args.viewMode"
+        v-model:mode="mode"
+        v-model:page-size="pageSize"
+        v-model:current-page="currentPage"
+      />
+    `,
+  }),
+} satisfies Meta<typeof PaginationControls>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Paginated mode with a page-size select, item range and page navigation. */
+export const Default: Story = {}
+
+/** In table view the mode toggle is hidden — tables always paginate. */
+export const TableView: Story = {
+  args: {
+    viewMode: 'table',
+  },
+}
+
+/** Few enough items that every page number is shown (no ellipsis). */
+export const FewPages: Story = {
+  args: {
+    totalItems: 60,
+  },
+}

--- a/app/components/PaginationControls.stories.ts
+++ b/app/components/PaginationControls.stories.ts
@@ -20,15 +20,24 @@ const meta = {
       const pageSize = ref(args.pageSize)
       const currentPage = ref(args.currentPage)
 
-      watch(() => args.mode, value => {
-        mode.value = value
-      })
-      watch(() => args.pageSize, value => {
-        pageSize.value = value
-      })
-      watch(() => args.currentPage, value => {
-        currentPage.value = value
-      })
+      watch(
+        () => args.mode,
+        value => {
+          mode.value = value
+        },
+      )
+      watch(
+        () => args.pageSize,
+        value => {
+          pageSize.value = value
+        },
+      )
+      watch(
+        () => args.currentPage,
+        value => {
+          currentPage.value = value
+        },
+      )
 
       return { args, mode, pageSize, currentPage }
     },

--- a/app/components/PaginationControls.stories.ts
+++ b/app/components/PaginationControls.stories.ts
@@ -19,6 +19,17 @@ const meta = {
       const mode = ref(args.mode)
       const pageSize = ref(args.pageSize)
       const currentPage = ref(args.currentPage)
+
+      watch(() => args.mode, value => {
+        mode.value = value
+      })
+      watch(() => args.pageSize, value => {
+        pageSize.value = value
+      })
+      watch(() => args.currentPage, value => {
+        currentPage.value = value
+      })
+
       return { args, mode, pageSize, currentPage }
     },
     template: `

--- a/app/components/ProgressBar.stories.ts
+++ b/app/components/ProgressBar.stories.ts
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import ProgressBar from './ProgressBar.vue'
+
+const meta = {
+  component: ProgressBar,
+  tags: ['autodocs'],
+  argTypes: {
+    val: {
+      control: { type: 'range', min: 0, max: 100, step: 1 },
+    },
+  },
+  args: {
+    val: 82,
+    label: 'Completion',
+  },
+  decorators: [() => ({ template: '<div class="flex w-80"><story /></div>' })],
+} satisfies Meta<typeof ProgressBar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Colour shifts with the value: red → orange → green as it fills. */
+export const Default: Story = {}
+
+export const Low: Story = {
+  args: { val: 30 },
+}
+
+export const Medium: Story = {
+  args: { val: 68 },
+}
+
+export const High: Story = {
+  args: { val: 95 },
+}
+
+/** A full bar (100%) gets the strongest "complete" colour. */
+export const Complete: Story = {
+  args: { val: 100 },
+}

--- a/app/components/ProvenanceBadge.stories.ts
+++ b/app/components/ProvenanceBadge.stories.ts
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import ProvenanceBadge from './ProvenanceBadge.vue'
+
+const meta = {
+  component: ProvenanceBadge,
+  tags: ['autodocs'],
+  argTypes: {
+    provider: {
+      control: 'select',
+      options: ['github', 'gitlab', undefined],
+    },
+  },
+  args: {
+    provider: 'github',
+    packageName: 'example-package',
+    version: '1.0.0',
+  },
+} satisfies Meta<typeof ProvenanceBadge>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Links to the npm provenance page when a package name and version are given. */
+export const Default: Story = {}
+
+/** Icon-only variant for tight spaces. */
+export const Compact: Story = {
+  args: {
+    compact: true,
+  },
+}
+
+/** Built on GitLab CI rather than GitHub Actions. */
+export const GitLab: Story = {
+  args: {
+    provider: 'gitlab',
+  },
+}
+
+/** Rendered as static text (no link) when `linked` is false. */
+export const NotLinked: Story = {
+  args: {
+    linked: false,
+  },
+}
+
+/** Without a provider, it shows a generic "verified" title. */
+export const NoProvider: Story = {
+  args: {
+    provider: undefined,
+  },
+}

--- a/app/components/SkeletonBlock.stories.ts
+++ b/app/components/SkeletonBlock.stories.ts
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import SkeletonBlock from './SkeletonBlock.vue'
+
+const meta = {
+  component: SkeletonBlock,
+  tags: ['autodocs'],
+} satisfies Meta<typeof SkeletonBlock>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Block-level loading placeholder. Size it with the surrounding layout —
+ * here a fixed width and height stand in for a card.
+ */
+export const Default: Story = {
+  render: () => ({
+    components: { SkeletonBlock },
+    template: '<SkeletonBlock class="w-64 h-4" />',
+  }),
+}
+
+/** Stacked placeholders standing in for a list of items. */
+export const List: Story = {
+  render: () => ({
+    components: { SkeletonBlock },
+    template: `
+      <div class="flex flex-col gap-2 w-80">
+        <SkeletonBlock class="h-5 w-1/2" />
+        <SkeletonBlock class="h-4 w-full" />
+        <SkeletonBlock class="h-4 w-5/6" />
+      </div>
+    `,
+  }),
+}

--- a/app/components/SkeletonInline.stories.ts
+++ b/app/components/SkeletonInline.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import SkeletonInline from './SkeletonInline.vue'
+
+const meta = {
+  component: SkeletonInline,
+  tags: ['autodocs'],
+} satisfies Meta<typeof SkeletonInline>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Inline loading placeholder for a single value. Width and height come from
+ * the surrounding text context.
+ */
+export const Default: Story = {
+  render: () => ({
+    components: { SkeletonInline },
+    template: '<SkeletonInline class="w-64 h-4" />',
+  }),
+}
+
+/** Sitting inline within a line of text. */
+export const InText: Story = {
+  render: () => ({
+    components: { SkeletonInline },
+    template: `
+      <p class="text-sm text-fg-muted">
+        Downloaded <SkeletonInline class="w-4 h-3.5 align-middle" /> times this week.
+      </p>
+    `,
+  }),
+}


### PR DESCRIPTION
### 🔗 Linked issue

fixes some of #1841

### 🧭 Context

If desired, I can scaffold the stories for the remaining components, but I'd like to know if this is the direction you want to take.

I also think that it could be nice to organize the components a bit more, to store some core UI components separate from specific features. This will also help with storybook organization, as it should mirror the repo structure.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
