### PR TITLE
chore(deps): bump vue-data-ui from 3.23.1 to 3.23.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "catalog:vite-plus",
     "vue": "3.5.39",
-    "vue-data-ui": "3.23.1",
+    "vue-data-ui": "3.23.2",
     "vue-router": "5.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,8 +269,8 @@ importers:
         specifier: 3.5.39
         version: 3.5.39(typescript-native-bridge@6.0.3-bridge.9.tsgo.7.0.2)
       vue-data-ui:
-        specifier: 3.23.1
-        version: 3.23.1(vue@3.5.39)
+        specifier: 3.23.2
+        version: 3.23.2(vue@3.5.39)
       vue-router:
         specifier: 5.2.0
         version: 5.2.0(@voidzero-dev/vite-plus-core@0.2.7)(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.2)(vue@3.5.39)(webpack@5.108.4)
@@ -10839,8 +10839,8 @@ packages:
   vue-component-type-helpers@3.3.9:
     resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
 
-  vue-data-ui@3.23.1:
-    resolution: {integrity: sha512-zLf9V8Dz7fInz5OAIBJwfxk80rK71gDkI9K/aXdOO/nJcWdvmF9D8L2FPKfic3HtUrBM6HbO9t1WHpC2hdZCzQ==}
+  vue-data-ui@3.23.2:
+    resolution: {integrity: sha512-w08Nd24la0n1nItNytUeU/K42VJn6wBAxDQCG10xRIGDcthXzpMucZcL2FzsMutlc/G4DM4tzh1eeBng9ft9mg==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -23451,7 +23451,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.9: {}
 
-  vue-data-ui@3.23.1(vue@3.5.39):
+  vue-data-ui@3.23.2(vue@3.5.39):
     dependencies:
       vue: 3.5.39(typescript-native-bridge@6.0.3-bridge.9.tsgo.7.0.2)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,7 +43,7 @@ ignoreWorkspaceRootCheck: true
 
 minimumReleaseAgeExclude:
   - '@iconify-json/simple-icons@1.2.93'
-  - vue-data-ui@3.23.0 || 3.23.1
+  - vue-data-ui@3.23.0 || 3.23.1 || 3.23.2
 
 overrides:
   '@types/node': 24.13.3


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

Bump vue-data-ui to latest 3.23.2 with `-61 kB` install size ([release notes](https://github.com/graphieros/vue-data-ui/releases/tag/v3.23.2)).
