### PR TITLE
fix(ui): stop truncated html showing as package description

### DIFF
--- a/app/composables/useMarkdown.ts
+++ b/app/composables/useMarkdown.ts
@@ -56,9 +56,10 @@ function stripAndEscapeHtml(text: string): string {
     (match, codeSpan: string | undefined) => codeSpan ?? '',
   )
 
-  // Strip unclosed HTML tags left by registry truncation (no closing '>')
+  // Strip unclosed HTML tags left by registry truncation (no closing '>').
+  // The tag branch must not cross a backtick, or it would swallow a later code span
   stripped = stripped.replace(
-    /(`[^`]*`)|<\/?[a-z][^>]*$/gi,
+    /(`[^`]*`)|<\/?[a-z][^>`]*$/gi,
     (match, codeSpan: string | undefined) => codeSpan ?? '',
   )
 

--- a/app/composables/useMarkdown.ts
+++ b/app/composables/useMarkdown.ts
@@ -56,6 +56,12 @@ function stripAndEscapeHtml(text: string): string {
     (match, codeSpan: string | undefined) => codeSpan ?? '',
   )
 
+  // Strip unclosed HTML tags left by registry truncation (no closing '>')
+  stripped = stripped.replace(
+    /(`[^`]*`)|<\/?[a-z][^>]*$/gi,
+    (match, codeSpan: string | undefined) => codeSpan ?? '',
+  )
+
   // Strip HTML comments: <!-- ... --> (including unclosed comments from truncation)
   stripped = stripped.replace(
     /(`[^`]*`)|<!--[\s\S]*?(-->|$)/g,
@@ -69,6 +75,7 @@ function stripAndEscapeHtml(text: string): string {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;')
+    .trim()
 }
 
 // Parse simple inline markdown to HTML

--- a/shared/utils/html.ts
+++ b/shared/utils/html.ts
@@ -25,8 +25,9 @@ export function stripHtmlTags(text: string): string {
     previous = result
     result = result.replace(tagPattern, '')
   } while (result !== previous)
-  // Strip unclosed HTML tags left by registry truncation (no closing '>')
-  return result.replace(/<\/?[a-z][^>]*$/gi, '').trim()
+  // Strip unclosed HTML tags left by registry truncation (no closing '>').
+  // The match must not cross a backtick, or it would swallow a later code span
+  return result.replace(/<\/?[a-z][^>`]*$/gi, '').trim()
 }
 /**
  * Generate a GitHub-style slug from heading text.

--- a/shared/utils/html.ts
+++ b/shared/utils/html.ts
@@ -25,7 +25,8 @@ export function stripHtmlTags(text: string): string {
     previous = result
     result = result.replace(tagPattern, '')
   } while (result !== previous)
-  return result
+  // Strip unclosed HTML tags left by registry truncation (no closing '>')
+  return result.replace(/<\/?[a-z][^>]*$/gi, '').trim()
 }
 /**
  * Generate a GitHub-style slug from heading text.

--- a/test/nuxt/composables/use-markdown.spec.ts
+++ b/test/nuxt/composables/use-markdown.spec.ts
@@ -268,6 +268,11 @@ describe('useMarkdown', () => {
       const processed = useMarkdown({ text: 'A library <img src="https://img.s' })
       expect(processed.value).toBe('A library')
     })
+
+    it('preserves a backtick code span after an unclosed tag', () => {
+      const processed = useMarkdown({ text: 'compare a <b and run `npm i`' })
+      expect(processed.value).toContain('<code>npm i</code>')
+    })
   })
 
   describe('HTML comment stripping', () => {

--- a/test/nuxt/composables/use-markdown.spec.ts
+++ b/test/nuxt/composables/use-markdown.spec.ts
@@ -256,6 +256,18 @@ describe('useMarkdown', () => {
       const processed = useMarkdown({ text: '<b>bold</b> and **also bold**' })
       expect(processed.value).toBe('bold and <strong>also bold</strong>')
     })
+
+    it('strips unclosed HTML tags (truncated)', () => {
+      const processed = useMarkdown({
+        text: '<p>   <a href="https://www.npmjs.com/package/vue-tsc"><img src="https://img.shields.io/npm/v/vue-tsc.svg?labelColor=18181B&color=1584FC" alt="NPM version"></a>   <a href="https://github.com/vuejs/language-tools/blob/master/LICENSE"><img src="https://img.s',
+      })
+      expect(processed.value).toBe('')
+    })
+
+    it('strips a trailing unclosed tag but keeps preceding text', () => {
+      const processed = useMarkdown({ text: 'A library <img src="https://img.s' })
+      expect(processed.value).toBe('A library')
+    })
   })
 
   describe('HTML comment stripping', () => {
@@ -286,7 +298,7 @@ describe('useMarkdown', () => {
 
     it('strips unclosed HTML comments (truncated)', () => {
       const processed = useMarkdown({ text: 'A library <!-- automd:badges color=yel' })
-      expect(processed.value).toBe('A library ')
+      expect(processed.value).toBe('A library')
     })
   })
 

--- a/test/unit/shared/utils/html.spec.ts
+++ b/test/unit/shared/utils/html.spec.ts
@@ -64,4 +64,8 @@ describe('stripHtmlTags', () => {
   it('leaves comparison text that is not a tag', () => {
     expect(stripHtmlTags('a < b')).toBe('a < b')
   })
+
+  it('keeps a backtick code span after an unclosed tag', () => {
+    expect(stripHtmlTags('run <img src="x `npm i`')).toBe('run <img src="x `npm i`')
+  })
 })

--- a/test/unit/shared/utils/html.spec.ts
+++ b/test/unit/shared/utils/html.spec.ts
@@ -48,4 +48,20 @@ describe('stripHtmlTags', () => {
     const raw = '&lt;a href=&quot;url&quot;&gt;link&lt;/a&gt; and text'
     expect(stripHtmlTags(decodeHtmlEntities(raw))).toBe('link and text')
   })
+
+  it('removes unclosed HTML tags at the end of truncated text', () => {
+    expect(stripHtmlTags('A library <img src="https://img.s')).toBe('A library')
+  })
+
+  it('returns empty string when truncated text is only HTML tags', () => {
+    expect(
+      stripHtmlTags(
+        '<p>   <a href="https://www.npmjs.com/package/vue-tsc"><img src="https://img.shields.io/npm/v/vue-tsc.svg"></a>   <img src="https://img.s',
+      ),
+    ).toBe('')
+  })
+
+  it('leaves comparison text that is not a tag', () => {
+    expect(stripHtmlTags('a < b')).toBe('a < b')
+  })
 })


### PR DESCRIPTION
### Linked issue

Fixes #3181

### Context

vue-tsc (and similar packages) can show truncated HTML as the description, e.g. `<img src="https://img.s` on https://npmx.dev/package/vue-tsc.

### Description

Strip unclosed HTML tags left when npm truncates the description. If nothing useful remains, show the empty-description text.

No README fallback in this PR.

### Screenshots
Before
<img width="782" height="229" alt="image" src="https://github.com/user-attachments/assets/bf1b1d64-a7fb-47f6-a897-f974dcd14517" />
After
<img width="789" height="230" alt="image" src="https://github.com/user-attachments/assets/eccffb60-f89c-4125-8cf1-d1cda52e4e0a" />

### Test plan

- [ ] `/package/vue-tsc` does not show `<img src="https://img.s`
- [ ] A normal text description is unchanged
- [ ] `a < b` in a description still shows