### PR TITLE
fix(ui): align dependency size tooltip order with chart

### DIFF
--- a/app/components/Package/TimelineChart.vue
+++ b/app/components/Package/TimelineChart.vue
@@ -26,7 +26,7 @@ import {
   getAnnotatorIcon,
   getAnnotatorStyle,
   type TimelineChartMetric,
-  type StackbarTooltipPoint,
+  createStackbarTooltipPoints,
   type TimelinePlotItem,
   type TimelineMarkerItem,
 } from '~/utils/charts'
@@ -251,28 +251,8 @@ const dependencySegments = computed<DependencySegment[]>(() => {
   return [otherSegment, ...depSegments.toReversed(), selfSegment]
 })
 
-function stackbarTooltipPoints(
-  datapoint: VueUiStackbarTooltipDatapoint[],
-  versionIndex: number,
-): StackbarTooltipPoint[] {
-  return datapoint
-    .map(point => {
-      const segment = dependencySegments.value.find(s => s.name === point.name)
-      const previous = versionIndex > 0 ? (segment?.series[versionIndex - 1] ?? 0) : 0
-      const value = point.value ?? 0
-      const removed = value === 0 && previous > 0
-
-      return {
-        id: point.id,
-        name: point.name,
-        color: point.color,
-        size: removed ? previous : value,
-        delta: versionIndex > 0 ? value - previous : 0,
-        removed,
-      }
-    })
-    .filter(point => point.size > 0)
-    .toReversed()
+function stackbarTooltipPoints(datapoint: VueUiStackbarTooltipDatapoint[], versionIndex: number) {
+  return createStackbarTooltipPoints(datapoint, dependencySegments.value, versionIndex)
 }
 
 function areAllValuesEqual(array: number[]): boolean {

--- a/app/utils/charts.ts
+++ b/app/utils/charts.ts
@@ -10,6 +10,7 @@ import type {
   VueUiStackbarConfig,
   VueUiStackbarFormattedDatasetItem,
 } from 'vue-data-ui'
+import type { VueUiStackbarTooltipDatapoint } from 'vue-data-ui/vue-ui-stackbar'
 import type { ChartTimeGranularity } from '~/types/chart'
 
 interface SubEvent {
@@ -1135,6 +1136,31 @@ export interface StackbarTooltipPoint {
   delta: number
   /** Present in the previous bar but gone in this one */
   removed: boolean
+}
+
+export function createStackbarTooltipPoints(
+  datapoints: VueUiStackbarTooltipDatapoint[],
+  segments: Array<{ name: string; series: number[] }>,
+  versionIndex: number,
+): StackbarTooltipPoint[] {
+  // vue-data-ui already supplies datapoints in the stack's visual top-to-bottom order.
+  return datapoints
+    .map(point => {
+      const segment = segments.find(item => item.name === point.name)
+      const previous = versionIndex > 0 ? (segment?.series[versionIndex - 1] ?? 0) : 0
+      const value = point.value ?? 0
+      const removed = value === 0 && previous > 0
+
+      return {
+        id: point.id,
+        name: point.name,
+        color: point.color,
+        size: removed ? previous : value,
+        delta: versionIndex > 0 ? value - previous : 0,
+        removed,
+      }
+    })
+    .filter(point => point.size > 0)
 }
 
 export type TimelinePlotItem = {

--- a/test/unit/app/utils/charts.spec.ts
+++ b/test/unit/app/utils/charts.spec.ts
@@ -15,6 +15,7 @@ import {
   copyAltTextForTimelineChart,
   createAltTextForTimelineStackbar,
   copyAltTextForTimelineStackbar,
+  createStackbarTooltipPoints,
   sanitise,
   insertLineBreaks,
   applyEllipsis,
@@ -27,6 +28,7 @@ import {
   type EnrichedTimelineSizeCacheEntry,
 } from '~/utils/charts'
 import type { AltCopyArgs, VueUiStackbarFormattedDatasetItem } from 'vue-data-ui'
+import type { VueUiStackbarTooltipDatapoint } from 'vue-data-ui/vue-ui-stackbar'
 
 type TranslateCall = { key: string | number; named?: Record<string, unknown> }
 
@@ -1292,6 +1294,48 @@ describe('copyAltTextForTimelineChart', () => {
 
     expect(copyMock).toHaveBeenCalledTimes(1)
     expect(copyMock).toHaveBeenCalledWith(expected)
+  })
+})
+
+describe('createStackbarTooltipPoints', () => {
+  it('preserves visual stack order while calculating deltas and removed segments', () => {
+    const datapoints = [
+      { id: 'self', name: 'package', color: '#0000ff', value: 15 },
+      { id: 'dependency', name: 'dependency', color: '#00ff00', value: 0 },
+      { id: 'other', name: 'Other', color: '#cccccc', value: 5 },
+    ] as unknown as VueUiStackbarTooltipDatapoint[]
+    const segments = [
+      { name: 'package', series: [10, 15] },
+      { name: 'dependency', series: [4, 0] },
+      { name: 'Other', series: [7, 5] },
+    ]
+
+    expect(createStackbarTooltipPoints(datapoints, segments, 1)).toEqual([
+      {
+        id: 'self',
+        name: 'package',
+        color: '#0000ff',
+        size: 15,
+        delta: 5,
+        removed: false,
+      },
+      {
+        id: 'dependency',
+        name: 'dependency',
+        color: '#00ff00',
+        size: 4,
+        delta: -4,
+        removed: true,
+      },
+      {
+        id: 'other',
+        name: 'Other',
+        color: '#cccccc',
+        size: 5,
+        delta: -2,
+        removed: false,
+      },
+    ])
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #3239

### 🧭 Context

The dependency-size chart and its tooltip showed the same stack in opposite orders, which made similarly colored segments difficult to match.

### 📚 Description

- Keep `vue-data-ui`'s tooltip datapoint order, which already follows the visual stack from top to bottom.
- Preserve the existing delta and removed-dependency behavior in a testable helper.
- Add a regression test for ordering, deltas, and removed segments.

### Screenshots

| Before | After |
| --- | --- |
| ![Dependency-size tooltip before, with Other at the top and the package at the bottom](https://raw.githubusercontent.com/dvd233/npmx.dev/pr-assets-npmx-3239/pr-assets/npmx-3239-before.png) | ![Dependency-size tooltip after, with the package at the top and Other at the bottom](https://raw.githubusercontent.com/dvd233/npmx.dev/pr-assets-npmx-3239/pr-assets/npmx-3239-after.png) |

### Testing

- `pnpm test -- --coverage.enabled=false` — 2,919 passed, 5 skipped
- `pnpm test:types`
- `pnpm vp run lint`
- `pnpm vp run test:browser:prebuilt` — 266 passed, 1 skipped
- Manual verification on the `@babel/core@8.0.1` dependency-size chart
