### PR TITLE
fix: only show changelog skeleton when actually loading

### DIFF
--- a/app/pages/package-changelog/[[org]]/[name].vue
+++ b/app/pages/package-changelog/[[org]]/[name].vue
@@ -45,7 +45,11 @@ const latestVersion = computed(() => {
 })
 
 // getting info
-const { data: changelog, error: changelogError } = usePackageChangelog(packageName, version)
+const {
+  data: changelog,
+  error: changelogError,
+  pending: changelogPending,
+} = usePackageChangelog(packageName, version)
 
 const providerIcon = useProviderIcon(() => changelog.value?.provider)
 const viewOnProvider = useViewOnGitProvider(() => changelog.value?.provider)
@@ -134,7 +138,10 @@ defineOgImage(
           <!-- prevents layout shift while loading -->
         </div>
       </div>
-      <section v-if="!changelog && !changelogError" class="flex flex-col gap-2 py-3">
+      <section
+        v-if="changelogPending && !changelog && !changelogError"
+        class="flex flex-col gap-2 py-3"
+      >
         <ChangelogSkeleton />
       </section>
 
@@ -168,15 +175,17 @@ defineOgImage(
       </LazyChangelogMarkdown>
 
       <!-- error handling -->
-      <p class="mt-5" v-else-if="changelogError?.statusMessage == ERROR_UNGH_API_KEY_EXHAUSTED">
-        {{ $t('changelog.rate_limit_ungh') }}
-      </p>
-      <p class="mt-5" v-else-if="!version || !pkg?.versions[version]">
-        {{ $t('changelog.version_unavailable') }}
-      </p>
-      <p class="mt-5" v-else>
-        {{ $t('changelog.no_logs') }}
-      </p>
+      <template v-else-if="!changelogPending">
+        <p class="mt-5" v-if="changelogError?.statusMessage == ERROR_UNGH_API_KEY_EXHAUSTED">
+          {{ $t('changelog.rate_limit_ungh') }}
+        </p>
+        <p class="mt-5" v-else-if="!version || !pkg?.versions[version]">
+          {{ $t('changelog.version_unavailable') }}
+        </p>
+        <p class="mt-5" v-else>
+          {{ $t('changelog.no_logs') }}
+        </p>
+      </template>
     </section>
   </main>
   <!-- resolving the version didn't succeed, assunming that the package doesn't exist -->


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #3168

### 🧭 Context

Previously, the `ChangelogSkeleton` was conditionally rendered using `v-if="!changelog && !changelogError"`. This caused the skeleton to remain visible permanently for packages that successfully returned from the API but simply didn't have any changelogs (like the `fcy` package).

This PR resolves the issue by extracting the `pending` state from `usePackageChangelog` and using it to conditionally render both the skeleton and the fallback error messages.

### 📚 Description

- Extracted `pending: changelogPending` state from `usePackageChangelog`.
- Updated the skeleton loader to only display while the fetch is still pending (`v-if="changelogPending && !changelog && !changelogError"`).
- Wrapped the fallback/error messages in a `<template v-else-if="!changelogPending">` so they don't render simultaneously while the skeleton is loading.

**Testing:**
Tested against packages with no changelogs (e.g., `fcy`) to confirm the skeleton gracefully hides and properly shows the "Sorry, this package does not publish changelogs..." text without overlap.
