### PR TITLE
feat(ui): paginate the timeline around the selected version

### DIFF
--- a/app/pages/package-timeline/[[org]]/[packageName].vue
+++ b/app/pages/package-timeline/[[org]]/[packageName].vue
@@ -75,35 +75,48 @@ const sort = usePermalink<TimelineSort>('sort', 'semver')
 // server-side so pagination totals and pages already exclude pre-releases.
 const stableOnly = useTimelineStableOnly()
 
-// Paginated timeline data from server
+// Paginated timeline data from server, anchored on the selected version: the
+// initial page is the page-aligned slice containing it (`around=<version>`),
+// and more pages can be loaded in both directions. All follow-up requests use
+// plain page-aligned offsets so every user shares the same page cache entries.
 const PAGE_SIZE = 25
 
 const timelineEntries = ref<TimelineVersion[]>([])
+// Offset of the first loaded entry in the full sorted list (page-aligned)
+const timelineOffset = ref(0)
 const totalVersions = ref(0)
-const loadingMore = ref(false)
-const loadError = ref(false)
+const loadingNewer = ref(false)
+const loadingOlder = ref(false)
+const loadError = ref<false | 'newer' | 'older'>(false)
 
-const hasMore = computed(() => timelineEntries.value.length < totalVersions.value)
+// Bumped whenever the list is replaced wholesale (package/version/sort/filter
+// change) so in-flight load-more requests from the old window are discarded.
+let listEpoch = 0
+
+const hasNewer = computed(() => timelineOffset.value > 0)
+const hasOlder = computed(
+  () => timelineOffset.value + timelineEntries.value.length < totalVersions.value,
+)
 
 async function fetchTimeline(
-  offset: number,
+  page: { offset: number } | { around: string },
   pkgName: string = packageName.value,
   sortOrder: TimelineSort = sort.value,
   stable: boolean = stableOnly.value,
 ): Promise<TimelineResponse> {
   return $fetch<TimelineResponse>(`/api/registry/timeline/${pkgName}`, {
-    query: { offset, 'limit': PAGE_SIZE, 'sort': sortOrder, 'stable-only': String(stable) },
+    query: { ...page, 'limit': PAGE_SIZE, 'sort': sortOrder, 'stable-only': String(stable) },
   })
 }
 
 // Initial load - useAsyncData serializes the full response across SSR to client.
