### PR TITLE
fix(ui): account for sticky headers in sidebar height

### DIFF
--- a/app/components/Package/Sidebar.vue
+++ b/app/components/Package/Sidebar.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
+const APP_HEADER_HEIGHT = 56
+
 const viewport = useWindowSize()
 const scroll = useWindowScroll()
 const container = useTemplateRef<HTMLDivElement>('container')
 const content = useTemplateRef<HTMLDivElement>('content')
 const bounds = useElementBounding(content)
+const packageHeaderHeight = usePackageHeaderHeight()
+const stickyTop = computed(() => APP_HEADER_HEIGHT + packageHeaderHeight.value)
 
 const active = computed(() => {
-  return bounds.height.value > viewport.height.value
+  return bounds.height.value > viewport.height.value - stickyTop.value
 })
 
 const direction = computed((previous = 'up'): string => {
@@ -23,9 +27,8 @@ const offset = computed(() => {
     ? content.value.offsetTop
     : container.value.offsetHeight - content.value.offsetTop - content.value.offsetHeight
 })
-const packageHeaderHeight = usePackageHeaderHeight()
 const stickyStyle = computed(() =>
-  direction.value === 'up' ? { top: `${56 + packageHeaderHeight.value}px` } : { bottom: `32px` },
+  direction.value === 'up' ? { top: `${stickyTop.value}px` } : { bottom: `32px` },
 )
 
 const style = computed(() => {

--- a/test/nuxt/components/Package/Sidebar.spec.ts
+++ b/test/nuxt/components/Package/Sidebar.spec.ts
@@ -40,6 +40,13 @@ describe('PackageSidebar', () => {
     expect(wrapper.attributes('data-active')).toBe('true')
   })
 
+  it('sets active=true when sticky headers leave less space than the content needs', async () => {
+    wrapper = await mountSidebar(VIEWPORT_HEIGHT - 40)
+    await nextTick()
+
+    expect(wrapper.attributes('data-active')).toBe('true')
+  })
+
   it('renders with direction=up by default', async () => {
     wrapper = await mountSidebar()
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #3212

### 🧭 Context

The sidebar currently decides whether to enable its scroll-aware sticky behavior by comparing its content height with the full viewport height. The app and package headers reduce the space actually available to the sidebar, so content near the viewport height can stay inactive while its last sections remain hidden.

### 📚 Description

- reuse one reactive sticky top offset for positioning and available-height calculation
- activate the scroll-aware sidebar when its content exceeds the viewport space left below the sticky headers
- add a component regression test for content that is shorter than the viewport but taller than the usable sidebar area

At a 1544×1400 viewport in the reported boundary case, the baseline left 53.55 px of the sidebar below the viewport. With this change the sidebar switches direction while scrolling and keeps its bottom at the existing 32 px inset.

### Screenshots

| Before | After |
| --- | --- |
| ![Sidebar remains pinned at the top with its lower sections below the viewport](https://raw.githubusercontent.com/dvd233/npmx.dev/fc20a884acb1bbcbca581ff4af298d1dbdceb8f4/before.png) | ![Sidebar follows downward scrolling and reveals the maintainers section](https://raw.githubusercontent.com/dvd233/npmx.dev/fc20a884acb1bbcbca581ff4af298d1dbdceb8f4/after.png) |

### Testing

- `vp test --project unit` — 1,781 passed
- `vp test --project nuxt` — 1,138 passed, 5 skipped
- `vue-tsc -b --noEmit`
- `vp run --filter npmx-connector test:types`
- `vp lint`
- `vp fmt --check`
- `node scripts/unocss-checker.ts`
- production build plus `playwright test --workers=1` against the built output — 266 passed, 1 skipped
