### PR TITLE
ci: pass new tag to release notes generator script

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -77,7 +77,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FROM_REF: ${{ steps.version.outputs.from }}
-        run: node scripts/release-notes.ts "$FROM_REF" > /tmp/release-notes.md
+          TO_REF: ${{ steps.version.outputs.next }}
+        run: node scripts/release-notes.ts "$FROM_REF" "$TO_REF" > /tmp/release-notes.md
 
       - name: 🚀 Create GitHub Release
         if: steps.check.outputs.skip == 'false'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

I noticed that release notes generated by our [script](https://github.com/npmx-dev/npmx.dev/blob/955a47bd847bac50862cadbf6b3821024b2a8a97/scripts/release-notes.ts) include the compare link from the previous release to `HEAD` instead of the new tag. This makes those links misleading if new releases come in because the compare link always shows the diff to the current `main` branch.

### 📚 Description

This PR fixes this by passing the new tag to the release notes generator script so it can use it in the release notes markdown heading and compare link, which makes those links always correct. This is also how @serhalp and I created the releases [`0.19.0`](https://github.com/npmx-dev/npmx.dev/releases/tag/v0.19.0), [`0.6.0`](https://github.com/npmx-dev/npmx.dev/releases/tag/v0.6.0), and [`0.5.0`](https://github.com/npmx-dev/npmx.dev/releases/tag/v0.5.0) manually.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