-// The key is a stable string (evaluated once); subsequent package/sort/filter
-// changes are handled by the reload watcher below so we control the page size.
+// The key is a stable string (evaluated once); subsequent package/version/sort/
+// filter changes are handled by the re-anchor watcher below.
 const initialLoadError = ref(false)
 
 const { data: initialTimeline, status: initialStatus } = await useAsyncData(
-  `timeline:${packageName.value}:${sort.value}:${stableOnly.value}`,
-  () => fetchTimeline(0),
+  `timeline:${packageName.value}:${version.value}:${sort.value}:${stableOnly.value}`,
+  () => fetchTimeline({ around: version.value }),
 )
 
 watch(
@@ -111,7 +124,9 @@ watch(
   data => {
     initialLoadError.value = false
     if (data) {
+      listEpoch++
       timelineEntries.value = data.versions
+      timelineOffset.value = data.offset
       totalVersions.value = data.total
     } else {
       initialLoadError.value = true
@@ -120,28 +135,44 @@ watch(
   { immediate: true },
 )
 
-async function loadMore() {
-  if (loadingMore.value) return
-  loadingMore.value = true
-  loadError.value = false
-  // Capture the request context; the package, sort or filter can change while
-  // the request is in flight, after which the reload watcher replaces the list.
-  const pkgName = packageName.value
-  const sortOrder = sort.value
-  const stable = stableOnly.value
-  const isStale = () =>
-    pkgName !== packageName.value || sortOrder !== sort.value || stable !== stableOnly.value
+async function loadMore(direction: 'newer' | 'older') {
+  const loading = direction === 'newer' ? loadingNewer : loadingOlder
+  if (loading.value) return
+  loading.value = true
+  if (loadError.value === direction) loadError.value = false
+  // Capture the window generation; a package, version, sort or filter change
+  // while the request is in flight replaces the window and bumps the epoch.
+  const epoch = listEpoch
   try {
-    const offset = timelineEntries.value.length
-    const data = await fetchTimeline(offset, pkgName, sortOrder, stable)
-    if (isStale()) return
-    timelineEntries.value = [...timelineEntries.value, ...data.versions]
+    const offset =
+      direction === 'newer'
+        ? Math.max(0, timelineOffset.value - PAGE_SIZE)
+        : timelineOffset.value + timelineEntries.value.length
+    const data = await fetchTimeline({ offset })
+    if (epoch !== listEpoch) return
+    if (direction === 'newer') {
+      // Guard against overlap in case the boundary shifted (never in practice,
+      // both offsets are page-aligned)
+      const prepended = data.versions.slice(0, timelineOffset.value - offset)
+      // Prepending grows the list above the viewport; compensate the scroll so
+      // the content the user is looking at stays put (native scroll anchoring
+      // is disabled on the list, and not supported everywhere).
+      const doc = document.documentElement
+      const previousHeight = doc.scrollHeight
+      const previousScrollY = window.scrollY
+      timelineEntries.value = [...prepended, ...timelineEntries.value]
+      timelineOffset.value = offset
+      await nextTick()
+      window.scrollTo({ top: previousScrollY + (doc.scrollHeight - previousHeight) })
+    } else {
+      timelineEntries.value = [...timelineEntries.value, ...data.versions]
+    }
     totalVersions.value = data.total
-    fetchSizes(offset, pkgName, sortOrder, stable)
+    fetchSizes(offset)
   } catch {
-    if (!isStale()) loadError.value = true
+    if (epoch === listEpoch) loadError.value = direction
   } finally {
-    loadingMore.value = false
+    loading.value = false
   }
 }
 
@@ -187,52 +218,50 @@ async function fetchSizes(
   }
 }
 
-// Fetch sizes for the first `pageCount` pages (one request per page).
-function fetchSizesPages(
-  pageCount: number,
-  pkgName: string = packageName.value,
-  sortOrder: TimelineSort = sort.value,
-  stable: boolean = stableOnly.value,
-) {
-  for (let page = 0; page < pageCount; page++) {
-    fetchSizes(page * PAGE_SIZE, pkgName, sortOrder, stable)
-  }
-}
-
 // Fetch sizes for the initial page
 if (import.meta.client) {
   watch(
     initialTimeline,
-    () => {
-      fetchSizes(0)
+    data => {
+      if (data) fetchSizes(data.offset)
     },
     { immediate: true },
   )
 
-  // When the package, sort or stable-only filter changes, re-fetch as many
-  // PAGE_SIZE pages as the user had already paginated (a package change starts
-  // fresh from page one) so their position is preserved. Fetching per page reuses
-  // each page's cache instead of issuing one oversized request.
-  watch([packageName, sort, stableOnly], async ([pkgName, sortOrder, stable], [previousPkg]) => {
-    loadError.value = false
-    const pageCount =
-      pkgName === previousPkg ? Math.max(1, Math.ceil(timelineEntries.value.length / PAGE_SIZE)) : 1
-    const isStale = () =>
-      pkgName !== packageName.value || sortOrder !== sort.value || stable !== stableOnly.value
-    try {
-      const pages = await Promise.all(
-        Array.from({ length: pageCount }, (_, page) =>
-          fetchTimeline(page * PAGE_SIZE, pkgName, sortOrder, stable),
-        ),
-      )
-      if (isStale()) return
-      timelineEntries.value = pages.flatMap(page => page.versions)
-      totalVersions.value = pages[0]?.total ?? 0
-      fetchSizesPages(pageCount, pkgName, sortOrder, stable)
-    } catch {
-      if (!isStale()) initialLoadError.value = true
-    }
-  })
+  // When the package, selected version, sort or stable-only filter changes,
+  // re-anchor the timeline on the page containing the selected version. A
+  // version change alone keeps the current window when the version is already
+  // loaded (no refetch needed).
+  watch(
+    [packageName, version, sort, stableOnly],
+    async ([pkgName, ver, sortOrder, stable], [previousPkg, , previousSort, previousStable]) => {
+      if (
+        pkgName === previousPkg &&
+        sortOrder === previousSort &&
+        stable === previousStable &&
+        timelineEntries.value.some(entry => entry.version === ver)
+      ) {
+        return
+      }
+      loadError.value = false
+      const isStale = () =>
+        pkgName !== packageName.value ||
+        ver !== version.value ||
+        sortOrder !== sort.value ||
+        stable !== stableOnly.value
+      try {
+        const data = await fetchTimeline({ around: ver }, pkgName, sortOrder, stable)
+        if (isStale()) return
+        listEpoch++
+        timelineEntries.value = data.versions
+        timelineOffset.value = data.offset
+        totalVersions.value = data.total
+        fetchSizes(data.offset, pkgName, sortOrder, stable)
+      } catch {
+        if (!isStale()) initialLoadError.value = true
+      }
+    },
+  )
 }
 
 const bytesFormatter = useBytesFormatter()
@@ -439,8 +468,26 @@ useSeoMeta({
     </div>
 
     <div class="container w-full py-8">
+      <!-- Load newer -->
+      <div v-if="hasNewer" class="mb-4 ms-10">
+        <button
+          type="button"
+          class="text-sm text-accent hover:text-accent/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="loadingNewer"
+          @click="loadMore('newer')"
+        >
+          {{ $t('package.timeline.load_newer') }}
+        </button>
+        <p v-if="loadError === 'newer'" class="text-xs text-red-600 dark:text-red-400 mt-1">
+          {{ $t('package.timeline.load_error') }}
+        </p>
+      </div>
+
       <!-- Timeline -->
-      <ol v-if="timelineEntries.length" class="relative border-s border-border ms-4">
+      <ol
+        v-if="timelineEntries.length"
+        class="relative border-s border-border ms-4 [overflow-anchor:none]"
+      >
         <li v-for="entry in timelineEntries" :key="entry.version" class="mb-6 ms-6">
           <!-- Dot -->
           <span
@@ -516,17 +563,17 @@ useSeoMeta({
         </li>
       </ol>
 
-      <!-- Load more -->
-      <div v-if="hasMore" class="mt-4 ms-10">
+      <!-- Load older -->
+      <div v-if="hasOlder" class="mt-4 ms-10">
         <button
           type="button"
           class="text-sm text-accent hover:text-accent/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          :disabled="loadingMore"
-          @click="loadMore"
+          :disabled="loadingOlder"
+          @click="loadMore('older')"
         >
           {{ $t('package.timeline.load_more') }}
         </button>
-        <p v-if="loadError" class="text-xs text-red-600 dark:text-red-400 mt-1">
+        <p v-if="loadError === 'older'" class="text-xs text-red-600 dark:text-red-400 mt-1">
           {{ $t('package.timeline.load_error') }}
         </p>
       </div>

--- a/app/pages/package-timeline/[[org]]/[packageName].vue
+++ b/app/pages/package-timeline/[[org]]/[packageName].vue
@@ -243,6 +243,9 @@ if (import.meta.client) {
       ) {
         return
       }
+      // Invalidate any in-flight load-more from the previous window before the
+      // request goes out, so a stale response can't commit while we re-anchor.
+      listEpoch++
       loadError.value = false
       const isStale = () =>
         pkgName !== packageName.value ||
@@ -252,7 +255,6 @@ if (import.meta.client) {
       try {
         const data = await fetchTimeline({ around: ver }, pkgName, sortOrder, stable)
         if (isStale()) return
-        listEpoch++
         timelineEntries.value = data.versions
         timelineOffset.value = data.offset
         totalVersions.value = data.total

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -641,6 +641,7 @@
       "no_match_filter": "No versions match {filter}"
     },
     "timeline": {
+      "load_newer": "Load newer versions",
       "load_more": "Load more",
       "load_error": "Failed to load timeline. Please try again later.",
       "no_stable_versions": "No stable versions to show. Turn off \u201cstable only\u201d to include pre-releases.",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -1927,6 +1927,9 @@
         "timeline": {
           "type": "object",
           "properties": {
+            "load_newer": {
+              "type": "string"
+            },
             "load_more": {
               "type": "string"
             },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -126,7 +126,7 @@ export default defineNuxtConfig({
       isr: {
         expiration: 300,
         passQuery: true,
-        allowQuery: ['offset', 'limit', 'sort', 'stable-only'],
+        allowQuery: ['offset', 'limit', 'sort', 'stable-only', 'around'],
       },
     },
     '/api/changelog/md/**': {

--- a/server/api/registry/timeline/[...pkg].get.ts
+++ b/server/api/registry/timeline/[...pkg].get.ts
@@ -34,6 +34,8 @@ export interface TimelineVersion {
 export interface TimelineResponse {
   versions: TimelineVersion[]
   total: number
+  /** Effective offset of the returned page (page-aligned when `around` is used) */
+  offset: number
 }
 
 export interface SubEvent {
@@ -51,8 +53,15 @@ export interface SubEvent {
  * sorts (descending) by publish time (default) or by semver (`sort=semver`),
  * then paginates.
  *
+ * Instead of an explicit `offset`, `around=<version>` returns the page-aligned
+ * slice containing that version (`offset = floor(index / limit) * limit`), so
+ * anchored requests still map onto the same shared page boundaries. The
+ * response reports the effective `offset` so clients can paginate from there
+ * in both directions.
+ *
  * Examples:
  * - /api/registry/timeline/packageName?offset=0&limit=25
+ * - /api/registry/timeline/packageName?around=3.0.0&limit=25
  * - /api/registry/timeline/@scope/packageName?offset=0&limit=25&sort=semver&stable-only=true
  */
 export default defineCachedEventHandler(
@@ -70,10 +79,11 @@ export default defineCachedEventHandler(
     }
 
     const query = getQuery(event)
-    const offset = Math.max(0, Number(query.offset) || 0)
+    let offset = Math.max(0, Number(query.offset) || 0)
     const limit = Math.max(1, Math.min(100, Number(query.limit) || DEFAULT_LIMIT))
     const sort = parseTimelineSort(query.sort)
     const stableOnly = parseStableOnly(query['stable-only'])
+    const around = typeof query.around === 'string' ? query.around : undefined
 
     try {
       const packument = await fetchNpmPackage(packageName)
@@ -94,6 +104,13 @@ export default defineCachedEventHandler(
         allVersions.sort((a, b) => compare(b, a))
       } else {
         allVersions.sort((a, b) => Date.parse(packument.time[b]!) - Date.parse(packument.time[a]!))
+      }
+
+      if (around) {
+        // Snap to the page boundary containing the anchor version so anchored
+        // requests reuse the same page slices as plain offset pagination.
+        const index = allVersions.indexOf(around)
+        offset = index === -1 ? 0 : Math.floor(index / limit) * limit
       }
 
       const versions = allVersions.slice(offset, offset + limit)
@@ -126,6 +143,7 @@ export default defineCachedEventHandler(
       return {
         versions: versionsData,
         total: allVersions.length,
+        offset,
       } satisfies TimelineResponse
     } catch (error: unknown) {
       handleApiError(error, {
@@ -143,7 +161,11 @@ export default defineCachedEventHandler(
       const limit = Math.max(1, Math.min(100, Number(query.limit) || DEFAULT_LIMIT))
       const sort = parseTimelineSort(query.sort)
       const stableOnly = parseStableOnly(query['stable-only'])
-      return `timeline:v1:${getRouterParam(event, 'pkg')}:${sort}:${stableOnly}:${offset}:${limit}`
+      const around = typeof query.around === 'string' ? query.around : undefined
+      // `around` supersedes `offset`, so anchored requests get their own key
+      // (one per anchor version - same cardinality as the per-version pages).
+      const page = around ? `around=${around}` : offset
+      return `timeline:v2:${getRouterParam(event, 'pkg')}:${sort}:${stableOnly}:${page}:${limit}`
     },
   },
 )

--- a/test/unit/server/api/registry/timeline/pkg.get.spec.ts
+++ b/test/unit/server/api/registry/timeline/pkg.get.spec.ts
@@ -143,6 +143,68 @@ describe('timeline API', () => {
     expect(result.versions).toHaveLength(1)
     // sorted newest first: 3.0.0, 2.0.0, 1.0.0 → offset 1 = 2.0.0
     expect(result.versions[0]!.version).toBe('2.0.0')
+    expect(result.offset).toBe(1)
+  })
+
+  it('returns the page-aligned slice containing the anchor version for around=', async () => {
+    routerParam = 'my-pkg'
+    queryParams = { around: '1.0.3', limit: 10, sort: 'semver' }
+
+    const versions: Record<string, {}> = {}
+    const time: Record<string, string> = {}
+    for (let i = 1; i <= 30; i++) {
+      const v = `1.0.${i}`
+      versions[v] = {}
+      time[v] = new Date(2024, 0, i).toISOString()
+    }
+
+    fetchNpmPackageMock.mockResolvedValue(makePackument({ versions, time }))
+
+    const result = await handler(fakeEvent)
+    // semver descending: 1.0.30 … 1.0.1 → 1.0.3 is at index 27 → page 2 (offset 20)
+    expect(result.offset).toBe(20)
+    expect(result.versions.map(v => v.version)).toContain('1.0.3')
+    expect(result.versions).toHaveLength(10)
+    expect(result.versions[0]!.version).toBe('1.0.10')
+    expect(result.total).toBe(30)
+  })
+
+  it('around= takes precedence over offset', async () => {
+    routerParam = 'my-pkg'
+    queryParams = { around: '1.0.0', offset: 2, limit: 1 }
+
+    fetchNpmPackageMock.mockResolvedValue(
+      makePackument({
+        versions: { '1.0.0': {}, '2.0.0': {} },
+        time: {
+          '1.0.0': '2024-01-01T00:00:00Z',
+          '2.0.0': '2024-06-01T00:00:00Z',
+        },
+      }),
+    )
+
+    const result = await handler(fakeEvent)
+    expect(result.offset).toBe(1)
+    expect(result.versions.map(v => v.version)).toEqual(['1.0.0'])
+  })
+
+  it('falls back to the first page when the around version is unknown', async () => {
+    routerParam = 'my-pkg'
+    queryParams = { around: '9.9.9', limit: 1 }
+
+    fetchNpmPackageMock.mockResolvedValue(
+      makePackument({
+        versions: { '1.0.0': {}, '2.0.0': {} },
+        time: {
+          '1.0.0': '2024-01-01T00:00:00Z',
+          '2.0.0': '2024-06-01T00:00:00Z',
+        },
+      }),
+    )
+
+    const result = await handler(fakeEvent)
+    expect(result.offset).toBe(0)
+    expect(result.versions.map(v => v.version)).toEqual(['2.0.0'])
   })
 
   it('defaults offset to 0 and limit to 25', async () => {


### PR DESCRIPTION
**This PR is implemented with help of agents**.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

Continue #3192

Right now, the timeline feature ignores the currently selected version. for example, for Nuxt v3.0.0 (https://npmx.dev/package-timeline/nuxt/v/3.0.0), we have:

<img width="2342" height="1770" alt="CleanShot 2026-08-24 at 14 58 15@2x" src="https://github.com/user-attachments/assets/12f396a4-f063-4cfd-9fb8-ce0c4f84a511" />

which only list the latest versions, that have no direct relationships with `v3.0.0`. "Load more" is also not feasible as `v3.0.0` is too long ago to navigate.

This PR implemented a two-way "load more" feature, by default to navigate the range that contains the selected version:

<img width="2400" height="2654" alt="CleanShot 2026-08-24 at 15 01 06@2x" src="https://github.com/user-attachments/assets/a4058be5-38f2-456c-8b8d-aea27463a0e3" />


<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
