### PR TITLE
chore(deps): bump vue-data-ui from 3.23.0 to 3.23.1

### DIFF
--- a/app/components/Package/TimelineChart.vue
+++ b/app/components/Package/TimelineChart.vue
@@ -542,6 +542,7 @@ const config = computed<VueUiXyConfig>(() => {
       legend: { show: false },
       padding: {
         top: 32,
+        right: 56,
       },
       title: {
         text: applyEllipsis(packageName.value, 32),
@@ -588,7 +589,7 @@ const config = computed<VueUiXyConfig>(() => {
       },
       zoom: {
         show: settings.value.timelineChart.showZoom,
-        maxWidth: isMobile.value ? 350 : 500,
+        autoFit: true,
         highlightColor: colors.value.bgElevated,
         useResetSlot: true,
         keepState: true,
@@ -1053,7 +1054,7 @@ const timelineMetricTabs = computed(() => [
           <button
             type="button"
             :aria-label="$t('package.timeline.chart.reset_minimap')"
-            class="absolute inset-is-1/2 -translate-x-1/2 -bottom-18 sm:inset-is-unset sm:translate-x-0 sm:bottom-auto sm:-inset-ie-20 sm:-top-3 flex items-center justify-center px-2.5 py-1.75 border border-transparent rounded-md text-fg-subtle hover:text-fg transition-colors hover:border-border focus-visible:outline-accent/70 sm:mb-0"
+            class="absolute inset-is-1/2 -translate-x-1/2 -bottom-18 sm:inset-is-unset sm:translate-x-0 sm:bottom-auto sm:-inset-ie-16 sm:-top-3 flex items-center justify-center px-2.5 py-1.75 border border-transparent rounded-md text-fg-subtle hover:text-fg transition-colors hover:border-border focus-visible:outline-accent/70 sm:mb-0"
             style="pointer-events: all !important"
             @click="resetMinimap"
           >

--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -1239,7 +1239,7 @@ const chartConfig = computed<VueUiXyConfig>(() => {
         },
       },
       zoom: {
-        maxWidth: isMobile.value ? 350 : 500,
+        autoFit: true,
         highlightColor: colors.value.bgElevated,
         useResetSlot: true,
         keepState: keepZoomState.value,
@@ -1824,7 +1824,7 @@ const copyEmbedUrl = () => copyEmbed(embedUrl.value)
               <button
                 type="button"
                 aria-label="reset minimap"
-                class="absolute inset-is-1/2 -translate-x-1/2 -bottom-18 sm:inset-is-unset sm:translate-x-0 sm:bottom-auto sm:-inset-ie-20 sm:-top-3 flex items-center justify-center px-2.5 py-1.75 border border-transparent rounded-md text-fg-subtle hover:text-fg transition-colors hover:border-border focus-visible:outline-accent/70 sm:mb-0"
+                class="absolute inset-is-1/2 -translate-x-1/2 -bottom-18 sm:inset-is-unset sm:translate-x-0 sm:bottom-auto sm:-inset-ie-16 sm:-top-3 flex items-center justify-center px-2.5 py-1.75 border border-transparent rounded-md text-fg-subtle hover:text-fg transition-colors hover:border-border focus-visible:outline-accent/70 sm:mb-0"
                 style="pointer-events: all !important"
                 @click="resetMinimap"
               >

--- a/app/components/Package/VersionDistribution.vue
+++ b/app/components/Package/VersionDistribution.vue
@@ -311,9 +311,8 @@ const chartConfig = computed<VueUiXyConfig>(() => {
         },
       },
       zoom: {
-        maxWidth: isMobile.value ? 350 : 500,
+        autoFit: true,
         highlightColor: colors.value.bgElevated,
-        useResetSlot: true,
         minimap: {
           show: true,
           lineColor: '#FAFAFA',
@@ -526,7 +525,7 @@ const chartConfig = computed<VueUiXyConfig>(() => {
               <button
                 type="button"
                 aria-label="reset minimap"
-                class="absolute inset-is-1/2 -translate-x-1/2 -bottom-18 sm:inset-is-unset sm:translate-x-0 sm:bottom-auto sm:-inset-ie-20 sm:-top-3 flex items-center justify-center px-2.5 py-1.75 border border-transparent rounded-md text-fg-subtle hover:text-fg transition-colors hover:border-border focus-visible:outline-accent/70 sm:mb-0"
+                class="absolute inset-is-1/2 -translate-x-1/2 -bottom-18 sm:inset-is-unset sm:translate-x-0 sm:bottom-auto sm:-inset-ie-16 sm:-top-3 flex items-center justify-center px-2.5 py-1.75 border border-transparent rounded-md text-fg-subtle hover:text-fg transition-colors hover:border-border focus-visible:outline-accent/70 sm:mb-0"
                 style="pointer-events: all !important"
                 @click="resetMinimap"
               >

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "catalog:vite-plus",
     "vue": "3.5.39",
-    "vue-data-ui": "3.23.0",
+    "vue-data-ui": "3.23.1",
     "vue-router": "5.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,8 +269,8 @@ importers:
         specifier: 3.5.39
         version: 3.5.39(typescript-native-bridge@6.0.3-bridge.9.tsgo.7.0.2)
       vue-data-ui:
-        specifier: 3.23.0
-        version: 3.23.0(vue@3.5.39)
+        specifier: 3.23.1
+        version: 3.23.1(vue@3.5.39)
       vue-router:
         specifier: 5.2.0
         version: 5.2.0(@voidzero-dev/vite-plus-core@0.2.7)(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.2)(vue@3.5.39)(webpack@5.108.4)
@@ -10839,8 +10839,8 @@ packages:
   vue-component-type-helpers@3.3.9:
     resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
 
-  vue-data-ui@3.23.0:
-    resolution: {integrity: sha512-Drgg76fb+eOn5yLFsUX7Kvfs3Fcyfpv0QKXL8EVfprklTeyWseeqeiP2yJWWSFD79JfB/4Ap6Dwtp2/w1RiwMw==}
+  vue-data-ui@3.23.1:
+    resolution: {integrity: sha512-zLf9V8Dz7fInz5OAIBJwfxk80rK71gDkI9K/aXdOO/nJcWdvmF9D8L2FPKfic3HtUrBM6HbO9t1WHpC2hdZCzQ==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -23451,7 +23451,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.9: {}
 
-  vue-data-ui@3.23.0(vue@3.5.39):
+  vue-data-ui@3.23.1(vue@3.5.39):
     dependencies:
       vue: 3.5.39(typescript-native-bridge@6.0.3-bridge.9.tsgo.7.0.2)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,7 +43,7 @@ ignoreWorkspaceRootCheck: true
 
 minimumReleaseAgeExclude:
   - '@iconify-json/simple-icons@1.2.93'
-  - vue-data-ui@3.23.0
+  - vue-data-ui@3.23.0 || 3.23.1
 
 overrides:
   '@types/node': 24.13.3


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

Bump vue-data-ui to latest 3.23.1 ([release notes](https://github.com/graphieros/vue-data-ui/releases/tag/v3.23.1))
This upgrade allows to align zoom range inputs to the sides of the charts.

Downloads:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/809f6e91-5066-443e-bbd3-9860d02a9d55" />

Timeline:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/61cc18e8-22aa-40e7-8c46-d92ee9cf0993" />

All charts with this range input were adjusted accordingly:
- slighly move the zoom reset button to the left
- add some right padding when necessary