### PR TITLE
chore(deps): bump vue-data-ui from 3.23.14 to 3.25.0

### DIFF
--- a/app/components/Package/TimelineChart.vue
+++ b/app/components/Package/TimelineChart.vue
@@ -442,6 +442,15 @@ const commonConfig = computed<CommonUserOptions>(() => ({
   },
 }))
 
+const XAXIS_LABELS_MOD_THRESHOLD = 32
+
+const xAxisLabelsModulo = computed(() => {
+  const count = versions.value.length
+  if (count <= XAXIS_LABELS_MOD_THRESHOLD) return 1
+  const targetLabelCount = Math.min(XAXIS_LABELS_MOD_THRESHOLD, Math.round(count / 2))
+  return Math.max(1, Math.round(count / targetLabelCount))
+})
+
 const config = computed<VueUiXyConfig>(() => {
   return {
     theme: isDarkMode.value ? 'dark' : '',
@@ -480,8 +489,8 @@ const config = computed<VueUiXyConfig>(() => {
           xAxisLabels: {
             color: colors.value.fgSubtle,
             fontSize: isMobile.value ? 12 : 10,
-            modulo: Math.min(32, Math.round(versions.value.length / 2)),
-            showOnlyAtModulo: versions.value.length > 32,
+            modulo: xAxisLabelsModulo.value,
+            showOnlyAtModulo: versions.value.length > XAXIS_LABELS_MOD_THRESHOLD,
             values: versions.value.map(v => applyEllipsis(v, 20)),
             rotation: -30,
             autoRotate: {
@@ -803,8 +812,8 @@ const stackbarConfig = computed<VueUiStackbarConfig>(() => ({
             color: colors.value.fgSubtle,
             fontSize: isMobile.value ? 12 : 10,
             rotation: -30,
-            modulo: Math.min(32, Math.round(versions.value.length / 2)),
-            showOnlyAtModulo: versions.value.length > 32,
+            modulo: xAxisLabelsModulo.value,
+            showOnlyAtModulo: versions.value.length > XAXIS_LABELS_MOD_THRESHOLD,
             autoRotate: { enable: false },
           },
         },

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "catalog:vite-plus",
     "vue": "3.5.42",
-    "vue-data-ui": "3.23.14",
+    "vue-data-ui": "3.25.0",
     "vue-router": "5.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,8 +271,8 @@ importers:
         specifier: 3.5.42
         version: 3.5.42(typescript-native-bridge@6.0.3-bridge.13.tsgo.7.0.2)
       vue-data-ui:
-        specifier: 3.23.14
-        version: 3.23.14(vue@3.5.42)
+        specifier: 3.25.0
+        version: 3.25.0(vue@3.5.42)
       vue-router:
         specifier: 5.2.0
         version: 5.2.0(@voidzero-dev/vite-plus-core@0.3.0)(@vue/compiler-sfc@3.5.42)(esbuild@0.28.1)(rolldown@1.2.4)(rollup@4.62.2)(vue@3.5.42)(webpack@5.108.4)
@@ -10611,8 +10611,8 @@ packages:
   vue-component-type-helpers@3.3.11:
     resolution: {integrity: sha512-LwcxzeliO9fkQcpJG0PoX8X5kmAhKmH9wkpDLxNabwzkQ9Zeib2YVHwFV4pcWmMLfXVfjr/dSV+DaJ3cIPgSNA==}
 
-  vue-data-ui@3.23.14:
-    resolution: {integrity: sha512-/cosH1iTd+lnyvR+5/kqG6AzLbaZdhJCLhNLWvUp1h0mU2fxOOUI/B9zVV0couixVC4+5PAR5pmWqvoDIbsFyQ==}
+  vue-data-ui@3.25.0:
+    resolution: {integrity: sha512-xVbeb6OXb7G9aAbO0GGdWPdyibl7jW4cuIuvB55T8JvEgT15Ns85BjtkmxrAq3ZIfAq9mFUJp7FZAvSBSfLlsQ==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: 3.5.42
@@ -23056,7 +23056,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.11: {}
 
-  vue-data-ui@3.23.14(vue@3.5.42):
+  vue-data-ui@3.25.0(vue@3.5.42):
     dependencies:
       vue: 3.5.42(typescript-native-bridge@6.0.3-bridge.13.tsgo.7.0.2)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,7 +48,7 @@ minimumReleaseAgeExclude:
   - '@nuxt/nitro-server@4.5.2'
   - '@nuxt/schema@4.5.2'
   - '@nuxt/vite-builder@4.5.2'
-  - vue-data-ui@3.23.14
+  - vue-data-ui@3.25.0
 
 minimumReleaseAgeExcludePrune: true
 

--- a/shared/utils/trends-chart.ts
+++ b/shared/utils/trends-chart.ts
@@ -367,6 +367,8 @@ export const LOCALES_WITH_EXTRA_SPACE = [
   'uk-UA',
 ]
 
+const XAXIS_LABELS_MOD_THRESHOLD = 12
+
 export function buildTrendsChartConfig(
   options: TrendChartConfigOptions & {
     dates: number[]
@@ -435,8 +437,8 @@ export function buildTrendsChartConfig(
           },
           xAxisLabels: {
             show: true,
-            showOnlyAtModulo: true,
-            modulo: 12,
+            showOnlyAtModulo: options.dates.length > XAXIS_LABELS_MOD_THRESHOLD,
+            modulo: Math.max(1, Math.round(options.dates.length / XAXIS_LABELS_MOD_THRESHOLD)),
             values: options.dates,
             datetimeFormatter: {
               enable: true,


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Bump vue-data-ui and update some chart configurations following a fix in the latest version of vue-data-ui.

### 📚 Description

vue-data-ui 3.25.0 fixes an old bug in the treatment of x-axis modulo display (see [release notes](https://github.com/graphieros/vue-data-ui/releases/tag/v3.25.0)), which treated the modulo setting as a 'number of labels to display' instead of actually displaying labels based on a real mod.

As a consequence, the last x-axis label can appear closer to the previous label, since its display is forced (a `showFirstAndLast` config property, true by default, forces the first and last labels to be visible, regardless of the mod setting). In some cases (for example with a download chart set on a daily granularity and using the zoom range inputs), the last label can overlap the previous label, in which case a stroke coating around the text element keeps it readable.

Charts affected by this change:
- download charts (stats page, + embedded ssr version)
- timeline charts