### PR TITLE
fix: preview recognized source files served as octet-stream

### DIFF
--- a/app/pages/package-code/[[org]]/[packageName]/v/[version]/[...filePath].vue
+++ b/app/pages/package-code/[[org]]/[packageName]/v/[version]/[...filePath].vue
@@ -147,13 +147,13 @@ const currentNode = computed(() => {
 
 const isViewingFile = computed<boolean>(() => currentNode.value?.type === 'file')
 
-// Estimate binary file based on mime type
+// Estimate binary file based on MIME type and the detected source language
 const isBinaryFile = computed<boolean>(() => {
   if (!isViewingFile.value) return false
 
   const contentType = fileContent.value?.contentType
   if (!contentType) return false
-  return isBinaryContentType(contentType)
+  return isBinaryContentType(contentType, fileContent.value?.language)
 })
 
 const isFileTooLarge = computed<boolean>(() => {

--- a/app/utils/file-types.ts
+++ b/app/utils/file-types.ts
@@ -21,7 +21,13 @@ const BINARY_MIME_PREFIXES = new Set([
   'application/octet-stream',
 ])
 
-export function isBinaryContentType(contentType: string): boolean {
+export function isBinaryContentType(contentType: string, language?: string): boolean {
+  // CDNs use octet-stream for source formats they don't recognize. The server
+  // already identifies their language from the path; 'text' is its unknown fallback.
+  if (contentType.startsWith('application/octet-stream') && language && language !== 'text') {
+    return false
+  }
+
   for (const prefix of BINARY_MIME_PREFIXES) {
     if (contentType.startsWith(prefix)) {
       return true

--- a/server/api/registry/file/[...pkg].get.ts
+++ b/server/api/registry/file/[...pkg].get.ts
@@ -7,7 +7,7 @@ import {
   ERROR_PACKAGE_VERSION_AND_FILE_FAILED,
 } from '#shared/utils/constants'
 
-const CACHE_VERSION = 3
+const CACHE_VERSION = 4
 
 // Maximum file size to fetch and highlight (500KB)
 const MAX_FILE_SIZE = 500 * 1024

--- a/server/utils/code-highlight.ts
+++ b/server/utils/code-highlight.ts
@@ -69,6 +69,7 @@ const FILENAME_MAP: Record<string, string> = {
   'package-lock.json': 'json',
   'pnpm-lock.yaml': 'yaml',
   'yarn.lock': 'yaml',
+  'bun.lock': 'jsonc',
   'Makefile': 'bash',
   'Dockerfile': 'bash',
   'LICENSE': 'text',

--- a/test/unit/file-types.spec.ts
+++ b/test/unit/file-types.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { isBinaryContentType } from '~/utils/file-types'
+
+describe('isBinaryContentType', () => {
+  it.each(['svelte', 'astro', 'typescript', 'jsonc'])(
+    'previews recognized %s source served as octet-stream',
+    language => {
+      expect(isBinaryContentType('application/octet-stream', language)).toBe(false)
+      expect(isBinaryContentType('application/octet-stream; charset=utf-8', language)).toBe(false)
+    },
+  )
+
+  it.each([undefined, '', 'text'])('keeps unknown octet-stream files binary (%s)', language => {
+    expect(isBinaryContentType('application/octet-stream', language)).toBe(true)
+  })
+
+  it.each(['image/svg+xml', 'application/wasm', 'application/zip', 'font/woff2'])(
+    'keeps explicit binary MIME type %s binary even with a recognized language',
+    contentType => {
+      expect(isBinaryContentType(contentType, 'xml')).toBe(true)
+    },
+  )
+
+  it.each(['text/plain', 'text/javascript', 'application/json'])(
+    'previews text MIME type %s without a recognized language',
+    contentType => {
+      expect(isBinaryContentType(contentType)).toBe(false)
+    },
+  )
+})

--- a/test/unit/server/utils/code-highlight.spec.ts
+++ b/test/unit/server/utils/code-highlight.spec.ts
@@ -173,6 +173,11 @@ describe('linkifyModuleSpecifiers', () => {
 })
 
 describe('getLanguageFromPath', () => {
+  it('recognizes text bun lockfiles without treating binary lockfiles as text', () => {
+    expect(getLanguageFromPath('nested/bun.lock')).toBe('jsonc')
+    expect(getLanguageFromPath('nested/bun.lockb')).toBe('text')
+  })
+
   it('prefers well-known filenames over extension heuristics', () => {
     expect(getLanguageFromPath('foo/README.md')).toBe('markdown')
     expect(getLanguageFromPath('nested/tsconfig.json')).toBe('jsonc')


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2721

### 🧭 Context

The code viewer hides recognized source files when jsDelivr serves them as `application/octet-stream`. Reproduced with `astro-icon@1.1.5/components/Icon.astro`: the API already detects Astro and highlights all 138 lines, but the page shows “Binary file”.

### 📚 Description

Use the existing detected language to allow previews for generic octet-stream responses. Unknown files (`text`, the language fallback) and specific binary MIME types retain their warning. This follows the approach suggested in the issue without duplicating the extension map.

Also recognize the text `bun.lock` format as JSONC. `bun.lockb` stays unknown/binary. Bump the file-response cache version so previously cached Bun lockfiles receive the new language classification.

Validation:
- The new regressions fail on the original code (5 failures); all 32 targeted tests pass with the fix.
- Full test run: 1,790 unit tests passed across 85 files. Nuxt component tests could not start because their Chromium session connection timed out, so the full command exited unsuccessfully.
- `pnpm test:types` and `pnpm vp run lint` passed; commit hooks also passed.
- Browser verification: Astro source renders with highlighting and line numbers; `bun.lock@0.0.0/bun.lock` renders its 28 lines. Both upstream responses still use `application/octet-stream`.

Before:

![Astro source incorrectly hidden as binary](https://raw.githubusercontent.com/Creatixpy/npmx.dev/d6c340b1df73b622ca0135e1c219837afa785810/before.png)

After:

![Astro source displayed with syntax highlighting](https://raw.githubusercontent.com/Creatixpy/npmx.dev/d6c340b1df73b622ca0135e1c219837afa785810/after.png)

Reviewed with the help of AI.
