### PR TITLE
fix(ui): make diff page layout responsive

### DIFF
--- a/app/components/Diff/ViewerPanel.vue
+++ b/app/components/Diff/ViewerPanel.vue
@@ -93,7 +93,7 @@ function getCodeUrl(version: string): string {
   return `/package-code/${props.packageName}/v/${version}/${props.file.path}`
 }
 
-const { toggleCodeContainer } = useCodeContainer()
+const { codeContainerFull, toggleCodeContainer } = useCodeContainer()
 
 const { announce } = useCommandPalette()
 
@@ -365,6 +365,7 @@ useCommandPaletteContextCommands(
             class="px-3 max-xl:hidden"
             classicon="i-lucide:unfold-horizontal [.container-full_&]:i-lucide:fold-horizontal"
             :aria-label="$t('code.toggle_container')"
+            :aria-pressed="codeContainerFull"
             @click="toggleCodeContainer()"
           />
         </TooltipApp>

--- a/app/components/Diff/ViewerPanel.vue
+++ b/app/components/Diff/ViewerPanel.vue
@@ -93,6 +93,8 @@ function getCodeUrl(version: string): string {
   return `/package-code/${props.packageName}/v/${version}/${props.file.path}`
 }
 
+const { toggleCodeContainer } = useCodeContainer()
+
 const { announce } = useCommandPalette()
 
 useCommandPaletteContextCommands(
@@ -356,6 +358,16 @@ useCommandPaletteContextCommands(
             </div>
           </Transition>
         </div>
+
+        <!-- Toggle container width -->
+        <TooltipApp :text="$t('code.toggle_container')" position="top">
+          <ButtonBase
+            class="px-3 max-xl:hidden"
+            classicon="i-lucide:unfold-horizontal [.container-full_&]:i-lucide:fold-horizontal"
+            :aria-label="$t('code.toggle_container')"
+            @click="toggleCodeContainer()"
+          />
+        </TooltipApp>
 
         <!-- View in code browser -->
         <NuxtLink

--- a/app/pages/diff/[[org]]/[packageName]/v/[versionRange].vue
+++ b/app/pages/diff/[[org]]/[packageName]/v/[versionRange].vue
@@ -182,13 +182,20 @@ useSeoMeta({
     </div>
 
     <!-- Comparison content -->
-    <div v-else-if="compare" class="flex-1 flex flex-col md:flex-row min-h-0 overflow-hidden">
+    <div
+      v-else-if="compare"
+      class="w-full container flex-1 min-h-0 grid grid-cols-[18rem_1fr] max-lg:grid-cols-[16rem_1fr] max-md:grid-cols-[1fr] border-border border-x px-0 mx-auto"
+      dir="ltr"
+    >
       <!-- Desktop sidebar -->
       <aside
-        class="hidden md:flex w-80 border-ie border-border bg-bg-subtle flex-col shrink-0 min-h-0"
+        class="sticky top-25 hidden md:flex shrink-0 self-start border-ie border-border bg-bg-subtle flex-col min-h-0"
       >
-        <div v-if="pkg?.versions && pkg?.['dist-tags']" class="px-3 py-2 border-b border-border">
-          <p class="text-xs font-medium text-fg mb-1 flex items-center gap-1.5">
+        <div
+          v-if="pkg?.versions && pkg?.['dist-tags']"
+          class="px-3 py-3 border-b border-border shrink-0"
+        >
+          <p class="text-xs font-medium text-fg mb-2 flex items-center gap-1.5">
             <span class="block i-lucide-git-compare-arrows w-3.5 h-3.5" />
             {{ $t('compare.version_selector_title') }}
           </p>
@@ -201,6 +208,7 @@ useSeoMeta({
           />
         </div>
         <DiffSidebarPanel
+          class="flex-1 min-h-0"
           :compare="compare"
           :grouped-deps="groupedDeps"
           :all-changes="allChanges"
@@ -211,7 +219,7 @@ useSeoMeta({
       </aside>
 
       <!-- Right side -->
-      <div class="flex-1 flex flex-col min-w-0 overflow-hidden">
+      <div class="flex flex-col min-w-0 min-h-0 self-stretch">
         <!-- Mobile summary bar -->
         <div
           class="md:hidden border-b border-border bg-bg-subtle px-4 py-3 flex items-center justify-between gap-3"
@@ -240,7 +248,7 @@ useSeoMeta({
         </div>
 
         <!-- Diff viewer -->
-        <div class="flex-1 overflow-hidden bg-bg-subtle">
+        <div class="flex-1 min-h-0 bg-bg-subtle">
           <DiffViewerPanel
             v-if="selectedFile"
             :package-name="packageName"
@@ -248,7 +256,7 @@ useSeoMeta({
             :to-version="toVersion"
             :file="selectedFile"
           />
-          <div v-else class="h-full flex items-center justify-center text-center p-8">
+          <div v-else class="flex items-center justify-center text-center p-8">
             <div>
               <span class="i-lucide:file-text w-16 h-16 mx-auto text-fg-subtle/50 block mb-4" />
               <p class="text-fg-muted">{{ $t('compare.select_file_prompt') }}</p>

--- a/app/pages/diff/[[org]]/[packageName]/v/[versionRange].vue
+++ b/app/pages/diff/[[org]]/[packageName]/v/[versionRange].vue
@@ -143,7 +143,7 @@ useSeoMeta({
 })
 
 onPrehydrate(el => {
-  let settingsSaved = {}
+  let settingsSaved: { codeContainerFull?: boolean } = {}
   try {
     settingsSaved = JSON.parse(localStorage.getItem('npmx-settings') || '{}')
   } catch {

--- a/app/pages/diff/[[org]]/[packageName]/v/[versionRange].vue
+++ b/app/pages/diff/[[org]]/[packageName]/v/[versionRange].vue
@@ -256,7 +256,7 @@ useSeoMeta({
             :to-version="toVersion"
             :file="selectedFile"
           />
-          <div v-else class="flex items-center justify-center text-center p-8">
+          <div v-else class="min-h-[60vh] flex items-center justify-center text-center p-8">
             <div>
               <span class="i-lucide:file-text w-16 h-16 mx-auto text-fg-subtle/50 block mb-4" />
               <p class="text-fg-muted">{{ $t('compare.select_file_prompt') }}</p>

--- a/app/pages/diff/[[org]]/[packageName]/v/[versionRange].vue
+++ b/app/pages/diff/[[org]]/[packageName]/v/[versionRange].vue
@@ -27,6 +27,7 @@ const fromVersion = computed(() => versionRange.value?.from ?? '')
 const toVersion = computed(() => versionRange.value?.to ?? '')
 
 const router = useRouter()
+const { codeContainerFull } = useCodeContainer()
 const { data: pkg } = usePackage(packageName)
 const { versions: commandPaletteVersions, ensureLoaded: ensureCommandPaletteVersionsLoaded } =
   useCommandPalettePackageVersions(packageName)
@@ -140,6 +141,20 @@ useSeoMeta({
   description: () =>
     `Compare changes between ${packageName.value} versions ${fromVersion.value} and ${toVersion.value}`,
 })
+
+onPrehydrate(el => {
+  let settingsSaved = {}
+  try {
+    settingsSaved = JSON.parse(localStorage.getItem('npmx-settings') || '{}')
+  } catch {
+    // Ignore invalid persisted settings.
+  }
+  const container = el.querySelector('#diff-page-container')
+
+  if (settingsSaved?.codeContainerFull === true && container) {
+    container.classList.add('container-full')
+  }
+})
 </script>
 
 <template>
@@ -184,7 +199,9 @@ useSeoMeta({
     <!-- Comparison content -->
     <div
       v-else-if="compare"
-      class="w-full container flex-1 min-h-0 grid grid-cols-[18rem_1fr] max-lg:grid-cols-[16rem_1fr] max-md:grid-cols-[1fr] border-border border-x px-0 mx-auto"
+      id="diff-page-container"
+      class="w-full container flex-1 min-h-0 grid grid-cols-[18rem_1fr] max-lg:grid-cols-[16rem_1fr] max-md:grid-cols-[1fr] border-border border-x px-0 mx-auto transition-[max-width] duration-300"
+      :class="codeContainerFull ? 'container-full' : ''"
       dir="ltr"
     >
       <!-- Desktop sidebar -->
@@ -286,3 +303,9 @@ useSeoMeta({
     </ClientOnly>
   </main>
 </template>
+
+<style>
+.container-full.container-full {
+  @apply max-w-full border-0;
+}
+</style>


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

- The compare page was full-screen while the code page uses a container layout, so both pages looked inconsistent.
- This updates the compare page to use the same responsive layout as the code page. No logic changes.
- Nothing was functionally broken before this, this is mainly a consistency and responsive layout improvement.

Before: 
<img width="1916" height="956" alt="image" src="https://github.com/user-attachments/assets/2e81cc26-42fb-4441-9274-99ed9fb8b9d5" />

After:
<img width="1919" height="963" alt="image" src="https://github.com/user-attachments/assets/1111a1cd-de58-4c46-8aa8-1b9be6c592bc" />

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
