### PR TITLE
fix: resolve npm aliases in dependency version links

### DIFF
--- a/app/utils/router.ts
+++ b/app/utils/router.ts
@@ -1,4 +1,5 @@
 import type { RouteLocationRaw } from 'vue-router'
+import { parsePackageSpec } from '#shared/utils/parse-package-param'
 import { splitPackageName } from '~/utils/package-name'
 
 export function packageRoute(
@@ -6,6 +7,12 @@ export function packageRoute(
   version?: string | null,
   hash?: string,
 ): RouteLocationRaw {
+  if (version?.startsWith('npm:')) {
+    const alias = parsePackageSpec(version.slice(4))
+    packageName = alias.name
+    version = alias.version
+  }
+
   const { org, name } = splitPackageName(packageName)
 
   if (version) {

--- a/test/unit/app/utils/router.spec.ts
+++ b/test/unit/app/utils/router.spec.ts
@@ -1,5 +1,52 @@
 import { describe, expect, it } from 'vitest'
-import { docsRoute } from '~/utils/router'
+import { docsRoute, packageRoute } from '~/utils/router'
+
+describe('packageRoute', () => {
+  it.each([
+    ['vue', '3.5.0', '', 'vue', '3.5.0'],
+    ['@nuxt/kit', ' >= 3.0.0 < 4.0.0 ', '@nuxt', 'kit', '>=3.0.0<4.0.0'],
+    ['vue', 'next', '', 'vue', 'next'],
+  ] as const)('routes %s at %s', (packageName, version, org, name, expectedVersion) => {
+    expect(packageRoute(packageName, version, '#dependencies')).toEqual({
+      name: 'package-version',
+      params: { org, name, version: expectedVersion },
+      hash: '#dependencies',
+    })
+  })
+
+  it.each([
+    ['vite', 'npm:@voidzero-dev/vite-plus-core@0.3.1', '@voidzero-dev', 'vite-plus-core', '0.3.1'],
+    ['string-width', 'npm:string-width@^4.2.0', '', 'string-width', '^4.2.0'],
+    ['@scope/alias', 'npm:vue@next', '', 'vue', 'next'],
+    ['alias', 'npm:@scope/pkg@>= 1.0.0 < 2.0.0', '@scope', 'pkg', '>=1.0.0<2.0.0'],
+  ] as const)(
+    'routes %s to its alias target %s',
+    (packageName, version, org, name, expectedVersion) => {
+      expect(packageRoute(packageName, version, '#dependencies')).toEqual({
+        name: 'package-version',
+        params: { org, name, version: expectedVersion },
+        hash: '#dependencies',
+      })
+    },
+  )
+
+  it.each([
+    ['npm:vue', '', 'vue'],
+    ['npm:@scope/pkg', '@scope', 'pkg'],
+  ] as const)('routes an alias without a version to %s', (version, org, name) => {
+    expect(packageRoute('alias', version)).toEqual({
+      name: 'package',
+      params: { org, name },
+    })
+  })
+
+  it.each([undefined, null, ''])('omits the version route for %s', version => {
+    expect(packageRoute('@nuxt/kit', version)).toEqual({
+      name: 'package',
+      params: { org: '@nuxt', name: 'kit' },
+    })
+  })
+})
 
 describe('docsRoute', () => {
   it('emits a scoped name as two path segments (literal slash, not %2F)', () => {


### PR DESCRIPTION
The `vite` version link on `vite-plus@0.3.1` returns `404` because `packageRoute()` treats the full `npm:` alias as a version.

`packageRoute()` now uses `parsePackageSpec()` to extract the target package and version. The link opens `/package/@voidzero-dev/vite-plus-core/v/0.3.1`. The fix covers regular, peer, and optional dependency version links.

Regression tests cover scoped and unscoped aliases, ranges, tags, and aliases without versions. All 56 focused tests, lint, formatting, and type checks pass.

Related to #2010. This draft overlaps with #2192 and limits the change to version-link routing.
