### PR TITLE
chore(deps): bump vue-data-ui from 3.25.0 to 3.25.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vite-plugin-pwa": "1.3.0",
     "vite-plus": "catalog:vite-plus",
     "vue": "3.5.42",
-    "vue-data-ui": "3.25.0",
+    "vue-data-ui": "3.25.5",
     "vue-router": "5.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,8 +271,8 @@ importers:
         specifier: 3.5.42
         version: 3.5.42(typescript-native-bridge@6.0.3-bridge.13.tsgo.7.0.2)
       vue-data-ui:
-        specifier: 3.25.0
-        version: 3.25.0(vue@3.5.42)
+        specifier: 3.25.5
+        version: 3.25.5(vue@3.5.42)
       vue-router:
         specifier: 5.2.0
         version: 5.2.0(@voidzero-dev/vite-plus-core@0.3.1)(@vue/compiler-sfc@3.5.42)(esbuild@0.28.1)(rolldown@1.2.4)(rollup@4.62.2)(vue@3.5.42)(webpack@5.108.4)
@@ -10621,8 +10621,8 @@ packages:
   vue-component-type-helpers@3.3.11:
     resolution: {integrity: sha512-LwcxzeliO9fkQcpJG0PoX8X5kmAhKmH9wkpDLxNabwzkQ9Zeib2YVHwFV4pcWmMLfXVfjr/dSV+DaJ3cIPgSNA==}
 
-  vue-data-ui@3.25.0:
-    resolution: {integrity: sha512-xVbeb6OXb7G9aAbO0GGdWPdyibl7jW4cuIuvB55T8JvEgT15Ns85BjtkmxrAq3ZIfAq9mFUJp7FZAvSBSfLlsQ==}
+  vue-data-ui@3.25.5:
+    resolution: {integrity: sha512-R+b6ejdPBVftZzk3q1HWyrfWi6D42K6F7iBoarnb35yZWbmlHaRSA5NI1Tp034BQtn+Q39SGAjY0rJa0lvA5hg==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: 3.5.42
@@ -23074,7 +23074,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.11: {}
 
-  vue-data-ui@3.25.0(vue@3.5.42):
+  vue-data-ui@3.25.5(vue@3.5.42):
     dependencies:
       vue: 3.5.42(typescript-native-bridge@6.0.3-bridge.13.tsgo.7.0.2)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,7 +48,6 @@ minimumReleaseAgeExclude:
   - '@nuxt/nitro-server@4.5.2'
   - '@nuxt/schema@4.5.2'
   - '@nuxt/vite-builder@4.5.2'
-  - vue-data-ui@3.25.0
 
 minimumReleaseAgeExcludePrune: true
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

- Bump vue-data-ui to latest, with improvements to the built-in chart annotator, which now allows to edit already positioned annotations (see [release notes](https://github.com/graphieros/vue-data-ui/releases#release-v3.25.4) related to this feature)

https://github.com/user-attachments/assets/60b0e22a-3d50-4002-b2c6-7f9d54c210e2

