### PR TITLE
fix: make hit areas of the charts zoom range handles more accessible f…

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "catalog:vite-plus",
     "vue": "3.5.41",
-    "vue-data-ui": "3.23.7",
+    "vue-data-ui": "3.23.14",
     "vue-router": "5.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,8 +271,8 @@ importers:
         specifier: 3.5.41
         version: 3.5.41(typescript-native-bridge@6.0.3-bridge.13.tsgo.7.0.2)
       vue-data-ui:
-        specifier: 3.23.7
-        version: 3.23.7(vue@3.5.41)
+        specifier: 3.23.14
+        version: 3.23.14(vue@3.5.41)
       vue-router:
         specifier: 5.2.0
         version: 5.2.0(@voidzero-dev/vite-plus-core@0.2.9)(@vue/compiler-sfc@3.5.41)(esbuild@0.28.1)(rolldown@1.2.4)(rollup@4.62.2)(vue@3.5.41)(webpack@5.108.4)
@@ -10611,8 +10611,11 @@ packages:
   vue-component-type-helpers@3.3.10:
     resolution: {integrity: sha512-t7IQivQ3oD4D01b7s7a9AWzHAcr3DGBIa/1jZREsFQJcFgSL92gqUkqNiHTYgzTt7QDuJa0I9wCeDwEtZICoBQ==}
 
-  vue-data-ui@3.23.7:
-    resolution: {integrity: sha512-QPfRd3oMQYHUydbA7m1M+dzmoCLJieLo4DvE2LZVZSFRyl/qt4PKvx+piCipaYfcllViRShHj15q6AoviIrQKA==}
+  vue-component-type-helpers@3.3.11:
+    resolution: {integrity: sha512-LwcxzeliO9fkQcpJG0PoX8X5kmAhKmH9wkpDLxNabwzkQ9Zeib2YVHwFV4pcWmMLfXVfjr/dSV+DaJ3cIPgSNA==}
+
+  vue-data-ui@3.23.14:
+    resolution: {integrity: sha512-/cosH1iTd+lnyvR+5/kqG6AzLbaZdhJCLhNLWvUp1h0mU2fxOOUI/B9zVV0couixVC4+5PAR5pmWqvoDIbsFyQ==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: 3.5.41
@@ -15138,7 +15141,7 @@ snapshots:
       storybook: 10.5.5(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8)(vite-plus@0.2.9)
       type-fest: 2.19.0
       vue: 3.5.41(typescript-native-bridge@6.0.3-bridge.13.tsgo.7.0.2)
-      vue-component-type-helpers: 3.3.10
+      vue-component-type-helpers: 3.3.11
 
   '@swc/helpers@0.5.23':
     dependencies:
@@ -23055,7 +23058,9 @@ snapshots:
 
   vue-component-type-helpers@3.3.10: {}
 
-  vue-data-ui@3.23.7(vue@3.5.41):
+  vue-component-type-helpers@3.3.11: {}
+
+  vue-data-ui@3.23.14(vue@3.5.41):
     dependencies:
       vue: 3.5.41(typescript-native-bridge@6.0.3-bridge.13.tsgo.7.0.2)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,12 +43,12 @@ ignoreWorkspaceRootCheck: true
 
 minimumReleaseAgeExclude:
   - '@iconify-json/simple-icons@1.2.93'
-  - vue-data-ui@3.23.7
   - 'nuxt@4.5.2'
   - '@nuxt/kit@4.5.2'
   - '@nuxt/nitro-server@4.5.2'
   - '@nuxt/schema@4.5.2'
   - '@nuxt/vite-builder@4.5.2'
+  - vue-data-ui@3.23.14
 
 minimumReleaseAgeExcludePrune: true
 


### PR DESCRIPTION
Resolves #3198

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

The charts zoom range handles hit areas were almost completely inaccessible on touch screens.

### 📚 Description

Bump vue-data-ui to latest, with a fix ([release notes](https://github.com/graphieros/vue-data-ui/releases/tag/v3.23.14))
