### PR TITLE
docs(ui): add stories for Profile page

### DIFF
--- a/app/pages/profile/[identity]/index.stories.ts
+++ b/app/pages/profile/[identity]/index.stories.ts
@@ -1,0 +1,86 @@
+import Profile from './index.vue'
+import type { Meta, StoryObj } from '@storybook-vue/nuxt'
+import { expect, userEvent } from 'storybook/test'
+import { pageDecorator } from '../../../../.storybook/decorators'
+import {
+  mockAuthSessionHandler,
+  mockPackageLikesHandler,
+  mockProfile,
+  mockProfileHandle,
+  mockProfileHandler,
+  mockProfileLikesHandler,
+  mockUpdateProfileHandler,
+} from '../../../storybook/mocks/handlers/profile'
+import { renderPageAt } from '../../../storybook/render-page'
+
+const PROFILE_PATH = `/profile/${mockProfileHandle}`
+
+const meta = {
+  component: Profile,
+
+  render: renderPageAt(Profile, PROFILE_PATH),
+
+  beforeEach({ msw }) {
+    msw.use(
+      mockProfileHandler(),
+      mockProfileLikesHandler(),
+      mockPackageLikesHandler,
+      mockAuthSessionHandler(),
+      mockUpdateProfileHandler,
+    )
+  },
+
+  parameters: {
+    layout: 'fullscreen',
+  },
+
+  decorators: [pageDecorator],
+} satisfies Meta<typeof Profile>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Public profile with profile metadata and several liked packages. */
+export const Default: Story = {}
+
+/** Authenticated as the profile owner so the edit action is available. */
+export const Owner: Story = {
+  beforeEach({ msw }) {
+    msw.use(mockAuthSessionHandler(mockProfileHandle))
+  },
+}
+
+/** Owner profile with the edit form opened and its editable controls visible. */
+export const Editing: Story = {
+  ...Owner,
+  play: async ({ canvas }) => {
+    await userEvent.click(await canvas.findByRole('button', { name: /edit/i }))
+
+    await expect(canvas.getByText(/display name/i)).toBeVisible()
+    await expect(await canvas.findByDisplayValue(mockProfile.displayName)).toBeVisible()
+    await expect(canvas.getByText(/description/i)).toBeVisible()
+    await expect(canvas.getByDisplayValue(mockProfile.description ?? '')).toBeVisible()
+    await expect(canvas.getByText(/website/i)).toBeVisible()
+    await expect(canvas.getByDisplayValue(mockProfile.website ?? '')).toBeVisible()
+    await expect(canvas.getByRole('button', { name: /cancel/i })).toBeVisible()
+    await expect(canvas.getByRole('button', { name: /save/i })).toBeVisible()
+  },
+}
+
+/** Missing npmx profile record with no likes; authenticated as another user so the invite section appears. */
+export const Invite: Story = {
+  beforeEach({ msw }) {
+    msw.use(
+      mockProfileHandler({ recordExists: false }),
+      mockProfileLikesHandler([]),
+      mockAuthSessionHandler('other-user.test'),
+    )
+  },
+}
+
+/** Existing profile with no liked packages and no invite section. */
+export const WithoutLikes: Story = {
+  beforeEach({ msw }) {
+    msw.use(mockProfileLikesHandler([]))
+  },
+}

