### PR TITLE
fix: respect registry Cache-Control instead of force-cache on client

### DIFF
--- a/app/composables/useCachedFetch.ts
+++ b/app/composables/useCachedFetch.ts
@@ -38,7 +38,7 @@ export function useCachedFetch(): CachedFetchFunction {
       _ttl: number = FETCH_CACHE_DEFAULT_TTL,
     ): Promise<CachedFetchResult<T>> => {
       const defaultFetchOptions: Parameters<typeof $fetch>[1] = {
-        cache: 'force-cache',
+        cache: 'default',
       }
       const data = (await $fetch<T>(url, defu(options, defaultFetchOptions))) as T
       return { data, isStale: false, cachedAt: null }
@@ -62,7 +62,7 @@ export function useCachedFetch(): CachedFetchFunction {
     _ttl: number = FETCH_CACHE_DEFAULT_TTL,
   ): Promise<CachedFetchResult<T>> => {
     const defaultFetchOptions: Parameters<typeof $fetch>[1] = {
-      cache: 'force-cache',
+      cache: 'default',
     }
     const data = (await $fetch<T>(url, defu(options, defaultFetchOptions))) as T
     return { data, isStale: false, cachedAt: null }


### PR DESCRIPTION
Fixes #1832

## The bug

Package comparison pages (`/compare?packages=...`) can show outdated
version numbers even after a package has published a newer release.

## Root cause

`usePackageComparison` fetches each package's registry data through
`$npmRegistry`, which is backed by `useCachedFetch()`. On the client,
that composable hardcodes `cache: 'force-cache'` on the underlying
`$fetch` call:

```ts
const defaultFetchOptions: Parameters<typeof $fetch>[1] = {
  cache: 'force-cache',
}
```

`force-cache` tells the browser to reuse any existing cached response
for a URL indefinitely, without checking whether it's still fresh. Once
a package's registry data was fetched once, the browser would keep
serving that same snapshot — including a stale `dist-tags.latest` —
regardless of how much time had passed or how many new versions were
published.

This also means the `ttl` parameter this function accepts (`_ttl`,
currently unused on the client branch) had no real effect on the
client — caching was left entirely to the browser's HTTP cache in
"never revalidate" mode.

Worth noting: `registry.npmjs.org` already sends the headers needed to
do this correctly —