### PR TITLE
fix: follow bare github shorthands

### DIFF
--- a/shared/utils/git-providers.ts
+++ b/shared/utils/git-providers.ts
@@ -310,7 +310,19 @@ export function normalizeGitUrl(input: string): string | null {
     .replace(/^ssh:\/\//, 'https://')
   // Bare GitHub shorthand (e.g. "repository": "owner/repo"), following npm's convention
   const hostAndPath = url.split('/')
-  if (!url.includes('://') && hostAndPath.length === 2 && !hostAndPath[0]!.includes('.')) {
+  const scpMatch = /^(?:[^@/]+@)?([^/:]+):(.+)$/.exec(url)
+  if (!url.includes('://') && scpMatch) {
+    const [, host, path] = scpMatch
+    if (host && path) url = `https://${host}/${path}`
+  }
+
+  const shorthandMatch = /^([^./:?#]+)\/([^/?#:]+)([?#].*)?$/.exec(url)
+  if (shorthandMatch) {
+    const [, owner, repo, suffix] = shorthandMatch
+    if (owner && repo) {
+      return `https://github.com/${owner}/${repo}${suffix ?? ''}`
+    }
+  }
     return `https://github.com/${url}`
   }
   if (!url) return null

--- a/shared/utils/git-providers.ts
+++ b/shared/utils/git-providers.ts
@@ -308,23 +308,29 @@ export function normalizeGitUrl(input: string): string | null {
     .replace(/(\.[^./]+?):/, '$1/') // change ".com:" to ".com/" from "ssh://user@host.com:..."
     .replace(/^git:\/\//, 'https://')
     .replace(/^ssh:\/\//, 'https://')
-  // Bare GitHub shorthand (e.g. "repository": "owner/repo"), following npm's convention
-  const hostAndPath = url.split('/')
-  const scpMatch = /^(?:[^@/]+@)?([^/:]+):(.+)$/.exec(url)
-  if (!url.includes('://') && scpMatch) {
-    const [, host, path] = scpMatch
-    if (host && path) url = `https://${host}/${path}`
-  }
-
-  const shorthandMatch = /^([^./:?#]+)\/([^/?#:]+)([?#].*)?$/.exec(url)
-  if (shorthandMatch) {
-    const [, owner, repo, suffix] = shorthandMatch
-    if (owner && repo) {
-      return `https://github.com/${owner}/${repo}${suffix ?? ''}`
+  // SCP-style shorthand with a dotless host (e.g. "git@localhost:owner/repo"); hosts with a
+  // dot (e.g. "git@github.com:user/repo") are already handled by the replacements above
+  if (!url.includes('://')) {
+    const scpMatch = /^(?:[^@/]+@)?([^/:]+):(.+)$/.exec(url)
+    const host = scpMatch?.[1]
+    const path = scpMatch?.[2]
+    if (host && path) {
+      url = `https://${host}/${path}`
     }
   }
-    return `https://github.com/${url}`
+
+  // Bare GitHub shorthand (e.g. "repository": "owner/repo"), following npm's convention;
+  // host-prefixed paths (e.g. "git.sr.ht/~user/repo") are preserved as-is
+  if (!url.includes('://')) {
+    const shorthandMatch = /^([^./?#]+)\/([^?#]*)([?#].*)?$/.exec(url)
+    const owner = shorthandMatch?.[1]
+    const repo = shorthandMatch?.[2]
+    const suffix = shorthandMatch?.[3] ?? ''
+    if (owner && repo) {
+      return `https://github.com/${owner}/${repo}${suffix}`
+    }
   }
+
   if (!url) return null
   return url.includes('://') ? url : `https://${url}`
 }

--- a/shared/utils/git-providers.ts
+++ b/shared/utils/git-providers.ts
@@ -308,6 +308,11 @@ export function normalizeGitUrl(input: string): string | null {
     .replace(/(\.[^./]+?):/, '$1/') // change ".com:" to ".com/" from "ssh://user@host.com:..."
     .replace(/^git:\/\//, 'https://')
     .replace(/^ssh:\/\//, 'https://')
+  // Bare GitHub shorthand (e.g. "repository": "owner/repo"), following npm's convention
+  const hostAndPath = url.split('/')
+  if (!url.includes('://') && hostAndPath.length === 2 && !hostAndPath[0]!.includes('.')) {
+    return `https://github.com/${url}`
+  }
   if (!url) return null
   return url.includes('://') ? url : `https://${url}`
 }

--- a/test/unit/shared/utils/git-providers.spec.ts
+++ b/test/unit/shared/utils/git-providers.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import {
   normalizeGitUrl,
   parseRepositoryInfo,

--- a/test/unit/shared/utils/git-providers.spec.ts
+++ b/test/unit/shared/utils/git-providers.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest'
 import {
   normalizeGitUrl,
   parseRepositoryInfo,
@@ -101,6 +100,17 @@ describe('normalizeGitUrl', () => {
     expect.soft(normalizeGitUrl('wevm/ox')).toBe('https://github.com/wevm/ox')
     expect.soft(normalizeGitUrl('user/repo.git')).toBe('https://github.com/user/repo')
     expect.soft(normalizeGitUrl(' user/repo ')).toBe('https://github.com/user/repo')
+    expect.soft(normalizeGitUrl('user/repo#readme')).toBe('https://github.com/user/repo#readme')
+    expect
+      .soft(normalizeGitUrl('user/repo?path=packages/core'))
+      .toBe('https://github.com/user/repo?path=packages/core')
+    expect
+      .soft(normalizeGitUrl('user/repo/tree/main'))
+      .toBe('https://github.com/user/repo/tree/main')
+  })
+
+  it('should convert scp-style shorthand with a dotless host', () => {
+    expect.soft(normalizeGitUrl('git@localhost:owner/repo')).toBe('https://localhost/owner/repo')
   })
 
   it('should not treat host-prefixed paths as owner/repo shorthand', () => {

--- a/test/unit/shared/utils/git-providers.spec.ts
+++ b/test/unit/shared/utils/git-providers.spec.ts
@@ -96,6 +96,26 @@ describe('normalizeGitUrl', () => {
       .soft(normalizeGitUrl('github:user/repo.git#readme'))
       .toBe('https://github.com/user/repo#readme')
   })
+
+  it('should expand bare owner/repo GitHub shorthand', () => {
+    expect.soft(normalizeGitUrl('wevm/ox')).toBe('https://github.com/wevm/ox')
+    expect.soft(normalizeGitUrl('user/repo.git')).toBe('https://github.com/user/repo')
+    expect.soft(normalizeGitUrl(' user/repo ')).toBe('https://github.com/user/repo')
+  })
+
+  it('should not treat host-prefixed paths as owner/repo shorthand', () => {
+    expect.soft(normalizeGitUrl('git.sr.ht/~user/repo')).toBe('https://git.sr.ht/~user/repo')
+    expect.soft(normalizeGitUrl('example.com/user/repo')).toBe('https://example.com/user/repo')
+  })
+
+  it('should parse bare shorthand repository fields', () => {
+    const info = parseRepositoryInfo('wevm/ox')
+    expect.soft(info?.provider).toBe('github')
+    expect.soft(info?.owner).toBe('wevm')
+    expect.soft(info?.repo).toBe('ox')
+    expect.soft(info?.rawBaseUrl).toBe('https://raw.githubusercontent.com/wevm/ox/HEAD')
+    expect.soft(info?.blobBaseUrl).toBe('https://github.com/wevm/ox/blob/HEAD')
+  })
 })
 
 describe('parseRepositoryInfo', () => {


### PR DESCRIPTION
### 🔗 Linked issue

None
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

NPM allows bare GitHub repo shorthands like `owner/repo` in the `repository` field in `package.json` which npmx currently doesn't link properly like here https://npmx.dev/package/ox. 

### 📚 Description

This PR fixes such behavior to properly account for such shorthands.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
