### PR TITLE
fix: prevent modal close button from crowding header text

### DIFF
--- a/app/components/Modal.client.vue
+++ b/app/components/Modal.client.vue
@@ -59,8 +59,8 @@ defineExpose({
       @transitionend="onDialogTransitionEnd"
     >
       <!-- Modal top header section -->
-      <div class="flex items-center justify-between mb-6">
-        <div>
+      <div class="flex items-center justify-between gap-4 mb-6">
+        <div class="min-w-0">
           <h2 :id="modalTitleId" class="font-mono text-lg font-medium">
             {{ modalTitle }}
           </h2>
@@ -70,6 +70,7 @@ defineExpose({
         </div>
         <ButtonBase
           type="button"
+          class="shrink-0"
           :aria-label="$t('common.close')"
           @click="handleModalClose"
           classicon="i-lucide:x"


### PR DESCRIPTION
Fixed the close button in the modal header sitting flush against the title/subtitle text.

The header is a flex row with the text block and close button as siblings, but had no gap between them and no width constraint on the text. On narrow viewports the subtitle wraps and expands until it butts right into the button.

before:
<img width="695" height="997" alt="before-1" src="https://github.com/user-attachments/assets/88f97167-b685-4488-a59a-24ccb12b0316" />

after: 

<img width="672" height="747" alt="correct" src="https://github.com/user-attachments/assets/003174a4-c911-49bd-9600-c8cee4ee982f" />