--- a/app/storybook/mocks/handlers/profile.ts
+++ b/app/storybook/mocks/handlers/profile.ts
@@ -1,0 +1,68 @@
+import { http, HttpResponse } from 'msw'
+import type { NPMXProfile, PackageLikes } from '#shared/types/social'
+
+export const mockProfileHandle = 'mock-steward'
+
+export const mockProfile: NPMXProfile = {
+  displayName: mockProfileHandle,
+  description: 'Maintains small tools for package metadata, docs, and release workflows.',
+  website: `https://github.com/${mockProfileHandle}`,
+  handle: mockProfileHandle,
+  recordExists: true,
+}
+
+export const mockLikedPackages = [
+  'https://npmx.dev/package/nuxt',
+  'https://npmx.dev/package/vitest',
+]
+
+export function createMockAuthSession(handle: string) {
+  return {
+    did: `did:plc:${handle}`,
+    handle,
+    pds: 'https://bsky.social',
+  }
+}
+
+export function mockProfileHandler(overrides: Partial<NPMXProfile> = {}) {
+  return http.get(`/api/social/profile/${mockProfileHandle}`, () =>
+    HttpResponse.json({
+      ...mockProfile,
+      ...overrides,
+    }),
+  )
+}
+
+export function mockProfileLikesHandler(likes = mockLikedPackages) {
+  return http.get(`/api/social/profile/${mockProfileHandle}/likes`, () =>
+    HttpResponse.json({
+      cursor: null,
+      likes,
+    }),
+  )
+}
+
+export const mockPackageLikesHandler = http.get('/api/social/likes/:pkg', ({ params }) => {
+  const pkg = String(params.pkg)
+  const response: PackageLikes = {
+    totalLikes:
+      {
+        nuxt: 128,
+        vitest: 96,
+      }[pkg] ?? 12,
+    userHasLiked: false,
+    topLikedRank: null,
+  }
+
+  return HttpResponse.json(response)
+})
+
+export function mockAuthSessionHandler(handle: string | null = null) {
+  return http.get('/api/auth/session', () =>
+    HttpResponse.json(handle ? createMockAuthSession(handle) : null),
+  )
+}
+
+export const mockUpdateProfileHandler = http.put(`/api/social/profile/${mockProfileHandle}`, () =>
+  HttpResponse.text('ok'),
+)

--- a/app/storybook/mocks/handlers/profile.ts
+++ b/app/storybook/mocks/handlers/profile.ts
@@ -44,12 +44,12 @@ export function mockProfileLikesHandler(likes = mockLikedPackages) {
 
 export const mockPackageLikesHandler = http.get('/api/social/likes/:pkg', ({ params }) => {
   const pkg = String(params.pkg)
+  const packageLikesByName: Record<string, number | undefined> = {
+    nuxt: 128,
+    vitest: 96,
+  }
   const response: PackageLikes = {
-    totalLikes:
-      {
-        nuxt: 128,
-        vitest: 96,
-      }[pkg] ?? 12,
+    totalLikes: packageLikesByName[pkg] ?? 12,
     userHasLiked: false,
     topLikedRank: null,
   }

--- a/app/storybook/mocks/handlers/profile.ts
+++ b/app/storybook/mocks/handlers/profile.ts
@@ -11,12 +11,9 @@ export const mockProfile: NPMXProfile = {
   recordExists: true,
 }
 
-export const mockLikedPackages = [
-  'https://npmx.dev/package/nuxt',
-  'https://npmx.dev/package/vitest',
-]
+const mockLikedPackages = ['https://npmx.dev/package/nuxt', 'https://npmx.dev/package/vitest']
 
-export function createMockAuthSession(handle: string) {
+function createMockAuthSession(handle: string) {
   return {
     did: `did:plc:${handle}`,
     handle,

--- a/app/storybook/render-page.ts
+++ b/app/storybook/render-page.ts
@@ -1,0 +1,26 @@
+import { clearNuxtData, useRouter } from '#app'
+import { PageRouteSymbol } from '#app/components/injections'
+import { h, provide, shallowReactive, Suspense } from 'vue'
+import type { Component } from 'vue'
+import type { RouteLocationRaw } from 'vue-router'
+
+export function renderPageAt(component: Component, path: RouteLocationRaw) {
+  return () => ({
+    setup() {
+      clearNuxtData()
+
+      const router = useRouter()
+      const routeForStory = shallowReactive(router.resolve(path))
+      provide(PageRouteSymbol, routeForStory)
+
+      if (router.currentRoute.value.fullPath !== routeForStory.fullPath) {
+        router.replace(path).catch(() => {})
+      }
+
+      return () =>
+        h(Suspense, null, {
+          default: () => h(component),
+        })
+    },
+  })
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

#2150

### 🧭 Context

<!-- Brief background and why this change is needed -->

Adds storybook documentation and mocks for the Profile page.

<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->

- Add Storybook coverage for Profile page (Default, Owner, Editing, Invite & Without Likes)
- Add a `renderPageAt` helper for rendering Nuxt page components with a resolved route in Storybook
