### PR TITLE
chore(deps): bump vue-data-ui from 3.23.5 to 3.23.7

### DIFF
--- a/app/components/Package/TrendsChart.vue
+++ b/app/components/Package/TrendsChart.vue
@@ -2065,7 +2065,8 @@ const copyEmbedUrl = () => copyEmbed(embedUrl.value)
   background: var(--bg-elevated) !important;
 }
 
-.vue-ui-pen-and-paper-action {
+.vue-ui-pen-and-paper-action,
+.vue-ui-pen-and-paper-drag-handle {
   background: var(--bg-elevated) !important;
   border: none !important;
 }

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "catalog:vite-plus",
     "vue": "3.5.41",
-    "vue-data-ui": "3.23.5",
+    "vue-data-ui": "3.23.7",
     "vue-router": "5.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,8 +271,8 @@ importers:
         specifier: 3.5.41
         version: 3.5.41(typescript-native-bridge@6.0.3-bridge.13.tsgo.7.0.2)
       vue-data-ui:
-        specifier: 3.23.5
-        version: 3.23.5(vue@3.5.41)
+        specifier: 3.23.7
+        version: 3.23.7(vue@3.5.41)
       vue-router:
         specifier: 5.2.0
         version: 5.2.0(@voidzero-dev/vite-plus-core@0.2.9)(@vue/compiler-sfc@3.5.41)(esbuild@0.28.1)(rolldown@1.2.4)(rollup@4.62.2)(vue@3.5.41)(webpack@5.108.4)
@@ -10611,8 +10611,8 @@ packages:
   vue-component-type-helpers@3.3.10:
     resolution: {integrity: sha512-t7IQivQ3oD4D01b7s7a9AWzHAcr3DGBIa/1jZREsFQJcFgSL92gqUkqNiHTYgzTt7QDuJa0I9wCeDwEtZICoBQ==}
 
-  vue-data-ui@3.23.5:
-    resolution: {integrity: sha512-f0GUjRatJQ305e7OPOW3htV9jEsSzqJ2zGJSQoq0yEAXuQmxF08DsERd5MsdUG2f1tH0YKbRaD/QuXklts2NrA==}
+  vue-data-ui@3.23.7:
+    resolution: {integrity: sha512-QPfRd3oMQYHUydbA7m1M+dzmoCLJieLo4DvE2LZVZSFRyl/qt4PKvx+piCipaYfcllViRShHj15q6AoviIrQKA==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: 3.5.41
@@ -23055,7 +23055,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.10: {}
 
-  vue-data-ui@3.23.5(vue@3.5.41):
+  vue-data-ui@3.23.7(vue@3.5.41):
     dependencies:
       vue: 3.5.41(typescript-native-bridge@6.0.3-bridge.13.tsgo.7.0.2)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,7 +43,7 @@ ignoreWorkspaceRootCheck: true
 
 minimumReleaseAgeExclude:
   - '@iconify-json/simple-icons@1.2.93'
-  - vue-data-ui@3.23.0 || 3.23.1
+  - vue-data-ui@3.23.0 || 3.23.1 || 3.23.7
   - 'nuxt@4.5.2'
   - '@nuxt/kit@4.5.2'
   - '@nuxt/nitro-server@4.5.2'


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

Bump vue-data-ui to latest 3.23.7 ([release notes](https://github.com/graphieros/vue-data-ui/releases/tag/v3.23.7))

This version introduces a new feature for the built-in chart annotation menu, which is now draggable to clear the view if needed. The styles of the drag handle were adapted to fit our overrides.

This version also fixes some Safari issues with the annotator:
- the colour of arrow heads were not inherited
- caret position was offset in text mode

https://github.com/user-attachments/assets/045a0f77-cd08-4b66-9640-7eaacb49de5d

