### PR TITLE
ci: add agentscan

### DIFF
--- a/.github/agentscan.yml
+++ b/.github/agentscan.yml
@@ -1,0 +1,20 @@
+version: 1
+trusted-author-associations:
+  - owner
+  - member
+honeypot: true
+mode: labels
+messages:
+  honeypot-first-time: |-
+    Hello! Thank you for opening your **first PR** to npmx, **@{username}**! 🚀
+
+    Here's what will happen next:
+
+    1. Our GitHub bots will run to check your changes.\
+       If they spot any issues, you will see some error messages on this PR.\
+       Don't hesitate to ask any questions if you're not sure what these mean!
+
+    2. In a few minutes, you'll be able to see a preview of your changes on Vercel
+
+    3. One or more of our maintainers will take a look and may ask you to make changes.\
+       We try to be responsive, but don't worry if this takes a few days.


### PR DESCRIPTION
### 🔗 Linked issue

closes #2281 

### 🧭 Context

To keep AI Agents away, we're gonna add AgentScan GitHub App.

### 📚 Description

I've added the yml file so that once the app is installed, it will be used immediately as options:
- Owner and member are trusted user associations
- I've enabled the [honeypot feature](https://bsky.app/profile/matteogabriele.npmx.social/post/3ms3usa33fk2l), which adds a comment whenever someone not on the trusted list opens a PR. To maintain the npmx first-timer message, there's a separate honeypot message for first-time contributors.
- I've disabled messages, as Nuxt does, and AgentScan will only add tags. The only messages AgentScan will write are the honeypot messages.
- auto-close has not been enabled, but if we want to use it, we can.