### PR TITLE
feat: show error icon on the timeline chart

### DIFF
--- a/app/assets/main.css
+++ b/app/assets/main.css
@@ -17,6 +17,7 @@
   --fg: oklch(0.982 0 0);
   --fg-muted: oklch(0.849 0 0);
   --fg-subtle: oklch(0.773 0 0);
+  --fg-error: oklch(70.4% 0.191 22.216);
 
   /* border, separator colors */
   --border: oklch(0.269 0 0);
@@ -109,6 +110,7 @@
   --fg: oklch(0.046 0 0);
   --fg-muted: oklch(0.198 0 0);
   --fg-subtle: oklch(0.28 0 0);
+  --fg-error: oklch(50.5% 0.213 27.518);
 
   --border: oklch(0.8514 0 0);
   --border-subtle: oklch(0.922 0 0);

--- a/app/components/Package/TimelineChart.vue
+++ b/app/components/Package/TimelineChart.vue
@@ -72,7 +72,8 @@ function addEvaluationFlags(
       ...entry,
       events,
       hasPositive: events.some(event => event.state === 'success'),
-      hasNegative: events.some(event => event.state === 'warn' || event.state === 'error'),
+      hasNegative: events.some(event => event.state === 'warn'),
+      hasError: events.some(event => event.state === 'error'),
     }
   })
 }
@@ -103,6 +104,7 @@ const convertedData = computed(() => {
       events: [],
       hasPositive: false,
       hasNegative: false,
+      hasError: false,
     }
   })
 
@@ -621,6 +623,7 @@ type TimelineSourceItem = {
   events?: SubEvent[]
   hasPositive?: boolean
   hasNegative?: boolean
+  hasError?: boolean
 }
 
 type TimelineSvgDataItem = VueUiXyDatasetLineItem & {
@@ -656,6 +659,7 @@ function getDatapointPlots(
 
     const hasPositive = datapoint.hasPositive === true
     const hasNegative = datapoint.hasNegative === true
+    const hasError = datapoint.hasError === true
 
     return [
       {
@@ -663,7 +667,7 @@ function getDatapointPlots(
         index,
         x: plot.x,
         y: plot.y,
-        offsetY: markerKey === 'negative' && hasPositive && hasNegative ? 20 : 0,
+        offsetY: hasError ? 0 : markerKey === 'negative' && hasPositive && hasNegative ? 20 : 0,
       },
     ]
   })
@@ -707,28 +711,38 @@ function getActiveVersionDatapointBar(
     )
 }
 
+// If a data point also has an error, the positive icon will not be shown
 function getPositiveDatapointPlots(
   item: TimelineDatasetItem,
   zoomOffset: number,
 ): TimelineMarkerItem[] {
   return getDatapointPlots(
     item,
-    datapoint => datapoint.hasPositive === true,
+    datapoint => datapoint.hasPositive === true && datapoint.hasError !== true,
     'positive',
     zoomOffset,
   )
 }
 
