### PR TITLE
fix: remove tabindex=-1 for main skip link target

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -154,7 +154,7 @@ if (!isBlogPostRoute.value) {
       {{ route.name === 'search' ? `${$t('search.title_packages')} - npmx` : message }}
     </NuxtRouteAnnouncer>
 
-    <div id="main-content" class="flex-1 flex flex-col" tabindex="-1">
+    <div id="main-content" class="flex-1 flex flex-col">
       <NuxtPage />
     </div>
 


### PR DESCRIPTION
### 🧭 Context

Browsers already correctly set the [“sequential focus navigation starting point”](https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation-starting-point) and doing this tends to create a larger usability regression with regards to where the focus starts (i.e. clicking within the document doesn’t set the focus starting point to wherever that was, but rather to the outer element with `tabindex=-1`).

There is a counterpoint related to screen magnifiers, however, I find that the benefit that `tabindex=-1` brings to those situations is overstated/inconsistent and not the reason why `tabindex=-1` was initially used as a hack in the first place.

### 📚 Description

Just removes `tabindex=-1` on the main skip link target.