+// If a data point also has an error, the negative icon will not be shown
 function getNegativeDatapointPlots(
   item: TimelineDatasetItem,
   zoomOffset: number,
 ): TimelineMarkerItem[] {
   return getDatapointPlots(
     item,
-    datapoint => datapoint.hasNegative === true,
+    datapoint => datapoint.hasNegative === true && datapoint.hasError !== true,
     'negative',
     zoomOffset,
   )
+}
+
+// If a data point has an error, only this icon will be shown
+function getErrorDatapointPlots(
+  item: TimelineDatasetItem,
+  zoomOffset: number,
+): TimelineMarkerItem[] {
+  return getDatapointPlots(item, datapoint => datapoint.hasError === true, 'error', zoomOffset)
 }
 
 const indexSelection = computed(() => {
@@ -989,6 +1003,7 @@ const timelineMetricTabs = computed(() => [
             "
             :markersPositive="getPositiveDatapointPlots(svg.data[0], svg.slicer.start)"
             :markersNegative="getNegativeDatapointPlots(svg.data[0], svg.slicer.start)"
+            :markersError="getErrorDatapointPlots(svg.data[0], svg.slicer.start)"
             :colors
             :gradientColors="E18E_GRADIENT_COLORS"
             :pauseAnimations="shouldPauseChartAnimations || loading"

--- a/app/components/Package/TimelineChartXySvgSlot.vue
+++ b/app/components/Package/TimelineChartXySvgSlot.vue
@@ -8,6 +8,7 @@ const props = defineProps<{
   watermark?: string
   markersPositive: TimelineMarkerItem[]
   markersNegative: TimelineMarkerItem[]
+  markersError: TimelineMarkerItem[]
   colors: Record<string, string>
   gradientColors: string[]
   pauseAnimations: boolean
@@ -77,6 +78,28 @@ const svgElementTransitionClass = computed(() => [
         fill="none"
         :stroke="gradientColors[0]"
         stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        :class="svgElementTransitionClass"
+      />
+    </g>
+
+    <!-- Marker for error events -->
+    <g v-for="plot in markersError" :key="plot.key" class="pointer-events-none">
+      <path
+        :d="`m ${plot.x} ${plot.y - 20 - (plot.offsetY ?? 0)} l 0 4 m -3 -9 l -4 4 l 0 6 l 4 4 l 6 0 l 4 -4 l 0 -6 l -4 -4 l -6 0`"
+        fill="none"
+        :stroke="colors.bg"
+        stroke-width="6"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        :class="svgElementTransitionClass"
+      />
+      <path
+        :d="`m ${plot.x} ${plot.y - 20 - (plot.offsetY ?? 0)} l 0 4 m -3 -9 l -4 4 l 0 6 l 4 4 l 6 0 l 4 -4 l 0 -6 l -4 -4 l -6 0`"
+        fill="none"
+        :stroke="colors.fgError"
+        stroke-width="1.5"
         stroke-linecap="round"
         stroke-linejoin="round"
         :class="svgElementTransitionClass"

--- a/app/composables/useColors.ts
+++ b/app/composables/useColors.ts
@@ -28,6 +28,7 @@ const colorVariables = [
   '--fg',
   '--fg-muted',
   '--fg-subtle',
+  '--fg-error',
 ] as const
 
 function readCssVariable(element: HTMLElement, variableName: string): string {

--- a/app/utils/charts.ts
+++ b/app/utils/charts.ts
@@ -489,6 +489,7 @@ export type EnrichedTimelineSizeCacheEntry = ConvertedTimelineSizeCacheEntry & {
   events: SubEvent[]
   hasPositive: boolean
   hasNegative: boolean
+  hasError: boolean
 }
 
 export type TimelineChartMetric = 'totalSize' | 'dependencyCount' | 'dependencySize'

--- a/test/nuxt/a11y.spec.ts
+++ b/test/nuxt/a11y.spec.ts
@@ -2464,6 +2464,7 @@ describe('component accessibility audits', () => {
           watermark: '<g><text x="0" y="0" stroke="#000000" font-size="12">npmx</text></g>',
           markersPositive: [],
           markersNegative: [],
+          markersError: [],
           colors: { bg: '#FFFFFF', accent: '#FF0000' },
           pauseAnimations: false,
           gradientColors: [


### PR DESCRIPTION
### 🔗 Linked issue

Follow up to #3133

### 🧭 Context

Errors are now surfaced in the timeline (ej. deprecated versions).
The chart is missing a specific icon for this case.

### 📚 Description

This displays an error icon, inspired by the one already used on the timeline when a version is deprecated.
This icon takes precedence over other events, meaning if a data point happens to have multiple events, only the error will be visible, to avoid stacking possibly 3 icons on a very narrow height, but also because deprecation superseeds any other information.

| Dark mode | Light mode |
| - | - |
|<img width="120" height="135" alt="image" src="https://github.com/user-attachments/assets/62304a26-53ea-4266-b284-a912d9635972" />|<img width="120" height="135" alt="image" src="https://github.com/user-attachments/assets/3e3248e6-4cd6-4dee-adcc-7b43599c195b" />|

Example package to test: `node-domexception`